### PR TITLE
docs(*): add postman to mcp clients page

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -34,6 +34,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [Microsoft Copilot Studio]                  | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools                                                              |
 | [OpenSumi][OpenSumi]                        | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools in OpenSumi                                                  |
 | [oterm][oterm]                              | ❌          | ✅        | ✅      | ✅         | ❌    | Supports tools, prompts and sampling for Ollama.                                                 |
+| [Postman][postman]                          |✅           | ✅        | ✅      | ❌         | ❌    | Supports tools, resources, and prompts                                                 |
 | [Roo Code][Roo Code]                        | ✅          | ❌        | ✅      | ❌         | ❌    | Supports tools and resources.                                               |
 | [Sourcegraph Cody][Cody]                    | ✅          | ❌        | ❌      | ❌         | ❌    | Supports resources through OpenCTX                                          |
 | [SpinAI][SpinAI]                            | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools for Typescript AI Agents                                     |

--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -324,6 +324,7 @@ Programmatically assemble prompts for LLMs using [GenAIScript](https://microsoft
 **Key features**:
 - Full support of all major MCP features (tools, prompts, resources, and subscriptions)
 - Fast, seamless UI for debugging MCP capabilities
+- MCP config integration (Claude, VSCode, etc.) for fast first-time experience in testing MCPs
 - Integration with history, varibles, and collections for re-use and collaboration
 
 ### Sourcegraph Cody

--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -34,7 +34,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [Microsoft Copilot Studio]                  | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools                                                              |
 | [OpenSumi][OpenSumi]                        | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools in OpenSumi                                                  |
 | [oterm][oterm]                              | ❌          | ✅        | ✅      | ✅         | ❌    | Supports tools, prompts and sampling for Ollama.                                                 |
-| [Postman][postman]                          |✅           | ✅        | ✅      | ❌         | ❌    | Supports tools, resources, and prompts                                                 |
+| [Postman][postman]                          | ✅          | ✅        | ✅      | ❌         | ❌    | Supports tools, resources, prompts, and sampling                                                 |
 | [Roo Code][Roo Code]                        | ✅          | ❌        | ✅      | ❌         | ❌    | Supports tools and resources.                                               |
 | [Sourcegraph Cody][Cody]                    | ✅          | ❌        | ❌      | ❌         | ❌    | Supports resources through OpenCTX                                          |
 | [SpinAI][SpinAI]                            | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools for Typescript AI Agents                                     |
@@ -70,6 +70,7 @@ This page provides an overview of applications that support the Model Context Pr
 [Microsoft Copilot Studio]: https://learn.microsoft.com/en-us/microsoft-copilot-studio/agent-extend-action-mcp
 [OpenSumi]: https://github.com/opensumi/core
 [oterm]: https://github.com/ggozad/oterm
+[Postman]: https://postman.com/downloads
 [Roo Code]: https://roocode.com
 [Cody]: https://sourcegraph.com/cody
 [SpinAI]: https://spinai.dev
@@ -315,6 +316,15 @@ Programmatically assemble prompts for LLMs using [GenAIScript](https://microsoft
 - Support for MCP tools and resources
 - Integration with development workflows
 - Extensible AI capabilities
+
+### Postman
+
+[Postman](https://postman.com/downloads) is the most popular API client and now supports MCP server testing and debugging.
+
+**Key features**:
+- Full support of all major MCP features (tools, prompts, resources, and subscriptions)
+- Fast, seamless UI for debugging MCP capabilities
+- Integration with history, varibles, and collections for re-use and collaboration
 
 ### Sourcegraph Cody
 [Cody](https://openctx.org/docs/providers/modelcontextprotocol) is Sourcegraph's AI coding assistant, which implements MCP through OpenCTX.


### PR DESCRIPTION
Adding Postman as an official MCP client

## Motivation and Context

This is a great resource for users, and as of v11.42.3, Postman now supports MCP as a request type alongside other request types like HTTP, GraphQL, gRPC, etc.

## How Has This Been Tested?

This is a docs PR, I haven't tested it really. The MCP client in Postman has been copiously tested by users and our internal teams building MCP servers.

## Breaking Changes

No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context

I used the GitHub PR editor like a pleb, so it's possible there are some formatting / syntax issues I will edit as needed.
