### PR TITLE
Adding Pipedream to example servers

### DIFF
--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -117,12 +117,12 @@ To use an MCP server with Claude, add it to your configuration:
 
 ## Additional resources
 
-- [MCP Servers Repository](https://github.com/modelcontextprotocol/servers) - Complete collection of reference implementations and community servers
 - [Awesome MCP Servers](https://github.com/punkpeye/awesome-mcp-servers) - Curated list of MCP servers
 - [MCP CLI](https://github.com/wong2/mcp-cli) - Command-line inspector for testing MCP servers
 - [MCP Get](https://mcp-get.com) - Tool for installing and managing MCP servers
+- [MCP Servers Repository](https://github.com/modelcontextprotocol/servers) - Complete collection of reference implementations and community servers
+- [Pipedream MCP](https://mcp.pipedream.com) - MCP servers with built-in auth for 3,000+ APIs and 10,000+ tools
 - [Supergateway](https://github.com/supercorp-ai/supergateway) - Run MCP stdio servers over SSE
 - [Zapier MCP](https://zapier.com/mcp) - MCP Server with over 7,000+ apps and 30,000+ actions
-- [Pipedream MCP](https://mcp.pipedream.com) - MCP servers with built-in auth for 3,000+ APIs and 10,000+ tools
 
 Visit our [GitHub Discussions](https://github.com/orgs/modelcontextprotocol/discussions) to engage with the MCP community.

--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -118,10 +118,10 @@ To use an MCP server with Claude, add it to your configuration:
 
 ## Additional resources
 
+- [MCP Servers Repository](https://github.com/modelcontextprotocol/servers) - Complete collection of reference implementations and community servers
 - [Awesome MCP Servers](https://github.com/punkpeye/awesome-mcp-servers) - Curated list of MCP servers
 - [MCP CLI](https://github.com/wong2/mcp-cli) - Command-line inspector for testing MCP servers
 - [MCP Get](https://mcp-get.com) - Tool for installing and managing MCP servers
-- [MCP Servers Repository](https://github.com/modelcontextprotocol/servers) - Complete collection of reference implementations and community servers
 - [Pipedream MCP](https://mcp.pipedream.com) - MCP servers with built-in auth for 3,000+ APIs and 10,000+ tools
 - [Supergateway](https://github.com/supercorp-ai/supergateway) - Run MCP stdio servers over SSE
 - [Zapier MCP](https://zapier.com/mcp) - MCP Server with over 7,000+ apps and 30,000+ actions

--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -123,5 +123,6 @@ To use an MCP server with Claude, add it to your configuration:
 - [MCP Get](https://mcp-get.com) - Tool for installing and managing MCP servers
 - [Supergateway](https://github.com/supercorp-ai/supergateway) - Run MCP stdio servers over SSE
 - [Zapier MCP](https://zapier.com/mcp) - MCP Server with over 7,000+ apps and 30,000+ actions
+- [Pipedream MCP](https://mcp.pipedream.com) - MCP servers with built-in auth for 3,000+ APIs and 10,000+ tools
 
 Visit our [GitHub Discussions](https://github.com/orgs/modelcontextprotocol/discussions) to engage with the MCP community.


### PR DESCRIPTION
Adding [Pipedream's MCP servers](https://mcp.pipedream.com/) to the set of example servers

## Motivation and Context
Pipedream provides an aggregated set of 3k+ MCP servers and 10k+ tools with built-in auth, which provides immense value for end users, as well as an option for developers to self host all of our 3k+ servers in their app.

## How Has This Been Tested?
This is only a docs change, but all of Pipedream's MCP servers are battle tested and validated by human users.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
