### PR TITLE
Add `instructions` in initialize response

### DIFF
--- a/docs/specification/2025-03-26/basic/lifecycle.mdx
+++ b/docs/specification/2025-03-26/basic/lifecycle.mdx
@@ -101,7 +101,8 @@ The server **MUST** respond with its own capabilities and information:
     "serverInfo": {
       "name": "ExampleServer",
       "version": "1.0.0"
-    }
+    },
+    "instructions": "Optional instructions for the client"
   }
 }
 ```


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

I noticed that `instructions` is defined in the [schema](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-03-26/schema.ts#L192), and it's already supported in both the [TypeScript](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/server/index.ts#L81) and [Python](https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/server/models.py#L17) implementations. However, it wasn’t mentioned in the spec, so I added `instructions` to the initialize response on the Lifecycle page. Apologies if it was intentionally left out!

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

I ran the `serve:docs` command and visually confirmed that the `instructions` field has been added:

<img width="600" alt="Screenshot 2025-04-09 at 23 59 27" src="https://github.com/user-attachments/assets/ebdeaa45-d704-4ac5-a854-75dd369f7dfa" />

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
