### PR TITLE
Add Awesome Remote MCP servers to the resources section

### DIFF
--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -126,5 +126,6 @@ To use an MCP server with Claude, add it to your configuration:
 - [Pipedream MCP](https://mcp.pipedream.com) - MCP servers with built-in auth for 3,000+ APIs and 10,000+ tools
 - [Supergateway](https://github.com/supercorp-ai/supergateway) - Run MCP stdio servers over SSE
 - [Zapier MCP](https://zapier.com/mcp) - MCP Server with over 7,000+ apps and 30,000+ actions
+- [Awesome Remote MCP Servers](https://github.com/jaw9c/awesome-remote-mcp-servers) - Curated list of **remote** MCP servers
 
 Visit our [GitHub Discussions](https://github.com/orgs/modelcontextprotocol/discussions) to engage with the MCP community.


### PR DESCRIPTION
Adds a bespoke list of **remote** MCP servers to the resources section of the examples 

## Motivation and Context
As Claude Custom Integrations has been released, there is increased interest in remote MCP as a specific type of MCP server, powered only via URLs

## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
N/A