### PR TITLE
Match tool results' structure to that of prompts

### DIFF
--- a/docs/spec/tools.md
+++ b/docs/spec/tools.md
@@ -236,7 +236,8 @@ Example:
 
 The server MUST respond with a `CallToolResult` containing:
 
-- `toolResult`: The result of the tool invocation (any JSON-serializable value)
+- `content`: An array of content items that can be text, images, or embedded resources
+- `isError`: A boolean indicating whether this result represents an error state
 
 Example:
 ```json
@@ -244,11 +245,11 @@ Example:
   "jsonrpc": "2.0",
   "id": 2,
   "result": {
-    "toolResult": {
-      "temperature": 72,
-      "humidity": 65,
-      "description": "Partly cloudy"
-    }
+    "content": [{
+      "type": "text",
+      "text": "Current weather in New York:\nTemperature: 72°F\nHumidity: 65%\nConditions: Partly cloudy"
+    }],
+    "isError": false
   }
 }
 ```

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -54,17 +54,36 @@
             "type": "object"
         },
         "CallToolResult": {
-            "description": "The server's response to a tool call.\n\nAny errors that originate from the tool SHOULD be reported inside the result\nobject—i.e., as part of an MCP successful result, not as an MCP error\nresponse. Otherwise, the LLM would not be able to see that an error occurred\nand self-correct.\n\nHowever, any errors in _finding_ the tool, an error indicating that the\nserver does not support tool calls, or any other exceptional conditions,\nshould be reported as an MCP error response.",
+            "description": "The server's response to a tool call.\n\nAny errors that originate from the tool SHOULD be reported inside the result\nobject, with `isError` set to true, _not_ as an MCP protocol-level error\nresponse. Otherwise, the LLM would not be able to see that an error occurred\nand self-correct.\n\nHowever, any errors in _finding_ the tool, an error indicating that the\nserver does not support tool calls, or any other exceptional conditions,\nshould be reported as an MCP error response.",
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
                     "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
                     "type": "object"
                 },
-                "toolResult": {}
+                "content": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/TextContent"
+                            },
+                            {
+                                "$ref": "#/definitions/ImageContent"
+                            },
+                            {
+                                "$ref": "#/definitions/EmbeddedResource"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "isError": {
+                    "type": "boolean"
+                }
             },
             "required": [
-                "toolResult"
+                "content",
+                "isError"
             ],
             "type": "object"
         },
@@ -365,6 +384,30 @@
         "Cursor": {
             "description": "An opaque token used to represent a cursor for pagination.",
             "type": "string"
+        },
+        "EmbeddedResource": {
+            "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
+            "properties": {
+                "resource": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TextResourceContents"
+                        },
+                        {
+                            "$ref": "#/definitions/BlobResourceContents"
+                        }
+                    ]
+                },
+                "type": {
+                    "const": "resource",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "resource",
+                "type"
+            ],
+            "type": "object"
         },
         "EmptyResult": {
             "$ref": "#/definitions/Result"
@@ -1171,30 +1214,6 @@
             ],
             "type": "object"
         },
-        "PromptEmbeddedResource": {
-            "description": "The contents of a resource, embedded into a prompt.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
-            "properties": {
-                "resource": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/TextResourceContents"
-                        },
-                        {
-                            "$ref": "#/definitions/BlobResourceContents"
-                        }
-                    ]
-                },
-                "type": {
-                    "const": "resource",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "resource",
-                "type"
-            ],
-            "type": "object"
-        },
         "PromptListChangedNotification": {
             "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.",
             "properties": {
@@ -1231,7 +1250,7 @@
                             "$ref": "#/definitions/ImageContent"
                         },
                         {
-                            "$ref": "#/definitions/PromptEmbeddedResource"
+                            "$ref": "#/definitions/EmbeddedResource"
                         }
                     ]
                 },

--- a/schema/schema.ts
+++ b/schema/schema.ts
@@ -5,7 +5,7 @@ export type JSONRPCMessage =
   | JSONRPCResponse
   | JSONRPCError;
 
-export const LATEST_PROTOCOL_VERSION = "2024-10-07";
+export const LATEST_PROTOCOL_VERSION = "2024-11-05";
 export const JSONRPC_VERSION = "2.0";
 
 /**
@@ -562,16 +562,16 @@ export interface PromptArgument {
  */
 export interface PromptMessage {
   role: "user" | "assistant";
-  content: TextContent | ImageContent | PromptEmbeddedResource;
+  content: TextContent | ImageContent | EmbeddedResource;
 }
 
 /**
- * The contents of a resource, embedded into a prompt.
+ * The contents of a resource, embedded into a prompt or tool call result.
  *
  * It is up to the client how best to render embedded resources for the benefit
  * of the LLM and/or the user.
  */
-export interface PromptEmbeddedResource {
+export interface EmbeddedResource {
   type: "resource";
   resource: TextResourceContents | BlobResourceContents;
 }
@@ -602,7 +602,7 @@ export interface ListToolsResult extends PaginatedResult {
  * The server's response to a tool call.
  *
  * Any errors that originate from the tool SHOULD be reported inside the result
- * object—i.e., as part of an MCP successful result, not as an MCP error
+ * object, with `isError` set to true, _not_ as an MCP protocol-level error
  * response. Otherwise, the LLM would not be able to see that an error occurred
  * and self-correct.
  *
@@ -611,7 +611,8 @@ export interface ListToolsResult extends PaginatedResult {
  * should be reported as an MCP error response.
  */
 export interface CallToolResult extends Result {
-  toolResult: unknown;
+  content: (TextContent | ImageContent | EmbeddedResource)[];
+  isError: boolean;
 }
 
 /**


### PR DESCRIPTION
Tool results have suffered from being completely unstructured, which can make it hard for the client to integrate them into an LLM flow (for example—even just understanding whether they should be JSON stringified or treated as raw text).

I think this was not the case when we designed it originally, but now the Anthropic API [requires structured tool results](https://docs.anthropic.com/en/docs/build-with-claude/tool-use#handling-tool-use-and-tool-result-content-blocks) that include content blocks (like you would see during sampling).*

It's a bit of nice serendipity that we just aligned prompts with this format, _and_ built in support for embedded resources. I see no reason not to do the same for tools too!

Unfortunately, this is a properly breaking change, so I'm revving the protocol version. **However, servers and clients can still set and check the old `toolResult` field, for their own compatibility handling.**

_* OpenAI's API only supports string results AFAICT, but content blocks can be broken down into strings more easily than the reverse._