### PR TITLE
Fix Card hrefs by making them absolute

### DIFF
--- a/docs/specification/2024-11-05/index.mdx
+++ b/docs/specification/2024-11-05/index.mdx
@@ -122,9 +122,9 @@ implementors **SHOULD**:
 Explore the detailed specification for each protocol component:
 
 <CardGroup cols={5}>
-  <Card title="Architecture" icon="sitemap" href="architecture" />
-  <Card title="Base Protocol" icon="code" href="basic" />
-  <Card title="Server Features" icon="server" href="server" />
-  <Card title="Client Features" icon="user" href="client" />
-  <Card title="Contributing" icon="pencil" href="contributing" />
+  <Card title="Architecture" icon="sitemap" href="/specification/2024-11-05/architecture" />
+  <Card title="Base Protocol" icon="code" href="/specification/2024-11-05/basic" />
+  <Card title="Server Features" icon="server" href="/specification/2024-11-05/server" />
+  <Card title="Client Features" icon="user" href="/specification/2024-11-05/client" />
+  <Card title="Contributing" icon="pencil" href="/development/contributing" />
 </CardGroup>

--- a/docs/specification/2024-11-05/server/index.mdx
+++ b/docs/specification/2024-11-05/server/index.mdx
@@ -25,7 +25,7 @@ Each primitive can be summarized in the following control hierarchy:
 Explore these key primitives in more detail below:
 
 <CardGroup cols={3}>
-  <Card title="Prompts" icon="message" href="prompts" />
-  <Card title="Resources" icon="file-lines" href="resources" />
-  <Card title="Tools" icon="wrench" href="tools" />
+  <Card title="Prompts" icon="message" href="/specification/2024-11-05/server/prompts" />
+  <Card title="Resources" icon="file-lines" href="/specification/2024-11-05/server/resources" />
+  <Card title="Tools" icon="wrench" href="/specification/2024-11-05/server/tools" />
 </CardGroup>

--- a/docs/specification/2025-03-26/index.mdx
+++ b/docs/specification/2025-03-26/index.mdx
@@ -124,9 +124,9 @@ implementors **SHOULD**:
 Explore the detailed specification for each protocol component:
 
 <CardGroup cols={5}>
-  <Card title="Architecture" icon="sitemap" href="architecture" />
-  <Card title="Base Protocol" icon="code" href="basic" />
-  <Card title="Server Features" icon="server" href="server" />
-  <Card title="Client Features" icon="user" href="client" />
-  <Card title="Contributing" icon="pencil" href="contributing" />
+  <Card title="Architecture" icon="sitemap" href="/specification/2025-03-26/architecture" />
+  <Card title="Base Protocol" icon="code" href="/specification/2025-03-26/basic" />
+  <Card title="Server Features" icon="server" href="/specification/2025-03-26/server" />
+  <Card title="Client Features" icon="user" href="/specification/2025-03-26/client" />
+  <Card title="Contributing" icon="pencil" href="/development/contributing" />
 </CardGroup>

--- a/docs/specification/2025-03-26/server/index.mdx
+++ b/docs/specification/2025-03-26/server/index.mdx
@@ -25,7 +25,7 @@ Each primitive can be summarized in the following control hierarchy:
 Explore these key primitives in more detail below:
 
 <CardGroup cols={3}>
-  <Card title="Prompts" icon="message" href="prompts" />
-  <Card title="Resources" icon="file-lines" href="resources" />
-  <Card title="Tools" icon="wrench" href="tools" />
+  <Card title="Prompts" icon="message" href="/specification/2025-03-26/server/prompts" />
+  <Card title="Resources" icon="file-lines" href="/specification/2025-03-26/server/resources" />
+  <Card title="Tools" icon="wrench" href="/specification/2025-03-26/server/tools" />
 </CardGroup>

--- a/docs/specification/draft/index.mdx
+++ b/docs/specification/draft/index.mdx
@@ -124,9 +124,9 @@ implementors **SHOULD**:
 Explore the detailed specification for each protocol component:
 
 <CardGroup cols={5}>
-  <Card title="Architecture" icon="sitemap" href="architecture" />
-  <Card title="Base Protocol" icon="code" href="basic" />
-  <Card title="Server Features" icon="server" href="server" />
-  <Card title="Client Features" icon="user" href="client" />
-  <Card title="Contributing" icon="pencil" href="contributing" />
+  <Card title="Architecture" icon="sitemap" href="/specification/draft/architecture" />
+  <Card title="Base Protocol" icon="code" href="/specification/draft/basic" />
+  <Card title="Server Features" icon="server" href="/specification/draft/server" />
+  <Card title="Client Features" icon="user" href="/specification/draft/client" />
+  <Card title="Contributing" icon="pencil" href="/development/contributing" />
 </CardGroup>

--- a/docs/specification/draft/server/index.mdx
+++ b/docs/specification/draft/server/index.mdx
@@ -25,7 +25,7 @@ Each primitive can be summarized in the following control hierarchy:
 Explore these key primitives in more detail below:
 
 <CardGroup cols={3}>
-  <Card title="Prompts" icon="message" href="prompts" />
-  <Card title="Resources" icon="file-lines" href="resources" />
-  <Card title="Tools" icon="wrench" href="tools" />
+  <Card title="Prompts" icon="message" href="/specification/draft/server/prompts" />
+  <Card title="Resources" icon="file-lines" href="/specification/draft/server/resources" />
+  <Card title="Tools" icon="wrench" href="/specification/draft/server/tools" />
 </CardGroup>


### PR DESCRIPTION
This makes the hrefs absolute, following the style already used in docs/specification/2024-11-05/basic/index.mdx

This fixes a problem where a card with e.g. href `architecture` served at https://modelcontextprotocol.io/specification/2025-03-26 would actually end up linking to
https://modelcontextprotocol.io/specification/architecture (which doesn't exist) rather than the correct
https://modelcontextprotocol.io/specification/2025-03-26/architecture

## Motivation and Context

Right now all of the card links at https://modelcontextprotocol.io/specification/2025-03-26 don't work, they hit a page-not-found handler and you end up at https://modelcontextprotocol.io/introduction

I suspect that possibly historically the pages were served at URLs with trailing slashes (e.g. https://modelcontextprotocol.io/specification/2025-03-26/ rather than https://modelcontextprotocol.io/specification/2025-03-26) where these relative hrefs would have worked as intended

I suspect this has also been confounded by `mintlify dev` serving pages at URLs in the style of "http://localhost:3000/specification/2025-03-26/server/index" (where, again, the relative hrefs work as intended) - note the trailing "/index"

## How Has This Been Tested?

This has been tested under `npm run serve:docs` and the links work, though per previous, this is not a robust test as they always worked under `mintlify dev` - however this has also been tested with browser tools using the live URLs and confirmed to work

## Breaking Changes

None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

I'm conscious that absolute hrefs aren't especially convenient. If the live URLs had trailing slashes, this PR wouldn't be needed, but I'm not familiar with the tooling/ecosystem here and it's not clear to me how much effort that change would entail. I suspect that in an ideal world it would be preferable though, but this at least fixes the issue right now.