### PR TITLE
DOC: Fix link to mcp-snowflake-server with latest link from MCP Servers Repository

### DIFF
--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -62,7 +62,7 @@ A growing ecosystem of community-developed servers extends MCP's capabilities:
 - **[Docker](https://github.com/ckreiling/mcp-server-docker)** - Manage containers, images, volumes, and networks
 - **[Kubernetes](https://github.com/Flux159/mcp-server-kubernetes)** - Manage pods, deployments, and services
 - **[Linear](https://github.com/jerhadf/linear-mcp-server)** - Project management and issue tracking
-- **[Snowflake](https://github.com/datawiz168/mcp-snowflake-service)** - Interact with Snowflake databases
+- **[Snowflake](https://github.com/isaacwasserman/mcp-snowflake-server)** - Interact with Snowflake databases
 - **[Spotify](https://github.com/varunneal/spotify-mcp)** - Control Spotify playback and manage playlists
 - **[Todoist](https://github.com/abhiz123/todoist-mcp-server)** - Task management integration
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

The outdated link to `mcp-snowflake-service`  listed here in the [official documentation page](https://modelcontextprotocol.io/examples) - https://github.com/datawiz168/mcp-snowflake-service)

But the latest and up-to-date link to `mcp-snowflake-service ` listed in the [MCP Servers Repository](https://github.com/modelcontextprotocol/servers/blob/main/README.md?plain=1#L408) - https://github.com/isaacwasserman/mcp-snowflake-server

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
This change makes sure the documentation is up to date and in sync with [MCP Servers Repository](https://github.com/modelcontextprotocol/servers)

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
I have successfully integrated with and utilized the MCP server with Enterprise Snowflake according to the protocol specification for agent-based tool execution.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None, documentation update.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
