### PR TITLE
[RFC] Search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .DS_Store
+.idea/

--- a/docs/specification/2025-03-26/server/utilities/search.mdx
+++ b/docs/specification/2025-03-26/server/utilities/search.mdx
@@ -1,0 +1,168 @@
+---
+title: Search
+---
+
+<Info>**Protocol Revision**: 2025-03-26</Info>
+
+The Model Context Protocol (MCP) provides a standardized way for agents to search tools,
+resources, prompts, and other features.
+
+## User Interaction Model
+
+Search in MCP is designed to facilitate discovery of tools for assisting and automating
+tasks, especially in environments where the number of tools is either too large to be
+reasonably paginated or there are concerns with LLM context length for the number of tools.
+
+For example, given a prompt such as what's the weather in San Francisco, an LLM could
+request a search of tools such as "Get weather data for North America". The list of tools
+will be returned and ordered by relevance, with the server's approximation of most relevant
+tools at the top.
+
+Implementations are free to use any different method to enable search, from very simple
+keyword search, to more complex embedded vectorization search.
+
+## Capabilities
+
+Servers that support search **MUST** declare the `search` capability in the respective
+feature area:
+
+```json
+{
+  "capabilities": {
+    "tools": {
+      "search": true
+    }
+  }
+}
+```
+
+```json
+{
+  "capabilities": {
+    "prompts": {
+      "search": true
+    }
+  }
+}
+```
+
+```json
+{
+  "capabilities": {
+    "resources": {
+      "search": true
+    }
+  }
+}
+```
+
+## Protocol Messages
+
+### Requesting earch
+
+To get completion suggestions, clients send the appropriate request to the server, `tools/search`,
+identifying both what feature set is being searched and providing a query. Pagination is handled
+through the cursor, but the client **MUST** provide the original query parameter paired with the
+cursor.
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/search",
+  "params": {
+    "query": "tools to return the weather in San Francisco",
+    "cursor": "optional-cursor-value"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "tools": [
+      {
+        "name": "get_weather",
+        "description": "Get current weather information for a location",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string",
+              "description": "City name or zip code"
+            }
+          },
+          "required": ["location"]
+        }
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+```
+
+### Search Results
+
+Servers return an array of search results, matching the format of the list call for, for the
+various features, ranked by relevance, with:
+
+- Maximum 10 items per response
+- Optional next cursor
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client: Client searches for tool
+    Client->>Server: tools/search
+    Server-->>Client: Search Results
+```
+
+## Data Types
+
+### SearchRequest
+
+- `query`: Text that expresses what is being searched for. This can be a keyword (e.g., 'weather'), a description (e.g., 'cities weather is available for'), or a use case (e.g., 'trying to generate weather reports').
+- `nextCursor`: An opaque pagination token
+
+### SearchResult
+Please see the list results in [Tools](/specification/2025-03-26/server/tools),
+[Prompts](/specification/2025-03-26/server/prompts), and [Resources](/specification/2025-03-26/server/resources),
+
+## Error Handling
+
+Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Method not found: `-32601` (Capability not supported)
+- Missing required arguments: `-32602` (Invalid params)
+- Internal errors: `-32603` (Internal error)
+
+## Implementation Considerations
+
+1. Servers **SHOULD**:
+   - Return suggestions sorted by relevance
+   - Implement embedded vectorization when possible to enable better natural language results
+   - Rate limit search results
+   - Validate all inputs
+
+2. Clients **SHOULD**:
+   - Use batching if it's not clear whether a tool, resource, or prompt is being searched
+   - Cache results when possible
+   - Facilitate pagination through the `nextCursor` field
+
+## Security
+
+Implementations **MUST**:
+
+- Validate all completion inputs
+- Implement appropriate rate limiting
+- Limit access to search results based on appropriate user controls

--- a/schema/2025-03-26/schema.json
+++ b/schema/2025-03-26/schema.json
@@ -226,6 +226,15 @@
                     "$ref": "#/definitions/ListResourcesRequest"
                 },
                 {
+                    "$ref": "#/definitions/SearchResourcesRequest"
+                },
+                {
+                    "$ref": "#/definitions/ListResourceTemplatesRequest"
+                },
+                {
+                    "$ref": "#/definitions/SearchResourceTemplatesRequest"
+                },
+                {
                     "$ref": "#/definitions/ReadResourceRequest"
                 },
                 {
@@ -238,10 +247,16 @@
                     "$ref": "#/definitions/ListPromptsRequest"
                 },
                 {
+                    "$ref": "#/definitions/SearchPromptsRequest"
+                },
+                {
                     "$ref": "#/definitions/GetPromptRequest"
                 },
                 {
                     "$ref": "#/definitions/ListToolsRequest"
+                },
+                {
+                    "$ref": "#/definitions/SearchToolsRequest"
                 },
                 {
                     "$ref": "#/definitions/CallToolRequest"
@@ -902,6 +917,32 @@
             ],
             "type": "object"
         },
+        "SearchPromptsRequest": {
+            "description": "Search for prompts and prompt templates the server provides, given a natural language or keyword query.",
+            "properties": {
+                "method": {
+                    "const": "prompts/search",
+                    "type": "string"
+                },
+                "params": {
+                    "properties": {
+                        "query": {
+                            "description": "Text that expresses what prompts to search for. This can be a specific prompt type (e.g., 'summarization'), a capability description (e.g., 'writing in a professional tone'), or a task description (e.g., 'generating creative content'). The server will return prompts matching this query.",
+                            "type": "string"
+                        },
+                        "cursor": {
+                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "required": [
+                "method"
+            ],
+            "type": "object"
+        },
         "ListPromptsResult": {
             "description": "The server's response to a prompts/list request from the client.",
             "properties": {
@@ -948,6 +989,32 @@
             ],
             "type": "object"
         },
+        "SearchResourceTemplatesRequest": {
+            "description": "Search for resource templates the server provides, given a natural language or keyword query.",
+            "properties": {
+                "method": {
+                    "const": "resources/templates/search",
+                    "type": "string"
+                },
+                "params": {
+                    "properties": {
+                        "query": {
+                            "description": "Text that expresses what resource templates to search for. This can be a specific template type (e.g., 'document'), a format description (e.g., 'markdown templates'), or a use case (e.g., 'templates for scientific reports'). The server will return resource templates matching this query.",
+                            "type": "string"
+                        },
+                        "cursor": {
+                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "required": [
+                "method"
+            ],
+            "type": "object"
+        },
         "ListResourceTemplatesResult": {
             "description": "The server's response to a resources/templates/list request from the client.",
             "properties": {
@@ -981,6 +1048,32 @@
                 },
                 "params": {
                     "properties": {
+                        "cursor": {
+                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "required": [
+                "method"
+            ],
+            "type": "object"
+        },
+        "SearchResourcesRequest": {
+            "description": "Search for resources the server provides, given a natural language or keyword query.",
+            "properties": {
+                "method": {
+                    "const": "resources/search",
+                    "type": "string"
+                },
+                "params": {
+                    "properties": {
+                        "query": {
+                            "description": "Text that expresses what resources to search for. This can be a specific resource type (e.g., 'image'), a content description (e.g., 'data about climate change'), or a usage intent (e.g., 'background information for an article'). The server will return resources matching this query.",
+                            "type": "string"
+                        },
                         "cursor": {
                             "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
                             "type": "string"
@@ -1075,6 +1168,32 @@
                 },
                 "params": {
                     "properties": {
+                        "cursor": {
+                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "required": [
+                "method"
+            ],
+            "type": "object"
+        },
+        "SearchToolsRequest": {
+            "description": "Search for tools the server provides, given a natural language or keyword query.",
+            "properties": {
+                "method": {
+                    "const": "tools/search",
+                    "type": "string"
+                },
+                "params": {
+                    "properties": {
+                        "query": {
+                            "description": "Text that expresses what tools to search for. This can be a specific tool name (e.g., 'calculator'), a capability description (e.g., 'something that can analyze images'), or a task description (e.g., 'I need to process CSV data'). The server will return tools matching this query.",
+                            "type": "string"
+                        },
                         "cursor": {
                             "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
                             "type": "string"
@@ -2130,4 +2249,3 @@
         }
     }
 }
-


### PR DESCRIPTION
## Motivation and Context
On MCP servers that potentially have hundreds or thousands of tools, resources, or prompts, paginating and holding these items in LLM context can be either prohibitively slow or exceed context thresholds. This proposal is for a well known search capability where, rather than having to list and cache all tools, the server can be queried ad hoc for tools, and implementations can provide various levels of support for simple keyword or natural language search.

## How Has This Been Tested?
This is purely a spec change.

## Breaking Changes
This is an opt-in capability, and is thus fully backwards compatible.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
Open to comments - this is a first draft. The other option for implementation rather than <feature>/search was to have a single unified search capability, search/query. I think specific searching is easier to implement (when you have a single search you have the question of how to interleave search results, or provide pagination on "sub lists" of items, which can be messy and hard to do agentically. 