### PR TITLE
RFC: add `Tool.outputSchema` and `CallToolResult.structuredContent`

### DIFF
--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -181,6 +181,7 @@ A tool definition includes:
 - `name`: Unique identifier for the tool
 - `description`: Human-readable description of functionality
 - `inputSchema`: JSON Schema defining expected parameters
+- `outputSchema`: Optional JSON Schema defining the expected output structure
 - `annotations`: optional properties describing tool behavior
 
 <Warning>For trust & safety and security, clients **MUST** consider
@@ -234,6 +235,76 @@ or data, behind a URI that can be subscribed to or fetched again by the client l
   }
 }
 ```
+
+### Output Schema
+
+The optional `outputSchema` property provides a JSON Schema that describes the expected structure of the tool's output. This schema applies to the `text` property of the TextContent object returned by the tool.
+
+When a tool specifies an `outputSchema`:
+
+1. Clients **SHOULD** validate that the tool's result:
+   - Contains exactly one content item
+   - This item is a `TextContent` object
+   - The `text` property of this object validates against the schema
+
+2. Servers **SHOULD**:
+   - Provide responses that conform to their declared schema
+   - Use proper JSON or structured formats in their responses when the schema specifies structured data
+
+Example tool with output schema:
+
+```json
+{
+  "name": "search_database",
+  "description": "Search a database for records",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "query": {
+        "type": "string",
+        "description": "Search query"
+      }
+    },
+    "required": ["query"]
+  },
+  "outputSchema": {
+    "type": "array",
+    "items": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "title": { "type": "string" },
+        "url": { "type": "string" }
+      },
+      "required": ["id", "title"]
+    }
+  }
+}
+```
+
+Example valid response for this tool:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "[{\"id\":\"doc-1\",\"title\":\"Introduction to MCP\",\"url\":\"https://example.com/docs/1\"},{\"id\":\"doc-2\",\"title\":\"Tool Usage Guide\",\"url\":\"https://example.com/docs/2\"}]"
+      }
+    ]
+  }
+}
+```
+
+The `outputSchema` helps clients and LLMs understand and properly handle tool outputs by:
+
+- Enabling schema validation of responses
+- Providing type information for better integration with programming languages
+- Guiding LLMs to properly parse and utilize the returned data
+- Supporting better documentation and developer experience
 
 ## Error Handling
 

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -189,7 +189,11 @@ tool annotations to be untrusted unless they come from trusted servers.</Warning
 
 ### Tool Result
 
-Tool results can contain multiple content items of different types:
+Tool results may be **structured** or **unstructured**, depending on whether the tool definition specifies an [output schema](#output-schema).
+
+**Structured** tool results are JSON objects that are valid with respect to the tool's output schema.
+
+**Unstructured** tool results can contain multiple content items of different types:
 
 #### Text Content
 
@@ -238,41 +242,93 @@ or data, behind a URI that can be subscribed to or fetched again by the client l
 
 ### Output Schema
 
-The optional `outputSchema` property provides a JSON Schema that describes the expected structure of the `structuredContent` property of a CallToolResult.
+Tools that produce structured results can use the `outputSchema` property to provide a JSON Schema describing the expected structure of their output.
 
 When a tool specifies an `outputSchema`:
 
-1. Clients **MUST** validate that the tool result contains a `structuredContent` field whose contents validate against the declared `outputSchema`.
+1. Clients **MUST** validate that results from that tool contain a `structuredContent` field whose contents validate against the declared `outputSchema`.
 
-2. Servers **MUST** provide tool results that conform to their declared `outputSchema`s.
+2. Servers **MUST** provide structured results in `structuredContent` that conform to the declared `outputSchema` of the tool.
+
+<Info>
+For backwards compatibility, a tool that declares an `outputSchema` may also return unstructured results in the `content` field.
+* If present, the unstructured result should be functionally equivalent to the structured result.
+* Clients that support `structuredContent` should ignore the `content` field if present.
+</Info>
 
 Example tool with output schema:
 
 ```json
 {
-  "name": "search_database",
-  "description": "Search a database for records",
+  "name": "get_weather_data",
+  "description": "Get current weather conditions and forecast data for a location",
   "inputSchema": {
     "type": "object",
     "properties": {
-      "query": {
+      "location": {
         "type": "string",
-        "description": "Search query"
+        "description": "City name or zip code"
+      },
+      "units": {
+        "type": "string",
+        "enum": ["celsius", "fahrenheit"],
+        "default": "celsius",
+        "description": "Temperature unit"
       }
     },
-    "required": ["query"]
+    "required": ["location"]
   },
   "outputSchema": {
-    "type": "array",
-    "items": {
-      "type": "object",
-      "properties": {
-        "id": { "type": "string" },
-        "title": { "type": "string" },
-        "url": { "type": "string" }
+    "type": "object",
+    "properties": {
+      "current": {
+        "type": "object",
+        "properties": {
+          "temperature": { "type": "number" },
+          "humidity": { "type": "number" },
+          "conditions": { "type": "string" },
+          "wind": {
+            "type": "object",
+            "properties": {
+              "speed": { "type": "number" },
+              "direction": { "type": "string" }
+            },
+            "required": ["speed", "direction"]
+          }
+        },
+        "required": ["temperature", "humidity", "conditions", "wind"]
       },
-      "required": ["id", "title"]
-    }
+      "forecast": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "date": { "type": "string", "format": "date" },
+            "high": { "type": "number" },
+            "low": { "type": "number" },
+            "conditions": { "type": "string" }
+          },
+          "required": ["date", "high", "low", "conditions"]
+        }
+      },
+      "location": {
+        "type": "object",
+        "properties": {
+          "city": { "type": "string" },
+          "country": { "type": "string" },
+          "coordinates": {
+            "type": "object",
+            "properties": {
+              "latitude": { "type": "number" },
+              "longitude": { "type": "number" }
+            },
+            "required": ["latitude", "longitude"]
+          }
+        },
+        "required": ["city", "country", "coordinates"]
+      }
+    },
+    "required": ["current", "forecast", "location"]
   }
 }
 ```
@@ -285,8 +341,37 @@ Example valid response for this tool:
   "id": 5,
   "result": {
     "structuredContent": {
-      "type": "text",
-      "text": "[{\"id\":\"doc-1\",\"title\":\"Introduction to MCP\",\"url\":\"https://example.com/docs/1\"},{\"id\":\"doc-2\",\"title\":\"Tool Usage Guide\",\"url\":\"https://example.com/docs/2\"}]"
+      "current": {
+        "temperature": 22.5,
+        "humidity": 65,
+        "conditions": "Partly cloudy",
+        "wind": {
+          "speed": 12,
+          "direction": "NW"
+        }
+      },
+      "forecast": [
+        {
+          "date": "2024-03-28",
+          "high": 25,
+          "low": 18,
+          "conditions": "Sunny"
+        },
+        {
+          "date": "2024-03-29",
+          "high": 23,
+          "low": 17,
+          "conditions": "Cloudy"
+        }
+      ],
+      "location": {
+        "city": "San Francisco",
+        "country": "US",
+        "coordinates": {
+          "latitude": 37.7749,
+          "longitude": -122.4194
+        }
+      }
     }
   }
 }

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -242,7 +242,7 @@ or data, behind a URI that can be subscribed to or fetched again by the client l
 
 ### Output Schema
 
-Tools that produce structured results can use the `outputSchema` property to provide a JSON Schema describing the expected structure of their output.
+Tools that produce structured results can use the `outputSchema` property to provide a JSON Schema describing the expected structure of their output. 
 
 When a tool specifies an `outputSchema`:
 
@@ -252,7 +252,7 @@ When a tool specifies an `outputSchema`:
 
 <Info>
 For backwards compatibility, a tool that declares an `outputSchema` may also return unstructured results in the `content` field.
-* If present, the unstructured result should be functionally equivalent to the structured result.
+* If present, the unstructured result should be functionally equivalent to the structured result. (For example, serialized JSON can be returned in a `TextContent` block.)
 * Clients that support `structuredContent` should ignore the `content` field if present.
 </Info>
 

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -181,7 +181,7 @@ A tool definition includes:
 - `name`: Unique identifier for the tool
 - `description`: Human-readable description of functionality
 - `inputSchema`: JSON Schema defining expected parameters
-- `outputSchema`: Optional JSON Schema defining the expected output structure
+- `outputSchema`: Optional JSON Schema defining expected output structure
 - `annotations`: optional properties describing tool behavior
 
 <Warning>For trust & safety and security, clients **MUST** consider
@@ -238,18 +238,13 @@ or data, behind a URI that can be subscribed to or fetched again by the client l
 
 ### Output Schema
 
-The optional `outputSchema` property provides a JSON Schema that describes the expected structure of the tool's output. This schema applies to the `text` property of the TextContent object returned by the tool.
+The optional `outputSchema` property provides a JSON Schema that describes the expected structure of the `structuredContent` property of a CallToolResult.
 
 When a tool specifies an `outputSchema`:
 
-1. Clients **SHOULD** validate that the tool's result:
-   - Contains exactly one content item
-   - This item is a `TextContent` object
-   - The `text` property of this object validates against the schema
+1. Clients **MUST** validate that the tool result contains a `structuredContent` field whose contents validate against the declared `outputSchema`.
 
-2. Servers **SHOULD**:
-   - Provide responses that conform to their declared schema
-   - Use proper JSON or structured formats in their responses when the schema specifies structured data
+2. Servers **MUST** provide tool results that conform to their declared `outputSchema`s.
 
 Example tool with output schema:
 
@@ -289,21 +284,19 @@ Example valid response for this tool:
   "jsonrpc": "2.0",
   "id": 5,
   "result": {
-    "content": [
-      {
-        "type": "text",
-        "text": "[{\"id\":\"doc-1\",\"title\":\"Introduction to MCP\",\"url\":\"https://example.com/docs/1\"},{\"id\":\"doc-2\",\"title\":\"Tool Usage Guide\",\"url\":\"https://example.com/docs/2\"}]"
-      }
-    ]
+    "structuredContent": {
+      "type": "text",
+      "text": "[{\"id\":\"doc-1\",\"title\":\"Introduction to MCP\",\"url\":\"https://example.com/docs/1\"},{\"id\":\"doc-2\",\"title\":\"Tool Usage Guide\",\"url\":\"https://example.com/docs/2\"}]"
+    }
   }
 }
 ```
 
-The `outputSchema` helps clients and LLMs understand and properly handle tool outputs by:
+The `outputSchema` helps clients and LLMs understand and properly handle structured tool outputs by:
 
-- Enabling schema validation of responses
+- Enabling strict schema validation of responses
 - Providing type information for better integration with programming languages
-- Guiding LLMs to properly parse and utilize the returned data
+- Guiding clients and LLMs to properly parse and utilize the returned data
 - Supporting better documentation and developer experience
 
 ## Error Handling

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -101,7 +101,18 @@
             "type": "object"
         },
         "CallToolResult": {
-            "description": "The server's response to a tool call.\n\nAny errors that originate from the tool SHOULD be reported inside the result\nobject, with `isError` set to true, _not_ as an MCP protocol-level error\nresponse. Otherwise, the LLM would not be able to see that an error occurred\nand self-correct.\n\nHowever, any errors in _finding_ the tool, an error indicating that the\nserver does not support tool calls, or any other exceptional conditions,\nshould be reported as an MCP error response.",
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/CallToolUnstructuredResult"
+                },
+                {
+                    "$ref": "#/definitions/CallToolStructuredResult"
+                }
+            ],
+            "description": "The server's response to a tool call.\n\nAny errors that originate from the tool SHOULD be reported inside the result\nobject, with `isError` set to true, _not_ as an MCP protocol-level error\nresponse. Otherwise, the LLM would not be able to see that an error occurred\nand self-correct.\n\nHowever, any errors in _finding_ the tool, an error indicating that the\nserver does not support tool calls, or any other exceptional conditions,\nshould be reported as an MCP error response."
+        },
+        "CallToolStructuredResult": {
+            "description": "Tool result for tools that do declare an outputSchema.",
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
@@ -109,7 +120,7 @@
                     "type": "object"
                 },
                 "content": {
-                    "description": "A list of content objects that represent the result of the tool call.",
+                    "description": "If the Tool defines an outputSchema, this field MAY be present in the result.\nTools should use this field to provide compatibility with older clients that do not support structured content.\nClients that support structured content should ignore this field.",
                     "items": {
                         "anyOf": [
                             {
@@ -133,10 +144,52 @@
                     "type": "boolean"
                 },
                 "structuredContent": {
-                    "description": "If the Tool defines an outputSchema, this field MUST contain a serialized JSON object that matches the schema.",
-                    "type": "string"
+                    "additionalProperties": {},
+                    "description": "An object containing structured tool output.\n\nIf the Tool defines an outputSchema, this field MUST be present in the result, and contain a JSON object that matches the schema.",
+                    "type": "object"
                 }
             },
+            "required": [
+                "structuredContent"
+            ],
+            "type": "object"
+        },
+        "CallToolUnstructuredResult": {
+            "description": "Tool result for tools that do not declare an outputSchema.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object"
+                },
+                "content": {
+                    "description": "A list of content objects that represent the result of the tool call.\n\nIf the Tool does not define an outputSchema, this field MUST be present in the result.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/TextContent"
+                            },
+                            {
+                                "$ref": "#/definitions/ImageContent"
+                            },
+                            {
+                                "$ref": "#/definitions/AudioContent"
+                            },
+                            {
+                                "$ref": "#/definitions/EmbeddedResource"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "isError": {
+                    "description": "Whether the tool call ended in an error.\n\nIf not set, this is assumed to be false (the call was successful).",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "content"
+            ],
             "type": "object"
         },
         "CancelledNotification": {
@@ -359,6 +412,25 @@
                 "completion"
             ],
             "type": "object"
+        },
+        "ContentList": {
+            "items": {
+                "anyOf": [
+                    {
+                        "$ref": "#/definitions/TextContent"
+                    },
+                    {
+                        "$ref": "#/definitions/ImageContent"
+                    },
+                    {
+                        "$ref": "#/definitions/AudioContent"
+                    },
+                    {
+                        "$ref": "#/definitions/EmbeddedResource"
+                    }
+                ]
+            },
+            "type": "array"
         },
         "CreateMessageRequest": {
             "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
@@ -1906,7 +1978,10 @@
                     "$ref": "#/definitions/ListToolsResult"
                 },
                 {
-                    "$ref": "#/definitions/CallToolResult"
+                    "$ref": "#/definitions/CallToolUnstructuredResult"
+                },
+                {
+                    "$ref": "#/definitions/CallToolStructuredResult"
                 },
                 {
                     "$ref": "#/definitions/CompleteResult"
@@ -2054,7 +2129,7 @@
                 },
                 "outputSchema": {
                     "additionalProperties": true,
-                    "description": "A JSON Schema object defining the structure of the tool's output.\n\nIf set, a CallToolResult for this Tool MUST contain a structuredContent field whose contents validate against this schema.",
+                    "description": "An optional JSON Schema object defining the structure of the tool's output.\n\nIf set, a CallToolResult for this Tool MUST contain a structuredContent field whose contents validate against this schema.\nIf not set, a CallToolResult for this Tool MUST contain a content field.",
                     "properties": {},
                     "type": "object"
                 }

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -109,6 +109,7 @@
                     "type": "object"
                 },
                 "content": {
+                    "description": "A list of content objects that represent the result of the tool call.",
                     "items": {
                         "anyOf": [
                             {
@@ -130,11 +131,12 @@
                 "isError": {
                     "description": "Whether the tool call ended in an error.\n\nIf not set, this is assumed to be false (the call was successful).",
                     "type": "boolean"
+                },
+                "structuredContent": {
+                    "description": "If the Tool defines an outputSchema, this field MUST contain a serialized JSON object that matches the schema.",
+                    "type": "string"
                 }
             },
-            "required": [
-                "content"
-            ],
             "type": "object"
         },
         "CancelledNotification": {
@@ -2052,7 +2054,7 @@
                 },
                 "outputSchema": {
                     "additionalProperties": true,
-                    "description": "A JSON Schema object defining the structure of the tool's output.\n\nIf set, a client SHOULD validate a CallToolResult for this Tool as follows:\n1. check that the length of the result's `content` property == 1\n2. check that this single item is a `TextContent` object\n3. validate this object's `text` property against this schema.\n\nIn other words, for a CallToolResult to be valid with respect to this schema,\nit must first satisfy the precondition that its payload be a single TextContent \nobject.",
+                    "description": "A JSON Schema object defining the structure of the tool's output.\n\nIf set, a CallToolResult for this Tool MUST contain a structuredContent field whose contents validate against this schema.",
                     "properties": {},
                     "type": "object"
                 }

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -2049,6 +2049,12 @@
                 "name": {
                     "description": "The name of the tool.",
                     "type": "string"
+                },
+                "outputSchema": {
+                    "additionalProperties": true,
+                    "description": "A JSON Schema object defining the structure of the tool's output.\n\nIf set, a client SHOULD validate a CallToolResult for this Tool as follows:\n1. check that the length of the result's `content` property == 1\n2. check that this single item is a `TextContent` object\n3. validate this object's `text` property against this schema.\n\nIn other words, for a CallToolResult to be valid with respect to this schema,\nit must first satisfy the precondition that its payload be a single TextContent \nobject.",
+                    "properties": {},
+                    "type": "object"
                 }
             },
             "required": [

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -696,7 +696,19 @@ export interface ListToolsResult extends PaginatedResult {
  * should be reported as an MCP error response.
  */
 export interface CallToolResult extends Result {
-  content: (TextContent | ImageContent | AudioContent | EmbeddedResource)[];
+  /**
+   * A list of content objects that represent the result of the tool call.
+   *
+   * If the Tool does not define an outputSchema, this field MUST be present in the result.
+   */
+  content?: (TextContent | ImageContent | AudioContent | EmbeddedResource)[];
+
+  /**
+   * A string containing structured tool output.
+   *
+   * If the Tool defines an outputSchema, this field MUST be present in the result, and contain a serialized JSON object that matches the schema.
+   */
+  structuredContent?: string;
 
   /**
    * Whether the tool call ended in an error.
@@ -804,16 +816,10 @@ export interface Tool {
   };
 
   /**
-   * A JSON Schema object defining the structure of the tool's output.
+   * An optional JSON Schema object defining the structure of the tool's output.
    *
-   * If set, a client SHOULD validate a CallToolResult for this Tool as follows:
-   * 1. check that the length of the result's `content` property == 1
-   * 2. check that this single item is a `TextContent` object
-   * 3. validate this object's `text` property against this schema.
-   *
-   * In other words, for a CallToolResult to be valid with respect to this schema,
-   * it must first satisfy the precondition that its payload be a single TextContent
-   * object.
+   * If set, a CallToolResult for this Tool MUST contain a structuredContent field whose contents validate against this schema.
+   * If not set, a CallToolResult for this Tool MUST contain a content field.
    */
   outputSchema?: object;
 

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -695,20 +695,25 @@ export interface ListToolsResult extends PaginatedResult {
  * server does not support tool calls, or any other exceptional conditions,
  * should be reported as an MCP error response.
  */
-export interface CallToolResult extends Result {
+export type CallToolResult = CallToolUnstructuredResult | CallToolStructuredResult;
+
+export type ContentList = (TextContent | ImageContent | AudioContent | EmbeddedResource)[];
+
+/**
+ * Tool result for tools that do not declare an outputSchema.
+ */
+export interface CallToolUnstructuredResult extends Result {
   /**
    * A list of content objects that represent the result of the tool call.
    *
    * If the Tool does not define an outputSchema, this field MUST be present in the result.
    */
-  content?: (TextContent | ImageContent | AudioContent | EmbeddedResource)[];
+  content: ContentList;
 
   /**
-   * A string containing structured tool output.
-   *
-   * If the Tool defines an outputSchema, this field MUST be present in the result, and contain a serialized JSON object that matches the schema.
+   * Structured output must not be provided in an unstructured tool result.
    */
-  structuredContent?: string;
+  structuredContent: never;
 
   /**
    * Whether the tool call ended in an error.
@@ -717,6 +722,33 @@ export interface CallToolResult extends Result {
    */
   isError?: boolean;
 }
+
+/**
+ * Tool result for tools that do declare an outputSchema.
+ */
+export interface CallToolStructuredResult extends Result {
+  /**
+   * An object containing structured tool output.
+   *
+   * If the Tool defines an outputSchema, this field MUST be present in the result, and contain a JSON object that matches the schema.
+   */
+  structuredContent: { [key: string]: unknown };
+
+  /**
+   * If the Tool defines an outputSchema, this field MAY be present in the result.
+   * Tools should use this field to provide compatibility with older clients that do not support structured content.
+   * Clients that support structured content should ignore this field.
+   */
+  content?: ContentList;
+
+  /**
+   * Whether the tool call ended in an error.
+   *
+   * If not set, this is assumed to be false (the call was successful).
+   */
+  isError?: boolean;
+}
+
 
 /**
  * Used by the client to invoke a tool provided by the server.

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -804,6 +804,20 @@ export interface Tool {
   };
 
   /**
+   * A JSON Schema object defining the structure of the tool's output.
+   *
+   * If set, a client SHOULD validate a CallToolResult for this Tool as follows:
+   * 1. check that the length of the result's `content` property == 1
+   * 2. check that this single item is a `TextContent` object
+   * 3. validate this object's `text` property against this schema.
+   *
+   * In other words, for a CallToolResult to be valid with respect to this schema,
+   * it must first satisfy the precondition that its payload be a single TextContent
+   * object.
+   */
+  outputSchema?: object;
+
+  /**
    * Optional additional tool information.
    */
   annotations?: ToolAnnotations;


### PR DESCRIPTION
Adds support for strict validation of structured tool results.
* A `Tool` can now optionally provide an `outputSchema` property, containing a JSON schema that defines the structure of its output.
* `CallToolResult` adds a new `structuredContent` property, mutually exclusive with `CallToolResult.content` property: 
  * for Tools that do not declare an outputSchema, `result.structuredContent` will be absent, and `result.content` will be returned as before.
  * for Tools that declare an outputSchema, `result.structuredContent` will contain a string whose contents must validate against the schema, and `result.content` will not be absent.

Prototype for typescript SDK support in https://github.com/modelcontextprotocol/typescript-sdk/pull/454.

**Design notes**

This PR aims to provide simple, lightweight support for strict validation of tool result data whose structure can be entirely described by a single JSON schema. The approach here pairs a new `Tool.outputSchema` property with a new `CallToolResult.structuredContent` property, avoiding use of the `CallToolResult.content` array.

This approach leaves the path open for adding schematic validation support to the much richer and more complex space of tools that make use of the full expressiveness of the `CallToolResult.content` array, via an additional `Tool` property. Support for these use cases has been proposed in #356, and is under active discussion there.

(After exploring possible ways of providing integrated support for both kinds use cases with one set of protocol additions, it's clear that both will be better served by a disjoint approach: strict validation of statically typed data results can be accomplished with the simple additions provided here, and the subtleties arising from supporting full space of `CallToolResult.content` shapes - see e.g. #415, in addition to #356 - can be addressed more naturally absent the need to support the use cases addressed here.)

## Motivation and Context
For tools that return structured output, having a description of that structure available is useful for various tasks, including:
* Validating the structure of tool results (and performing a more informed examination of the values they contain, post-validation). Especially useful when interacting with untrusted servers.
* Considering `outputSchema`s (or their absence) when making decisions about which tools to expose to the model.
* Transforming tool results before forwarding content to the model (e.g. formatting, projecting).
* Making tool results available as structured data in coding environments.

## How Has This Been Tested?
No tests yet.

## Breaking Changes
Optional new property that introduces a new behavior, not a breaking change. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
