### PR TITLE
fixed typo in java server doc

### DIFF
--- a/docs/sdk/java/mcp-server.mdx
+++ b/docs/sdk/java/mcp-server.mdx
@@ -476,7 +476,7 @@ var mcpServer = McpServer.async(mcpServerTransportProvider)
 </Tabs>
 
 The `McpSchema.CompletionReference` definition defines the type (`PromptRefernce` or `ResourceRefernce`) and the identifier for the completion specification (e.g handler).
-The handler function processes requests and returns the complition response. 
+The handler function processes requests and returns the completion response. 
 The first argument is `McpAsyncServerExchange` for client interaction, and the second argument is a `CompleteRequest` instance.
 
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
This fixes a small typo in the documentation to maintain the quality of the documentation.

## How Has This Been Tested?
```
npm run validate:schema    # validate schema
npm run generate:json     # generate JSON schema
npm run serve:docs
```

## Breaking Changes
No, this is a change only in the documentation

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
