### PR TITLE
Tighten Tool.outputSchema

### DIFF
--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -2128,9 +2128,30 @@
                     "type": "string"
                 },
                 "outputSchema": {
-                    "additionalProperties": true,
                     "description": "An optional JSON Schema object defining the structure of the tool's output.\n\nIf set, a CallToolResult for this Tool MUST contain a structuredContent field whose contents validate against this schema.\nIf not set, a CallToolResult for this Tool MUST contain a content field.",
-                    "properties": {},
+                    "properties": {
+                        "properties": {
+                            "additionalProperties": {
+                                "additionalProperties": true,
+                                "properties": {},
+                                "type": "object"
+                            },
+                            "type": "object"
+                        },
+                        "required": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "type": {
+                            "const": "object",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ],
                     "type": "object"
                 }
             },

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -853,7 +853,11 @@ export interface Tool {
    * If set, a CallToolResult for this Tool MUST contain a structuredContent field whose contents validate against this schema.
    * If not set, a CallToolResult for this Tool MUST contain a content field.
    */
-  outputSchema?: object;
+  outputSchema?: {
+    type: "object";
+    properties?: { [key: string]: object };
+    required?: string[];
+  };
 
   /**
    * Optional additional tool information.


### PR DESCRIPTION
Previously outputSchema was simply typed as `object`, which allows invalid JSON schemas.

## Motivation and Context
Provides a more precise schema definition for `Tool.outputSchema`, identical to that of `Tool.inputSchema`. The previous definition was too permissive, allowing objects that were not valid JSON schemas.

## How Has This Been Tested?
Being used in WIP on [TypeScript SDK support](https://github.com/modelcontextprotocol/typescript-sdk/pull/454)

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

