### PR TITLE
Added Tool Call and Tool Result to GetPrompt for in-context learning …

### DIFF
--- a/docs/specification/draft/server/prompts.mdx
+++ b/docs/specification/draft/server/prompts.mdx
@@ -182,6 +182,8 @@ A prompt definition includes:
 Messages in a prompt can contain:
 
 - `role`: Either "user" or "assistant" to indicate the speaker
+- `toolCall`: Example Tool Calls requested by the Assistant
+- `toolResult`: Example Tool Results supplied by the Server (or User)
 - `content`: One of the following content types:
 
 #### Text Content
@@ -251,6 +253,17 @@ Resources can contain either text or binary (blob) data and **MUST** include:
 Embedded resources enable prompts to seamlessly incorporate server-managed content like
 documentation, code samples, or other reference materials directly into the conversation
 flow.
+
+#### Example Tool Call
+
+An example Tool Call requested by the Assistant, usually in response to a preceding User
+message. The `id` provides a correlation to any provided results.
+
+#### Example Tool Result
+
+An example Tool Result supplied by the User (normally the MCP Server supplying the
+prompt), usually in response to a preceding Assistant message. The `id` allows the Host
+to correlate the example with its associated ExampleToolCall.
 
 ## Error Handling
 

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -1607,7 +1607,7 @@
                 "role": {
                     "$ref": "#/definitions/Role"
                 },
-                "toolCalls": {
+                "toolCall": {
                     "description": "Tool calls requested by the the Assistant. \nShould only be present if Role is Assistant",
                     "items": {
                         "$ref": "#/definitions/ExampleToolCall"

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -639,12 +639,11 @@ export interface PromptMessage {
    * Tool calls requested by the the Assistant. 
    * Should only be present if Role is Assistant
    */
-  toolCalls?: ExampleToolCall[]; 
+  toolCall?: ExampleToolCall[]; 
   /**
    * Tool calls results supplied by the User. 
    * Should only be present if Role is User (Host)
    */
-
   toolResult?: ExampleToolResult[];
 }
 


### PR DESCRIPTION
…of tool usage

Addition of ToolCall and ToolResult blocks to PromptMessage to allow in-context learning of Tool Usage patterns and error handling.

Submitted as draft for review before completing/adding documentation etc.

## Motivation and Context

To allow Tool developers to provide specific usage examples of how and when the Assistant should use tool calls and handle results and errors.

## How Has This Been Tested?

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
