### PR TITLE
feat: add missing SDKs to Hugo doc

### DIFF
--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -95,3 +95,15 @@ menu:
       name: "TypeScript SDK ↗"
       url: "https://github.com/modelcontextprotocol/typescript-sdk"
       weight: 5
+    - identifier: javaSdk
+      name: "Java SDK ↗"
+      url: "https://github.com/modelcontextprotocol/java-sdk"
+      weight: 6
+    - identifier: kotlinSdk
+      name: "Kotlin SDK ↗"
+      url: "https://github.com/modelcontextprotocol/kotlin-sdk"
+      weight: 7
+    - identifier: csharpSdk
+      name: "C# SDK ↗"
+      url: "https://github.com/modelcontextprotocol/csharp-sdk"
+      weight: 8


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Hello 👋 
 I was reading the specification for the latest MCP version ([2025-03-26](https://spec.modelcontextprotocol.io/specification/2025-03-26/)) and noticed that some SDKs appear to be missing. Feel free to reject the PR If this was intentional. 

## How Has This Been Tested?
I run hugo locally via `hugo server` and checked that the added SDKs were there

![Screenshot 2025-04-02 at 11 36 03](https://github.com/user-attachments/assets/71f7f52b-3c2e-4c28-8c60-2af15c847ea3)


## Breaking Changes
no

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
