### PR TITLE
Add link to official Swift SDK

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -261,6 +261,11 @@
           "anchor": "C# SDK",
           "href": "https://github.com/modelcontextprotocol/csharp-sdk",
           "icon": "square-c"
+        },
+        {
+          "anchor": "Swift SDK",
+          "href": "https://github.com/modelcontextprotocol/swift-sdk",
+          "icon": "swift"
         }
       ]
     }


### PR DESCRIPTION
This PR adds a link to the [Swift SDK](https://github.com/modelcontextprotocol/swift-sdk) that's displayed in the sidebar, alongside the other official SDKs.

## Motivation and Context

Developers building apps in Swift can use the official Swift SDK to incorporate MCP functionality. This change will help them discover this library.

## How Has This Been Tested?

I ran `npm run serve:docs` and previewed the site locally.

<img width="282" alt="Screenshot 2025-05-09 at 04 57 11" src="https://github.com/user-attachments/assets/66dff3b9-2fbf-49df-9bae-b4b2c910b7ca" />

(Screenshot taken while hovering over link for emphasis)

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
