### PR TITLE
Allow `Implementation`s to optionally expose a `websiteUrl` and `iconUrl`

### DIFF
--- a/schema/2025-03-26/schema.json
+++ b/schema/2025-03-26/schema.json
@@ -584,12 +584,20 @@
             "type": "object"
         },
         "Implementation": {
-            "description": "Describes the name and version of an MCP implementation.",
+            "description": "Describes the MCP implementation.",
             "properties": {
+                "iconUrl": {
+                    "description": "The optional URL, pointing to an icon for this implementation. The URL should be accessible over the public internet, and should return a square (1:1 aspect ratio) PNG, with recommended dimensions of 512x512.",
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
                 "version": {
+                    "type": "string"
+                },
+                "websiteUrl": {
+                    "description": "An optional URL of the website for this implementation.",
                     "type": "string"
                 }
             },

--- a/schema/2025-03-26/schema.ts
+++ b/schema/2025-03-26/schema.ts
@@ -279,6 +279,8 @@ export interface Implementation {
   version: string;
   /**
    * An optional URL of the website for this implementation.
+   *
+   * @format: uri
    */
   websiteUrl?: string;
   /**

--- a/schema/2025-03-26/schema.ts
+++ b/schema/2025-03-26/schema.ts
@@ -272,11 +272,19 @@ export interface ServerCapabilities {
 }
 
 /**
- * Describes the name and version of an MCP implementation.
+ * Describes the MCP implementation.
  */
 export interface Implementation {
   name: string;
   version: string;
+  /**
+   * An optional URL of the website for this implementation.
+   */
+  websiteUrl?: string;
+  /**
+   * The optional URL, pointing to an icon for this implementation. The URL should be accessible over the public internet, and should return a square (1:1 aspect ratio) PNG, with recommended dimensions of 512x512.
+   */
+  iconUrl?: string;
 }
 
 /* Ping */


### PR DESCRIPTION
This proposed update to the specification allows MCP `Implementation`s (servers and clients) to optionally declare a `websiteUrl` and `iconUrl`.

## Motivation and Context

Most MCP clients will render custom UI showing when an MCP server is used - for example, when one of the server's tools is invoked.

Existing metadata allows clients to show a human-readable name for the tool (`ToolAnnotations.title`) and a name for the server `Implementation.name`) - but this leads to a not very rich, underwhelming UI.

These changes will allow clients to render richer UI, showing a logo for the server (e.g. the GitHub logo for the [GitHub MCP server][1]) and linking to the server's website for more information, like the example below:

![CleanShot 2025-04-09 at 15 54 16 (1)](https://github.com/user-attachments/assets/ed5fbf8e-8db3-4aca-86f9-0da7c262d2b4)


[1]: https://github.com/github/github-mcp-server

## How Has This Been Tested?

N/A

## Breaking Changes

No - the newly-added fields are optional

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
