### PR TITLE
replacing deprecated link of GitHub MCP repo 

### DIFF
--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -17,7 +17,7 @@ These official reference servers demonstrate core MCP features and SDK usage:
 
 ### Development tools
 - **[Git](https://github.com/modelcontextprotocol/servers/tree/main/src/git)** - Tools to read, search, and manipulate Git repositories
-- **[GitHub](https://github.com/modelcontextprotocol/servers/tree/main/src/github)** - Repository management, file operations, and GitHub API integration
+- **[GitHub](https://github.com/github/github-mcp-server)** - Repository management, file operations, and GitHub API integration
 - **[GitLab](https://github.com/modelcontextprotocol/servers/tree/main/src/gitlab)** - GitLab API integration enabling project management
 - **[Sentry](https://github.com/modelcontextprotocol/servers/tree/main/src/sentry)** - Retrieving and analyzing issues from Sentry.io
 


### PR DESCRIPTION
Replacing deprecated link of GitHub MCP repo with the latest repository link

## Motivation and Context
Pointing users to actively maintainer repo

## How Has This Been Tested?
just document update

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

