### PR TITLE
Removed URI restriction from roots.mdx

### DIFF
--- a/docs/specification/draft/client/roots.mdx
+++ b/docs/specification/draft/client/roots.mdx
@@ -5,8 +5,8 @@ title: Roots
 <Info>**Protocol Revision**: draft</Info>
 
 The Model Context Protocol (MCP) provides a standardized way for clients to expose
-filesystem "roots" to servers. Roots define the boundaries of where servers can operate
-within the filesystem, allowing them to understand which directories and files they have
+system "roots" to servers. Roots define the boundaries of where servers can operate
+within the system, allowing them to understand which directories and files they have
 access to. Servers can request the list of roots from supporting clients and receive
 notifications when that list changes.
 
@@ -107,8 +107,7 @@ sequenceDiagram
 
 A root definition includes:
 
-- `uri`: Unique identifier for the root. This **MUST** be a `file://` URI in the current
-  specification.
+- `uri`: Unique identifier for the root.
 - `name`: Optional human-readable name for display purposes.
 
 Example roots for different use cases:


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
This change removes the restriction that root URIs **MUST** be `file://`
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Forcing the use of `file://` arbitrarily limits the utility of roots and ultimately reduces the likelihood that hosts will adopt and support all MCP client and server capabilities. Additionally [concepts/roots](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/docs/docs/concepts/roots.mdx#what-are-roots) shows `https://` as an example root. This is misleading and disappointing for developers. See [Issue 505](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/505)
## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Some server and client implementations currently reject any URI other than `file://` to align with March 2025 specification.
## Breaking Changes
<!-- Will users need to update their code or configurations? -->
If a server is blindly assuming that a URI is `file://` then they should add a validation step. If a server or client is rejecting all URIs other than `file://` they should instead verify that the URI is [RFC3986](https://datatracker.ietf.org/doc/html/rfc3986) compliant.
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
