### PR TITLE
Fix doc example of embedding resources

### DIFF
--- a/docs/spec/prompts.md
+++ b/docs/spec/prompts.md
@@ -254,9 +254,11 @@ Example:
         "role": "user",
         "content": {
           "type": "resource",
-          "uri": "file:///workspace/project/requirements.txt",
-          "mimeType": "text/plain",
-          "text": "flask==2.0.1\nnumpy==1.21.0\npandas==1.3.0\n"
+          "resource": {
+            "uri": "file:///workspace/project/requirements.txt",
+            "mimeType": "text/plain",
+            "text": "flask==2.0.1\nnumpy==1.21.0\npandas==1.3.0\n"
+          }
         }
       },
       {


### PR DESCRIPTION
I missed this as part of https://github.com/modelcontextprotocol/specification/pull/36.