### PR TITLE
Add Comet Opik to official MCP intergrations

### DIFF
--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -42,6 +42,7 @@ These MCP servers are maintained by companies for their platforms:
 
 - **[Axiom](https://github.com/axiomhq/mcp-server-axiom)** - Query and analyze logs, traces, and event data using natural language
 - **[Browserbase](https://github.com/browserbase/mcp-server-browserbase)** - Automate browser interactions in the cloud
+- **[Comet Opik](https://github.com/comet-ml/opik-mcp) - Interact and analyze your Opik enviroment including traces, telemetry and metrics with natural language.
 - **[Cloudflare](https://github.com/cloudflare/mcp-server-cloudflare)** - Deploy and manage resources on the Cloudflare developer platform
 - **[E2B](https://github.com/e2b-dev/mcp-server)** - Execute code in secure cloud sandboxes
 - **[Neon](https://github.com/neondatabase/mcp-server-neon)** - Interact with the Neon serverless Postgres platform


### PR DESCRIPTION
## Motivation and Context
Comet Opik is a leading open-source LLM observability and telemetry platform. This is their official MCP server for both the open-source and cloud editions.

## How Has This Been Tested?
Tested by Comet team on local IDE's and MCP inspector. Tests and unit tests are configured for the MCP package.

## Breaking Changes
No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Relates to https://github.com/modelcontextprotocol/servers/pull/813 (merged)
and moving https://github.com/modelcontextprotocol/docs/pull/177 to this PR
