### PR TITLE
Removed redundant section in Authorization spec

### DIFF
--- a/docs/specification/draft/basic/authorization.mdx
+++ b/docs/specification/draft/basic/authorization.mdx
@@ -52,20 +52,6 @@ while maintaining simplicity:
    Server Metadata ([RFC8414](https://datatracker.ietf.org/doc/html/rfc8414)).
    MCP clients **MUST** use the OAuth 2.0 Authorization Server Metadata.
 
-### 2.1.1 OAuth Grant Types
-
-OAuth specifies different flows or grant types, which are different ways of obtaining an
-access token. Each of these targets different use cases and scenarios.
-
-MCP servers **SHOULD** support the OAuth grant types that best align with the intended
-audience. For instance:
-
-1. Authorization Code: useful when the client is acting on behalf of a (human) end user.
-   - For instance, an agent calls an MCP tool implemented by a SaaS system.
-2. Client Credentials: the client is another application (not a human)
-   - For instance, an agent calls a secure MCP tool to check inventory at a specific
-     store. No need to impersonate the end user.
-
 ### 2.2 Roles
 A protected MCP server acts as a [OAuth 2.1 resource server](https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-12.html#name-roles),
 capable of accepting and responding to protected resource requests using access tokens.
@@ -162,7 +148,7 @@ Any MCP authorization servers that _do not_ support Dynamic Client Registration 
 alternative ways to obtain a client ID (and, if applicable, client credentials). For one of
 these authorization servers, MCP clients will have to either:
 
-1. Hardcode a client ID (and, if applicable, client credentials) specifically for that MCP
+1. Hardcode a client ID (and, if applicable, client credentials) specifically for that authorization
    server, or
 2. Present a UI to users that allows them to enter these details, after registering an
    OAuth client themselves (e.g., through a configuration interface hosted by the

--- a/docs/specification/draft/basic/authorization.mdx
+++ b/docs/specification/draft/basic/authorization.mdx
@@ -148,8 +148,8 @@ Any MCP authorization servers that _do not_ support Dynamic Client Registration 
 alternative ways to obtain a client ID (and, if applicable, client credentials). For one of
 these authorization servers, MCP clients will have to either:
 
-1. Hardcode a client ID (and, if applicable, client credentials) specifically for that authorization
-   server, or
+1. Hardcode a client ID (and, if applicable, client credentials) specifically for the MCP client to use when
+   interacting with that authorization server, or
 2. Present a UI to users that allows them to enter these details, after registering an
    OAuth client themselves (e.g., through a configuration interface hosted by the
    server).


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
The section on OAuth grant types is removed and fixed typo in Section 2.5. 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The new direction of the Authorization spec is to treat MCP Servers as Auth 2.0 resource servers instead of auth servers. The OAuth grant types section states the MCP Server must support various grant types, but this is no longer the case as Auth servers will separately take care of this. This is included in the OAuth 2.1 IETF DRAFT ([draft-ietf-oauth-v2-1-12](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12)) and does not need to be included here. 

I believe the typo in Section 2.5 is also related to this change. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->