### PR TITLE
chore(docs): add highlightai to client list

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -24,6 +24,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [Genkit][Genkit]                            | ⚠️          | ✅        | ✅      | ❌         | ❌    | Supports resource list and lookup through tools.                            |
 | [GenAIScript][GenAIScript]                  | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools.                                                             |
 | [Goose][Goose]                              | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools.                                                             |
+| [HighlightAI][HighlightAI]                  | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools.                                                             |
 | [LibreChat][LibreChat]                      | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools for Agents                                                   |
 | [mcp-agent][mcp-agent]                      | ❌          | ❌        | ✅      | ⚠️         | ❌    | Supports tools, server connection management, and agent workflows.          |
 | [Microsoft Copilot Studio]                  | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools                                                              |
@@ -53,6 +54,7 @@ This page provides an overview of applications that support the Model Context Pr
 [Genkit]: https://github.com/firebase/genkit
 [GenAIScript]: https://microsoft.github.io/genaiscript/reference/scripts/mcp-tools/
 [Goose]: https://block.github.io/goose/docs/goose-architecture/#interoperability-with-extensions
+[HighlightAI]: https://highlightai.com
 [LibreChat]: https://github.com/danny-avila/LibreChat
 [mcp-agent]: https://github.com/lastmile-ai/mcp-agent
 [Microsoft Copilot Studio]: https://learn.microsoft.com/en-us/microsoft-copilot-studio/agent-extend-action-mcp
@@ -200,6 +202,18 @@ Programmatically assemble prompts for LLMs using [GenAIScript](https://microsoft
 - MCPs can be installed directly via the [extensions directory](https://block.github.io/goose/v1/extensions/), CLI, or UI.
 - Goose allows you to extend its functionality by [building your own MCP servers](https://block.github.io/goose/docs/tutorials/custom-extensions).
 - Includes built-in tools for development, web scraping, automation, memory, and integrations with JetBrains and Google Drive.
+
+### HighlightAI
+[HighlightAI](https://highlightai.com) lets you get instant answers about anything you've seen, heard or said. HighlightAI is an desktop app that runs on macOS and Windows.
+
+**Key features:**
+- Local audio and mic transcription: Automatically capture and share meeting notes, saving hours of manual work
+- Hold command anywhere to talk: Control apps, dictate content, and ask questions completely hands-free
+- Follows your actions on any app: Select text anywhere and instantly summarize, translate, or analyze it
+- Use Apps & Your Screen as input: Capture any part of your screen for instant insights and explanations
+- One-Click MCP Server: We take care of the MCP setup, you can set your environment variables and start using it in seconds
+- [Open source bundler](https://github.com/highlight-ing/mcp-bundler): We open sourced our bundler so any client can use it to add MCP support to their app
+- [Public registry](https://mcpservers.com/): We maintain a public registry of MCP servers that you can use in Highlight or your own MCP clients
 
 ### LibreChat
 [LibreChat](https://github.com/danny-avila/LibreChat) is an open-source, customizable AI chat UI that supports multiple AI providers, now including MCP integration.


### PR DESCRIPTION
I added HighlightAI to the clients list with feature support and detailed description.

## Motivation and Context
Adding HighlightAI to the MCP clients list to showcase another implementation and help users discover available MCP-compatible applications. HighlightAI provides unique features like local audio transcription and screen capture with MCP integration.

## How Has This Been Tested?
Verified HighlightAI's MCP implementation in production
Tested MCP server integration with environment variables
Validated feature matrix accuracy

## Breaking Changes
None - This is an additive change to documentation only.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
HighlightAI also maintains an open source MCP bundler and public registry of MCP servers that other clients can use.
Bundler: https://github.com/highlight-ing/mcp-bundler
Registry: https://mcpservers.com/