### PR TITLE
chore: Create .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore generated schema.json
+**/schema.json


### PR DESCRIPTION
Prettier is over-enthusiastic about reformatting the generated `schema.json` file, especially with editors configured to format on save. The autogenerated JSON doesn't _quite_ match prettier's default config for prettifying JSON, leading to whitespace changes. It is easy to accidentally introduce whitespace changes to the file, which contributes to PR noise.

## Motivation and Context
I inadvertently saved the schema.json file locally and didn't realize that introduced whitespace changes until I opened a PR.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
