### PR TITLE
docs: Describe handling of OAuth Scopes

### DIFF
--- a/docs/specification/2025-03-26/basic/authorization.md
+++ b/docs/specification/2025-03-26/basic/authorization.md
@@ -384,3 +384,11 @@ Since clients do not know the set of MCP servers in advance, we strongly recomme
 implementation of dynamic client registration. This allows applications to automatically
 register with the MCP server, and removes the need for users to obtain client ids
 manually.
+
+#### 3.4 Scope Management
+
+MCP servers **SHOULD** return the set of available OAuth scopes a Client may request 
+via the `scopes_supported` metadata field in the Authorization Server Metadata Document. 
+MCP clients **SHOULD** request the minimum set of scopes necessary for the particular 
+application or use case. MCP clients **MAY** perform subsequent authorization flows to 
+request additional scopes as needed. 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

The Authorization specification is great - but doesn't delve into how MCP Clients should request more fine-grained permissions from MCP Servers. Reference MCP Clients like the `inspector` don't request any OAuth scopes at all currently.

There is an exciting amount of literature on fine-grained authorization over OAuth that I am sure we will get into in the future (e.g. [RFC8707](https://www.rfc-editor.org/info/rfc8707), [RFC9396](https://datatracker.ietf.org/doc/html/rfc9396), etc.) but scopes are a foundational part of OAuth and seem to be a good place to start.

Added a short blurb calling out that servers report available scopes and that clients are responsible for requesting these scopes as needed. Language for minimum scope usage comes from [OAuth 2.1](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12#name-access-token-privilege-restr) though I must admit that I find the transition back and from `scope` to `scopes` awkward and have elected to only use the plural here.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
