### PR TITLE
[docs] fix missing Roots link in clients.mdx

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -9,7 +9,7 @@ This page provides an overview of applications that support the Model Context Pr
 
 <div id="feature-support-matrix-wrapper">
 
-| Client                                      | [Resources] | [Prompts] | [Tools]  | [Discovery][Discovery] | [Sampling] | Roots | Notes                                                                        |
+| Client                                      | [Resources] | [Prompts] | [Tools]  | [Discovery][Discovery] | [Sampling] | [Roots] | Notes                                                                        |
 |---------------------------------------------|-------------|-----------|----------|------------------------|------------|--------|-----------------------------------------------------------------------------|
 | [5ire][5ire]                                | ❌          | ❌        | ✅      | ❓                     | ❌          | ❌    | Supports tools.                                                             |
 | [AgentAI][AgentAI]                          | ❌          | ❌        | ✅      | ❓                     | ❌          | ❌    | Agent Library written in Rust with tools support                            |
@@ -113,6 +113,7 @@ This page provides an overview of applications that support the Model Context Pr
 [Prompts]: https://modelcontextprotocol.io/docs/concepts/prompts
 [Tools]: https://modelcontextprotocol.io/docs/concepts/tools
 [Sampling]: https://modelcontextprotocol.io/docs/concepts/sampling
+[Roots]: https://modelcontextprotocol.io/docs/concepts/roots
 [HyperAgent]: https://github.com/hyperbrowserai/HyperAgent
 [Discovery]: /docs/concepts/tools#tool-discovery-and-updates
 


### PR DESCRIPTION
Every header in the table was hyperlinked to the concept page, except for Roots

## Motivation and Context
was trying to learn more about roots but couldn't click on the link

## How Has This Been Tested?
ran locally, hyperlink on Roots works 
![CleanShot 2025-05-14 at 00 22 58@2x](https://github.com/user-attachments/assets/657f05ab-068e-4a63-931e-47aedfe9a8a9)

## Breaking Changes
N/A just docs

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
