### PR TITLE
`CallToolResult.isError` should be optional

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -78,12 +78,12 @@
                     "type": "array"
                 },
                 "isError": {
+                    "description": "Whether the tool call ended in an error.\n\nIf not set, this is assumed to be false (the call was successful).",
                     "type": "boolean"
                 }
             },
             "required": [
-                "content",
-                "isError"
+                "content"
             ],
             "type": "object"
         },

--- a/schema/schema.ts
+++ b/schema/schema.ts
@@ -612,7 +612,13 @@ export interface ListToolsResult extends PaginatedResult {
  */
 export interface CallToolResult extends Result {
   content: (TextContent | ImageContent | EmbeddedResource)[];
-  isError: boolean;
+
+  /**
+   * Whether the tool call ended in an error.
+   * 
+   * If not set, this is assumed to be false (the call was successful).
+   */
+  isError?: boolean;
 }
 
 /**


### PR DESCRIPTION
This was the intention, I just messed it up 😞 