### PR TITLE
Add license information and package metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2024 Anthropic, PBC.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Model Context Protocol spec
+# Model Context Protocol specification
 
 This repo contains the specification and protocol schema for the Model Context Protocol.
 
@@ -34,3 +34,11 @@ $ npm run serve:docs # serve the documentation
 ```
 
 Note that this requires Hugo and Go to be installed.
+
+## Contributing
+
+Issues and pull requests are welcome on GitHub at https://github.com/modelcontextprotocol/specification.
+
+## License
+
+This project is licensed under the MIT License—see the [LICENSE](LICENSE) file for details.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
-  "name": "mcp-spec",
+  "name": "@modelcontextprotocol/specification",
   "version": "0.1.0",
-  "private": true,
+  "description": "Model Context Protocol specification and protocol schema",
+  "license": "MIT",
+  "author": "Anthropic, PBC (https://anthropic.com)",
+  "homepage": "https://modelcontextprotocol.github.io",
+  "bugs": "https://github.com/modelcontextprotocol/specification/issues",
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
I don't think we'll actually want to publish this as an npm package (what would its utility be?), but I configured everything such that it is at least possible.