### PR TITLE
Add Klavis AI Slack & Discord in MCP Client list

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -24,7 +24,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [Genkit][Genkit]                            | ⚠️          | ✅        | ✅      | ❌         | ❌    | Supports resource list and lookup through tools.                            |
 | [GenAIScript][GenAIScript]                  | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools.                                                             |
 | [Goose][Goose]                              | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools.                                                             |
-| [Klavis AI][Klavis AI]                      | ✅          | ❌        | ✅      | ❌         | ❌    | Supports tools and resources.                                               |
+| [Klavis AI Slack & Discord][Klavis AI]      | ✅          | ❌        | ✅      | ❌         | ❌    | Supports tools and resources.                                               |
 | [LibreChat][LibreChat]                      | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools for Agents                                                   |
 | [mcp-agent][mcp-agent]                      | ❌          | ❌        | ✅      | ⚠️         | ❌    | Supports tools, server connection management, and agent workflows.          |
 | [Microsoft Copilot Studio]                  | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools                                                              |
@@ -205,14 +205,13 @@ Programmatically assemble prompts for LLMs using [GenAIScript](https://microsoft
 - Goose allows you to extend its functionality by [building your own MCP servers](https://block.github.io/goose/docs/tutorials/custom-extensions).
 - Includes built-in tools for development, web scraping, automation, memory, and integrations with JetBrains and Google Drive.
 
-### Klavis AI
+### Klavis AI Slack & Discord
 [Klavis AI](https://www.klavis.ai/) is an Open-Source Infra to Use, Build & Scale MCPs with ease.
 
 **Key features:**
-- Slack and Discord clients for using MCPs directly within these platforms
+- Slack and Discord clients for using MCPs directly
 - Simple web UI dashboard for easy MCP configuration
-- Hosted MCP servers (report generation, YouTube tools, doc conversion) without infrastructure management
-- Built-in OAuth support for secure access to user resources
+- Direct OAuth integration with Slack and Discord for secure user authentication
 - SSE transport support
 - Open-source infrastructure ([GitHub repository](https://github.com/Klavis-AI/klavis))
 

--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -24,7 +24,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [Genkit][Genkit]                            | ⚠️          | ✅        | ✅      | ❌         | ❌    | Supports resource list and lookup through tools.                            |
 | [GenAIScript][GenAIScript]                  | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools.                                                             |
 | [Goose][Goose]                              | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools.                                                             |
-| [Klavis AI Slack & Discord][Klavis AI]      | ✅          | ❌        | ✅      | ❌         | ❌    | Supports tools and resources.                                               |
+| [Klavis AI Slack/Discord/Web][Klavis AI]    | ✅          | ❌        | ✅      | ❌         | ❌    | Supports tools and resources.                                               |
 | [LibreChat][LibreChat]                      | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools for Agents                                                   |
 | [mcp-agent][mcp-agent]                      | ❌          | ❌        | ✅      | ⚠️         | ❌    | Supports tools, server connection management, and agent workflows.          |
 | [Microsoft Copilot Studio]                  | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools                                                              |
@@ -205,13 +205,13 @@ Programmatically assemble prompts for LLMs using [GenAIScript](https://microsoft
 - Goose allows you to extend its functionality by [building your own MCP servers](https://block.github.io/goose/docs/tutorials/custom-extensions).
 - Includes built-in tools for development, web scraping, automation, memory, and integrations with JetBrains and Google Drive.
 
-### Klavis AI Slack & Discord
+### Klavis AI Slack/Discord/Web
 [Klavis AI](https://www.klavis.ai/) is an Open-Source Infra to Use, Build & Scale MCPs with ease.
 
 **Key features:**
-- Slack and Discord clients for using MCPs directly
+- Slack/Discord/Web MCP clients for using MCPs directly
 - Simple web UI dashboard for easy MCP configuration
-- Direct OAuth integration with Slack and Discord for secure user authentication
+- Direct OAuth integration with Slack & Discord Clients and MCP Servers for secure user authentication
 - SSE transport support
 - Open-source infrastructure ([GitHub repository](https://github.com/Klavis-AI/klavis))
 

--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -24,7 +24,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [Genkit][Genkit]                            | ⚠️          | ✅        | ✅      | ❌         | ❌    | Supports resource list and lookup through tools.                            |
 | [GenAIScript][GenAIScript]                  | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools.                                                             |
 | [Goose][Goose]                              | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools.                                                             |
-| [Klavis AI Slack & Discord][Klavis AI]      | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools.                                               |
+| [Klavis AI Slack & Discord][Klavis AI]      | ✅          | ❌        | ✅      | ❌         | ❌    | Supports tools and resources.                                               |
 | [LibreChat][LibreChat]                      | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools for Agents                                                   |
 | [mcp-agent][mcp-agent]                      | ❌          | ❌        | ✅      | ⚠️         | ❌    | Supports tools, server connection management, and agent workflows.          |
 | [Microsoft Copilot Studio]                  | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools                                                              |

--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -24,6 +24,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [Genkit][Genkit]                            | ⚠️          | ✅        | ✅      | ❌         | ❌    | Supports resource list and lookup through tools.                            |
 | [GenAIScript][GenAIScript]                  | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools.                                                             |
 | [Goose][Goose]                              | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools.                                                             |
+| [Klavis AI][Klavis AI]                      | ✅          | ❌        | ✅      | ❌         | ❌    | Supports tools and resources.                                               |
 | [LibreChat][LibreChat]                      | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools for Agents                                                   |
 | [mcp-agent][mcp-agent]                      | ❌          | ❌        | ✅      | ⚠️         | ❌    | Supports tools, server connection management, and agent workflows.          |
 | [Microsoft Copilot Studio]                  | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools                                                              |
@@ -49,6 +50,7 @@ This page provides an overview of applications that support the Model Context Pr
 [CopilotMCP]: https://github.com/VikashLoomba/copilot-mcp
 [Cursor]: https://cursor.com
 [Daydreams]: https://github.com/daydreamsai/daydreams
+[Klavis AI]: https://www.klavis.ai/
 [Mcp.el]: https://github.com/lizqwerscott/mcp.el
 [fast-agent]: https://github.com/evalstate/fast-agent
 [Genkit]: https://github.com/firebase/genkit
@@ -202,6 +204,20 @@ Programmatically assemble prompts for LLMs using [GenAIScript](https://microsoft
 - MCPs can be installed directly via the [extensions directory](https://block.github.io/goose/v1/extensions/), CLI, or UI.
 - Goose allows you to extend its functionality by [building your own MCP servers](https://block.github.io/goose/docs/tutorials/custom-extensions).
 - Includes built-in tools for development, web scraping, automation, memory, and integrations with JetBrains and Google Drive.
+
+### Klavis AI
+[Klavis AI](https://www.klavis.ai/) is an Open-Source Infra to Use, Build & Scale MCPs with ease.
+
+**Key features:**
+- Slack and Discord clients for using MCPs directly within these platforms
+- Simple web UI dashboard for easy MCP configuration
+- Hosted MCP servers (report generation, YouTube tools, doc conversion) without infrastructure management
+- Built-in OAuth support for secure access to user resources
+- SSE transport support
+- Open-source infrastructure ([GitHub repository](https://github.com/Klavis-AI/klavis))
+
+**Learn more:**
+- [Demo video showing MCP usage in Slack/Discord](https://youtu.be/9-QQAhrQWw8)
 
 ### LibreChat
 [LibreChat](https://github.com/danny-avila/LibreChat) is an open-source, customizable AI chat UI that supports multiple AI providers, now including MCP integration.

--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -24,7 +24,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [Genkit][Genkit]                            | ⚠️          | ✅        | ✅      | ❌         | ❌    | Supports resource list and lookup through tools.                            |
 | [GenAIScript][GenAIScript]                  | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools.                                                             |
 | [Goose][Goose]                              | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools.                                                             |
-| [Klavis AI Slack & Discord][Klavis AI]      | ✅          | ❌        | ✅      | ❌         | ❌    | Supports tools and resources.                                               |
+| [Klavis AI Slack & Discord][Klavis AI]      | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools.                                               |
 | [LibreChat][LibreChat]                      | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools for Agents                                                   |
 | [mcp-agent][mcp-agent]                      | ❌          | ❌        | ✅      | ⚠️         | ❌    | Supports tools, server connection management, and agent workflows.          |
 | [Microsoft Copilot Studio]                  | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools                                                              |


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Add Klavis AI (YC X25) Slack/Discord/Web MCP Clients.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
We launched Klavis AI to make MCP accessible to a broader audience by eliminating setup complexity. Building AI workflows with MCP remain largely inaccessible to non-technical users and slow to scale for developers. 

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
We’ve validated clients internally with various MCPs and tested deployment in real-time on both Slack and Discord. We’ve also engaged early users from the community for feedback.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
