### PR TITLE
re-adding missing request/response for ListResourceTemplates in schema.ts

### DIFF
--- a/schema/2025-03-26/schema.ts
+++ b/schema/2025-03-26/schema.ts
@@ -726,11 +726,11 @@ export interface ToolListChangedNotification extends Notification {
 
 /**
  * Additional properties describing a Tool to clients.
- * 
- * NOTE: all properties in ToolAnnotations are **hints**. 
- * They are not guaranteed to provide a faithful description of 
+ *
+ * NOTE: all properties in ToolAnnotations are **hints**.
+ * They are not guaranteed to provide a faithful description of
  * tool behavior (including descriptive properties like `title`).
- * 
+ *
  * Clients should never make tool use decisions based on ToolAnnotations
  * received from untrusted servers.
  */
@@ -742,7 +742,7 @@ export interface ToolAnnotations {
 
   /**
    * If true, the tool does not modify its environment.
-   * 
+   *
    * Default: false
    */
   readOnlyHint?: boolean;
@@ -750,19 +750,19 @@ export interface ToolAnnotations {
   /**
    * If true, the tool may perform destructive updates to its environment.
    * If false, the tool performs only additive updates.
-   * 
+   *
    * (This property is meaningful only when `readOnlyHint == false`)
-   * 
+   *
    * Default: true
    */
   destructiveHint?: boolean;
 
   /**
-   * If true, calling the tool repeatedly with the same arguments 
+   * If true, calling the tool repeatedly with the same arguments
    * will have no additional effect on the its environment.
-   * 
+   *
    * (This property is meaningful only when `readOnlyHint == false`)
-   * 
+   *
    * Default: false
    */
   idempotentHint?: boolean;
@@ -772,7 +772,7 @@ export interface ToolAnnotations {
    * entities. If false, the tool's domain of interaction is closed.
    * For example, the world of a web search tool is open, whereas that
    * of a memory tool is not.
-   * 
+   *
    * Default: true
    */
   openWorldHint?: boolean;
@@ -1217,6 +1217,7 @@ export type ClientRequest =
   | GetPromptRequest
   | ListPromptsRequest
   | ListResourcesRequest
+  | ListResourceTemplatesRequest
   | ReadResourceRequest
   | SubscribeRequest
   | UnsubscribeRequest
@@ -1252,6 +1253,7 @@ export type ServerResult =
   | CompleteResult
   | GetPromptResult
   | ListPromptsResult
+  | ListResourceTemplatesResult
   | ListResourcesResult
   | ReadResourceResult
   | CallToolResult


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
I noticed when updating that ListResourceTemplate no longer appeared in the requests/responses, though it was still present in the schema and still discussed [in the docs](https://modelcontextprotocol.io/docs/concepts/resources#resource-templates), so I assume this was removed in error.

## How Has This Been Tested?
Tested the types are no-longer breaking.

## Breaking Changes
This removes a breaking change.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
