### PR TITLE
Add Runbear to clients list

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -37,6 +37,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [OpenSumi][OpenSumi]                        | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools in OpenSumi                                                  |
 | [Daydreams Agents][Daydreams]              | ✅          | ✅        | ✅      | ❌         | ❌    | Support for drop in Servers to Daydreams agents                             |
 | [Apify MCP Tester][Apify MCP Tester]  | ❌         | ❌         | ✅       | ❌          | ❌     | Supports tools |
+| [Runbear][Runbear]                          | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools in team communication platforms                              |
 
 
 
@@ -72,6 +73,7 @@ This page provides an overview of applications that support the Model Context Pr
 [Tools]: https://modelcontextprotocol.io/docs/concepts/tools
 [Sampling]: https://modelcontextprotocol.io/docs/concepts/sampling
 [Microsoft Copilot Studio]: https://learn.microsoft.com/en-us/microsoft-copilot-studio/agent-extend-action-mcp
+[Runbear]: https://runbear.io
 
 ## Client details
 
@@ -311,6 +313,14 @@ It uses plain JavaScript (old-school style) and is hosted on Apify, allowing you
 - Connects to any MCP server via SSE.
 - Works with the [Apify MCP Server](https://apify.com/apify/actors-mcp-server) to interact with one or more Apify [Actors](https://apify.com/store).
 - Dynamically utilizes tools based on context and user queries (if supported by the server).
+
+### Runbear
+[Runbear](https://runbear.io) enables teams to create AI assistants in communication platforms like Slack, Microsoft Teams, and HubSpot.
+
+**Key features:**
+- Support for MCP tools in team [communication platforms](https://runbear.io/solutions/integrations/slack/mcp)
+- Integration with remote MCP servers via SSE
+- Managed MCP server options for teams
 
 ## Adding MCP support to your application
 


### PR DESCRIPTION
Add Runbear, a new client to MCP Client list

## Motivation and Context
Runbear enables teams to use MCP tools in communication platforms. Adding it as a remote MCP client for Slack, Teams, and HubSpot.

## How Has This Been Tested?
The documentation has been reviewed to ensure it matches the style and format of existing client entries. The content has been verified against Runbear's actual MCP capabilities.

## Breaking Changes
None. This is a documentation-only change.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed