### PR TITLE
docs: remove minor ambiguity in python server docs, when nothing happens after execution in terminal

### DIFF
--- a/docs/quickstart/server.mdx
+++ b/docs/quickstart/server.mdx
@@ -230,9 +230,11 @@ if __name__ == "__main__":
     mcp.run(transport='stdio')
 ```
 
-Your server is complete! Run `uv run weather.py` to confirm that everything's working.
+Your server is complete! Run `uv run weather.py` to verify that the script can be executed without immediate errors.
+If there is no error, the server will start and listen for instructions via standard input/output (stdio). 
+It will appear idle in the terminal because it's waiting for a client connection. Press Ctrl+C to stop it.
 
-Let's now test your server from an existing MCP host, Claude for Desktop.
+We're now ready to test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Minor docs improvement:
The [server developer quickstart docs ](https://modelcontextprotocol.io/quickstart/server#running-the-server) currently read: `Your server is complete! Run uv run weather.py to confirm that everything’s working.`

In practice, however, running `uv run weather.py`does not really confirm if everything is working. It starts the server via the terminal and then nothing happens in the terminal, which can be confusing to readers. The actual confirmation that everything is working is happening in the next steps in the docs when using the client.

This PR just adds a minor reformulation of this passage in the docs to reduce ambiguity. 

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
