### PR TITLE
[feat] Introduce partial results as part of progress notifications

### DIFF
--- a/docs/specification/2025-03-26/basic/utilities/progress.mdx
+++ b/docs/specification/2025-03-26/basic/utilities/progress.mdx
@@ -55,6 +55,106 @@ The receiver **MAY** then send progress notifications containing:
 - The `progress` and the `total` values **MAY** be floating point.
 - The `message` field **SHOULD** provide relevant human readable progress information.
 
+## Partial Results
+
+Progress notifications can also include partial results for operations that generate data incrementally. This allows clients to display intermediate results while an operation is still in progress.
+
+To request partial results, the client includes both a `progressToken` and `partialResults: true` in the request metadata:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "_meta": {
+      "progressToken": "abc123",
+      "partialResults": true
+    },
+    "name": "analyzeData",
+    "arguments": {
+      "datasetId": "financial-q1-2025"
+    }
+  }
+}
+```
+
+The server can then include partial results in progress notifications:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/progress",
+  "params": {
+    "progressToken": "abc123",
+    "progress": 30,
+    "total": 100,
+    "message": "Initial analysis complete",
+    "partialResult": {
+      "chunk": {
+        "content": [
+          {
+            "type": "text",
+            "text": "## Preliminary Analysis\n\nData processing has revealed initial patterns..."
+          }
+        ]
+      },
+      "append": false,
+      "lastChunk": false
+    }
+  }
+}
+```
+
+### Partial Result Structure
+
+The `partialResult` object contains:
+
+- `chunk`: The partial result data (any JSON object)
+- `append`: Whether this chunk should be appended to previous chunks (`true`) or replace them (`false`)
+- `lastChunk`: Whether this is the final chunk of the result (`true`) or more chunks will follow (`false`)
+
+### Incremental Updates
+
+Subsequent progress notifications can append to previous chunks:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/progress",
+  "params": {
+    "progressToken": "abc123",
+    "progress": 60,
+    "total": 100,
+    "message": "Processing additional data",
+    "partialResult": {
+      "chunk": {
+        "content": [
+          {
+            "type": "text",
+            "text": "\n\n### Key Findings\n\n- Revenue increased by 12%\n- Customer acquisition cost reduced by 7%"
+          }
+        ]
+      },
+      "append": true,
+      "lastChunk": false
+    }
+  }
+}
+```
+
+### Final Response
+
+When partial results are used, the final response **SHOULD** be an empty result object, as the complete result has already been delivered through progress notifications:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {}
+}
+```
+
 ## Behavior Requirements
 
 1. Progress notifications **MUST** only reference tokens that:
@@ -67,23 +167,26 @@ The receiver **MAY** then send progress notifications containing:
    - Send notifications at whatever frequency they deem appropriate
    - Omit the total value if unknown
 
+3. When using partial results:
+   - The `lastChunk: true` flag **MUST** be set on the final chunk
+   - Clients **MUST** be prepared to handle both appended and replaced chunks
+   - Servers **SHOULD** return an empty result in the final response when all data has been delivered via partial results
+
 ```mermaid
 sequenceDiagram
     participant Sender
     participant Receiver
 
-    Note over Sender,Receiver: Request with progress token
-    Sender->>Receiver: Method request with progressToken
+    Note over Sender,Receiver: Request with progress token and partialResults
+    Sender->>Receiver: Method request with progressToken and partialResults=true
 
-    Note over Sender,Receiver: Progress updates
-    loop Progress Updates
-        Receiver-->>Sender: Progress notification (0.2/1.0)
-        Receiver-->>Sender: Progress notification (0.6/1.0)
-        Receiver-->>Sender: Progress notification (1.0/1.0)
-    end
+    Note over Sender,Receiver: Progress updates with partial results
+    Receiver-->>Sender: Progress notification (30%, initial chunk)
+    Receiver-->>Sender: Progress notification (60%, append=true)
+    Receiver-->>Sender: Progress notification (100%, lastChunk=true)
 
     Note over Sender,Receiver: Operation complete
-    Receiver->>Sender: Method response
+    Receiver->>Sender: Empty result response
 ```
 
 ## Implementation Notes
@@ -91,3 +194,4 @@ sequenceDiagram
 - Senders and receivers **SHOULD** track active progress tokens
 - Both parties **SHOULD** implement rate limiting to prevent flooding
 - Progress notifications **MUST** stop after completion
+- Clients **SHOULD** accumulate partial results according to the `append` flag

--- a/docs/specification/2025-03-26/changelog.mdx
+++ b/docs/specification/2025-03-26/changelog.mdx
@@ -22,6 +22,8 @@ the previous revision, [2024-11-05](/specification/2024-11-05).
 ## Other schema changes
 
 - Added `message` field to `ProgressNotification` to provide descriptive status updates
+- Added `partialResult` field to `ProgressNotification` to support streaming incremental results
+- Added `partialResults` flag to request metadata to enable streaming results via progress notifications
 - Added support for audio data, joining the existing text and image content types
 - Added `completions` capability to explicitly indicate support for argument
   autocompletion suggestions

--- a/schema/2025-03-26/schema.json
+++ b/schema/2025-03-26/schema.json
@@ -841,6 +841,10 @@
                     "properties": {
                         "_meta": {
                             "properties": {
+                                "partialResults": {
+                                    "description": "If true, the caller is requesting that results be streamed via progress notifications.\nWhen this is set to true, the final response may be empty as the complete result\nwill have been delivered through progress notifications.",
+                                    "type": "boolean"
+                                },
                                 "progressToken": {
                                     "$ref": "#/definitions/ProgressToken",
                                     "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
@@ -1030,6 +1034,10 @@
                     "properties": {
                         "_meta": {
                             "properties": {
+                                "partialResults": {
+                                    "description": "If true, the caller is requesting that results be streamed via progress notifications.\nWhen this is set to true, the final response may be empty as the complete result\nwill have been delivered through progress notifications.",
+                                    "type": "boolean"
+                                },
                                 "progressToken": {
                                     "$ref": "#/definitions/ProgressToken",
                                     "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
@@ -1269,6 +1277,10 @@
                     "properties": {
                         "_meta": {
                             "properties": {
+                                "partialResults": {
+                                    "description": "If true, the caller is requesting that results be streamed via progress notifications.\nWhen this is set to true, the final response may be empty as the complete result\nwill have been delivered through progress notifications.",
+                                    "type": "boolean"
+                                },
                                 "progressToken": {
                                     "$ref": "#/definitions/ProgressToken",
                                     "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
@@ -1297,6 +1309,30 @@
                         "message": {
                             "description": "An optional message describing the current progress.",
                             "type": "string"
+                        },
+                        "partialResult": {
+                            "description": "If present, contains a partial result chunk for the operation.\nThis is used to stream results incrementally while an operation is still in progress.",
+                            "properties": {
+                                "append": {
+                                    "description": "If true, this chunk should be appended to previously received chunks.\nIf false, this chunk replaces any previously received chunks.",
+                                    "type": "boolean"
+                                },
+                                "chunk": {
+                                    "additionalProperties": {},
+                                    "description": "The partial result data chunk.",
+                                    "type": "object"
+                                },
+                                "lastChunk": {
+                                    "description": "If true, this is the final chunk of the result.\nNo further chunks will be sent for this operation.",
+                                    "type": "boolean"
+                                }
+                            },
+                            "required": [
+                                "append",
+                                "chunk",
+                                "lastChunk"
+                            ],
+                            "type": "object"
                         },
                         "progress": {
                             "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
@@ -1511,6 +1547,10 @@
                     "properties": {
                         "_meta": {
                             "properties": {
+                                "partialResults": {
+                                    "description": "If true, the caller is requesting that results be streamed via progress notifications.\nWhen this is set to true, the final response may be empty as the complete result\nwill have been delivered through progress notifications.",
+                                    "type": "boolean"
+                                },
                                 "progressToken": {
                                     "$ref": "#/definitions/ProgressToken",
                                     "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."

--- a/schema/2025-03-26/schema.ts
+++ b/schema/2025-03-26/schema.ts
@@ -42,6 +42,12 @@ export interface Request {
        * If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications.
        */
       progressToken?: ProgressToken;
+      /**
+       * If true, the caller is requesting that results be streamed via progress notifications.
+       * When this is set to true, the final response may be empty as the complete result
+       * will have been delivered through progress notifications.
+       */
+      partialResults?: boolean;
     };
     [key: string]: unknown;
   };
@@ -314,6 +320,26 @@ export interface ProgressNotification extends Notification {
      * An optional message describing the current progress.
      */
     message?: string;
+    /**
+     * If present, contains a partial result chunk for the operation.
+     * This is used to stream results incrementally while an operation is still in progress.
+     */
+    partialResult?: {
+      /**
+       * The partial result data chunk.
+       */
+      chunk: { [key: string]: unknown; };
+      /**
+       * If true, this chunk should be appended to previously received chunks.
+       * If false, this chunk replaces any previously received chunks.
+       */
+      append: boolean;
+      /**
+       * If true, this is the final chunk of the result.
+       * No further chunks will be sent for this operation.
+       */
+      lastChunk: boolean;
+    };
   };
 }
 


### PR DESCRIPTION
Added support for streaming partial results through progress notifications, allowing for incremental updates during long-running operations. This enables more responsive agent-based workflows where intermediate results can be shared while a top-level operation is still running. #111, #314.

## Motivation and Context
This enhancement addresses a key need identified in discussion #111 for "structured, formatted intermediate updates from server -> client, so a deep agent graph can provide information to the user even while a top-level tool is still being run."

Progress notifications were an ideal mechanism to extend for this purpose, as they already provide a communication channel during long-running operations. By adding support for partial results, we enable servers to stream incremental data to clients without waiting for operations to complete, creating a more responsive and interactive experience.

LSP's partial result progress has been referred for this implementation: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#partialResults, specially the recommendation around if server send partial results over progressNotification then final result should be empty.

## How Has This Been Tested?
The implementation has been validated through:
1. Schema consistency checks
2. Documentation review
3. Verification of compatibility with existing progress notification behavior
4. The design follows existing MCP patterns, particularly using a JSON-based data structure that mirrors many other parts of the protocol. The implementation is intentionally flexible to support different types of partial results while maintaining a consistent structure.

## Breaking Changes
None. This is a non-breaking change that adds new optional fields while maintaining backward compatibility with existing implementations. Clients that don't support partial results can simply ignore the new fields.

## Types of changes
[x] New feature (non-breaking change which adds functionality)
[ ] Bug fix (non-breaking change which fixes an issue)
[ ] Breaking change (fix or feature that would cause existing functionality to change)
[x] Documentation update
## Checklist
[x] I have read the [MCP Documentation](https://modelcontextprotocol.io/)
[x] My code follows the repository's style guidelines
[x] New and existing tests pass locally
[x] I have added appropriate error handling
[x] I have added or updated documentation as needed
## Additional context
The implementation adds three key components:
1. Client Request Flag: A new partialResults boolean in the request _meta object allows clients to explicitly request streaming results.
2. Partial Result Structure: A new partialResult field in the ProgressNotification interface with:
  a. chunk: The partial result data (any JSON object)
  b. append: Boolean flag indicating whether to append to previously received chunks
  c. lastChunk: Boolean flag indicating the final chunk

## Protocol

To request partial results, the client includes both a `progressToken` and `partialResults: true` in the request metadata:

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "tools/call",
  "params": {
    "_meta": {
      "progressToken": "abc123",
      "partialResults": true
    },
    "name": "analyzeData",
    "arguments": {
      "datasetId": "financial-q1-2025"
    }
  }
}
```

The server can then include partial results in progress notifications:

```json
{
  "jsonrpc": "2.0",
  "method": "notifications/progress",
  "params": {
    "progressToken": "abc123",
    "progress": 30,
    "total": 100,
    "message": "Initial analysis complete",
    "partialResult": {
      "chunk": {
        "content": [
          {
            "type": "text",
            "text": "## Preliminary Analysis\n\nData processing has revealed initial patterns..."
          }
        ]
      },
      "append": false,
      "lastChunk": false
    }
  }
}
```

```mermaid
sequenceDiagram
    participant Sender
    participant Receiver

    Note over Sender,Receiver: Request with progress token and partialResults
    Sender->>Receiver: Method request with progressToken and partialResults=true

    Note over Sender,Receiver: Progress updates with partial results
    Receiver-->>Sender: Progress notification (30%, initial chunk)
    Receiver-->>Sender: Progress notification (60%, append=true)
    Receiver-->>Sender: Progress notification (100%, lastChunk=true)

    Note over Sender,Receiver: Operation complete
    Receiver->>Sender: Empty result response
```