### PR TITLE
Support embedding resource contents in prompts

### DIFF
--- a/docs/spec/prompts.md
+++ b/docs/spec/prompts.md
@@ -253,6 +253,7 @@ Example:
       {
         "role": "user",
         "content": {
+          "type": "resource",
           "uri": "file:///workspace/project/requirements.txt",
           "mimeType": "text/plain",
           "text": "flask==2.0.1\nnumpy==1.21.0\npandas==1.3.0\n"

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1167,18 +1167,18 @@
             "type": "object"
         },
         "PromptMessage": {
-            "description": "Describes a message returned as part of a prompt.\n\nThis is similar to `SamplingMessage`, but also supports the embedding of\nresource contents from the MCP server. The client MUST decide how to render\nembedded resources for the benefit of the LLM and/or the user.",
+            "description": "Describes a message returned as part of a prompt.\n\nThis is similar to `SamplingMessage`, but also supports the embedding of\nresource contents from the MCP server.",
             "properties": {
                 "content": {
                     "anyOf": [
-                        {
-                            "$ref": "#/definitions/ResourceContents"
-                        },
                         {
                             "$ref": "#/definitions/TextContent"
                         },
                         {
                             "$ref": "#/definitions/ImageContent"
+                        },
+                        {
+                            "$ref": "#/definitions/PromptResourceContents"
                         }
                     ]
                 },
@@ -1211,6 +1211,29 @@
             "required": [
                 "name",
                 "type"
+            ],
+            "type": "object"
+        },
+        "PromptResourceContents": {
+            "description": "The contents of a resource, embedded into a prompt.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
+            "properties": {
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "resource",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type",
+                "uri"
             ],
             "type": "object"
         },

--- a/schema/schema.ts
+++ b/schema/schema.ts
@@ -558,12 +558,21 @@ export interface PromptArgument {
  * Describes a message returned as part of a prompt.
  *
  * This is similar to `SamplingMessage`, but also supports the embedding of
- * resource contents from the MCP server. The client MUST decide how to render
- * embedded resources for the benefit of the LLM and/or the user.
+ * resource contents from the MCP server. 
  */
 export interface PromptMessage {
   role: "user" | "assistant";
-  content: TextContent | ImageContent | ResourceContents;
+  content: TextContent | ImageContent | PromptResourceContents;
+}
+
+/**
+ * The contents of a resource, embedded into a prompt.
+ * 
+ * It is up to the client how best to render embedded resources for the benefit
+ * of the LLM and/or the user.
+ */
+export interface PromptResourceContents extends ResourceContents {
+  type: "resource";
 }
 
 /**


### PR DESCRIPTION
Resolves https://github.com/modelcontextprotocol/specification/issues/2.

This technically breaks backwards compatibility (adds something new that the client MUST handle), but since no servers use this yet, I don't think we need to rev the protocol version. I did consider adding a capability to make this more optional, but:

1. It's not really a _server_ capability, since it's something the client needs to support
2. `ClientCapabilities` is quite sparse, and adding a top-level key like `prompts` (so we could have, e.g., `prompts.embeddedResources = true`) sounds like "does the client support prompts at all?"—which would be an even bigger breaking change than this