### PR TITLE
Add simplified example of spec compliance schema for sdks

### DIFF
--- a/compliance/example_python_manifest.json
+++ b/compliance/example_python_manifest.json
@@ -1,0 +1,33 @@
+{
+    "sdk_platform": "python",
+    "sdk_version": "1.0.0",
+    "mcp_spec_support": {
+      "2025-03-26": {
+        "transport": {
+          "stdio": true,
+          "streamable_http": true
+        },
+        "client": {
+          "roots": true,
+          "sampling": true
+        },
+        "server": {
+          "prompts": true,
+          "resources": true,
+          "tools": true
+        },
+        "utilities": {
+          "cancellation": true,
+          "ping": true,
+          "completion": false,
+          "logging": false,
+          "pagination": false,
+          "progress": false
+        },
+        "authorization": {
+          "oauth_client_auth": false
+        }
+      }
+    },
+    "last_updated": "2025-04-30"
+  }

--- a/compliance/schema.json
+++ b/compliance/schema.json
@@ -1,0 +1,78 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MCP SDK Support Manifest",
+    "description": "Defines which MCP specification features are supported by an SDK",
+    "type": "object",
+    "required": ["sdk_platform", "sdk_version", "mcp_spec_support", "last_updated"],
+    "properties": {
+      "sdk_platform": {
+        "type": "string",
+        "description": "The language or platform of the SDK",
+        "enum": ["python", "typescript", "java", "csharp"]
+      },
+      "sdk_version": {
+        "type": "string",
+        "description": "The version of the SDK",
+        "pattern": "^[0-9]+(\\.[0-9]+)*(-[a-zA-Z0-9]+)?(\\+[a-zA-Z0-9]+)?$"
+      },
+      "mcp_spec_support": {
+        "type": "object",
+        "description": "Support status for each MCP protocol version",
+        "patternProperties": {
+          "^[0-9]{4}-[0-9]{2}-[0-9]{2}$": {
+            "type": "object",
+            "properties": {
+              "transport": {
+                "type": "object",
+                "properties": {
+                  "stdio": { "type": "boolean" },
+                  "streamable_http": { "type": "boolean" },
+                  "http_sse": { "type": "boolean" }
+                }
+              },
+              "client": {
+                "type": "object",
+                "properties": {
+                  "roots": { "type": "boolean" },
+                  "sampling": { "type": "boolean" }
+                }
+              },
+              "server": {
+                "type": "object",
+                "properties": {
+                  "prompts": { "type": "boolean" },
+                  "resources": { "type": "boolean" },
+                  "tools": { "type": "boolean" }
+                }
+              },
+              "utilities": {
+                "type": "object",
+                "properties": {
+                  "cancellation": { "type": "boolean" },
+                  "ping": { "type": "boolean" },
+                  "completion": { "type": "boolean" },
+                  "logging": { "type": "boolean" },
+                  "pagination": { "type": "boolean" },
+                  "progress": { "type": "boolean" }
+                }
+              },
+              "authorization": {
+                "type": "object",
+                "properties": {
+                  "oauth_client_auth": { "type": "boolean" }
+                }
+              }
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "last_updated": {
+        "type": "string",
+        "description": "The date when this manifest was last updated",
+        "format": "date",
+        "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+      }
+    },
+    "additionalProperties": false
+  }

--- a/compliance/schema.json
+++ b/compliance/schema.json
@@ -1,21 +1,19 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MCP SDK Support Manifest",
-    {
-      "schemaVersion": {
+    "description": "Defines which MCP specification features are supported by an SDK",
+    "type": "object",
+    "required": ["schema_version", "sdk_platform", "sdk_version", "mcp_spec_support", "last_updated"],
+    "properties": {
+      "schema_version": {
         "type": "string",
         "description": "The version of the schema this manifest complies with",
         "pattern": "^[0-9]+(\\.[0-9]+)*(-[a-zA-Z0-9]+)?(\\+[a-zA-Z0-9]+)?$"
-      }
-    }
-    "description": "Defines which MCP specification features are supported by an SDK",
-    "type": "object",
-    "required": ["schemaVersion", "sdk_platform", "sdk_version", "mcp_spec_support", "last_updated"]
-    "properties": {
+      },
       "sdk_platform": {
         "type": "string",
         "description": "The language or platform of the SDK",
-        "enum": ["python", "typescript", "java", "csharp"]
+        "enum": ["python", "typescript", "java", "csharp", "kotlin", "go", "ruby", "rust", "swift"]
       },
       "sdk_version": {
         "type": "string",
@@ -82,4 +80,4 @@
       }
     },
     "additionalProperties": false
-  }
+}

--- a/compliance/schema.json
+++ b/compliance/schema.json
@@ -3,7 +3,7 @@
     "title": "MCP SDK Support Manifest",
     "description": "Defines which MCP specification features are supported by an SDK",
     "type": "object",
-    "required": ["sdk_platform", "sdk_version", "mcp_spec_support", "last_updated"],
+    "required": ["schemaVersion", "sdk_platform", "sdk_version", "mcp_spec_support", "last_updated"]
     "properties": {
       "sdk_platform": {
         "type": "string",

--- a/compliance/schema.json
+++ b/compliance/schema.json
@@ -1,6 +1,13 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MCP SDK Support Manifest",
+    {
+      "schemaVersion": {
+        "type": "string",
+        "description": "The version of the schema this manifest complies with",
+        "pattern": "^[0-9]+(\\.[0-9]+)*(-[a-zA-Z0-9]+)?(\\+[a-zA-Z0-9]+)?$"
+      }
+    }
     "description": "Defines which MCP specification features are supported by an SDK",
     "type": "object",
     "required": ["schemaVersion", "sdk_platform", "sdk_version", "mcp_spec_support", "last_updated"]

--- a/compliance/schema.ts
+++ b/compliance/schema.ts
@@ -49,7 +49,10 @@ export interface ProtocolSupport {
 }
 
 export interface McpSdkSupportManifest {
-  /** The language or platform of the SDK */
+  /** The schema version this manifest complies with */
+  schemaVersion: string;
+  
+   /** The language or platform of the SDK */
   sdk_platform: SdkPlatform;
   
   /** The version of the SDK */

--- a/compliance/schema.ts
+++ b/compliance/schema.ts
@@ -1,0 +1,63 @@
+/**
+ * MCP SDK Support Manifest TypeScript Types
+ */
+
+export type SdkPlatform = 
+  | "python" 
+  | "typescript" 
+  | "java" 
+  | "csharp";
+
+export type ProtocolVersion = string; // Format: YYYY-MM-DD
+
+export interface TransportFeatures {
+  stdio?: boolean;
+  streamable_http?: boolean;
+  http_sse?: boolean;
+}
+
+export interface ClientFeatures {
+  roots?: boolean;
+  sampling?: boolean;
+}
+
+export interface ServerFeatures {
+  prompts?: boolean;
+  resources?: boolean;
+  tools?: boolean;
+}
+
+export interface UtilityFeatures {
+  cancellation?: boolean;
+  ping?: boolean;
+  completion?: boolean;
+  logging?: boolean;
+  pagination?: boolean;
+  progress?: boolean;
+}
+
+export interface AuthorizationFeatures {
+  oauth_client_auth?: boolean;
+}
+
+export interface ProtocolSupport {
+  transport?: TransportFeatures;
+  client?: ClientFeatures;
+  server?: ServerFeatures;
+  utilities?: UtilityFeatures;
+  authorization?: AuthorizationFeatures;
+}
+
+export interface McpSdkSupportManifest {
+  /** The language or platform of the SDK */
+  sdk_platform: SdkPlatform;
+  
+  /** The version of the SDK */
+  sdk_version: string;
+  
+  /** Support status for each MCP protocol version */
+  mcp_spec_support: Record<ProtocolVersion, ProtocolSupport>;
+  
+  /** The date when this manifest was last updated (YYYY-MM-DD) */
+  last_updated: string;
+}

--- a/compliance/schema.ts
+++ b/compliance/schema.ts
@@ -6,7 +6,12 @@ export type SdkPlatform =
   | "python" 
   | "typescript" 
   | "java" 
-  | "csharp";
+  | "csharp"
+  | "kotlin"
+  | "go"
+  | "ruby"
+  | "rust"
+  | "swift";
 
 export type ProtocolVersion = string; // Format: YYYY-MM-DD
 
@@ -50,7 +55,7 @@ export interface ProtocolSupport {
 
 export interface McpSdkSupportManifest {
   /** The schema version this manifest complies with */
-  schemaVersion: string;
+  schema_version: string;
   
    /** The language or platform of the SDK */
   sdk_platform: SdkPlatform;


### PR DESCRIPTION
Adds a simplified example of a MCP spec compliance schema for SDKs.

## Motivation and Context

Taken from @localden 's original document:

Today, developers can use any of the available Model Context Protocol (MCP) SDKs, that include[ Python](https://github.com/modelcontextprotocol/python-sdk),[ TypeScript](https://github.com/modelcontextprotocol/typescript-sdk),[ Java](https://github.com/modelcontextprotocol/java-sdk),[ Kotlin](https://github.com/modelcontextprotocol/kotlin-sdk), or[ C#](https://github.com/modelcontextprotocol/csharp-sdk). These SDKs have varied levels of support for the capabilities outlined in the[ MCP specification](https://spec.modelcontextprotocol.io/specification/2025-03-26/).

As MCP evolves, new versions of the protocol specification are released – we started with[ 2024-11-05](https://spec.modelcontextprotocol.io/specification/2024-11-05/), and are now on[ 2025-03-26](https://spec.modelcontextprotocol.io/specification/2025-03-26/). SDKs, in their current implementation, carry no distinguishing information or markers that communicate to developers the fact that the SDK supports the full set or a subset of specific specification versions.

This proposal intends to establish a shared standard for how MCP SDKs declare their support for MCP capabilities outlined in the protocol specification documents.

## How Has This Been Tested?
Has not yet been tested with an actual SDK, this is just to align on the structure and format.

## Breaking Changes
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

Note that there is already a [GitHub Project](https://github.com/orgs/modelcontextprotocol/projects/3) meant for tracking progress towards SDK compliance, but this PR proposes a structure for populating this information as a JSON file alongside each language SDK.