### PR TITLE
docs: added the langwatch mcp server to the list of officially supported servers

### DIFF
--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -45,6 +45,7 @@ These MCP servers are maintained by companies for their platforms:
 - **[BrowserStack](https://github.com/browserstack/mcp-server)** - Access BrowserStack's [Test Platform](https://www.browserstack.com/test-platform) to debug, write and fix tests, do accessibility testing and more.
 - **[Cloudflare](https://github.com/cloudflare/mcp-server-cloudflare)** - Deploy and manage resources on the Cloudflare developer platform
 - **[E2B](https://github.com/e2b-dev/mcp-server)** - Execute code in secure cloud sandboxes
+- **[LangWatch](https://github.com/langwatch/langwatch/tree/main/mcp-server)** - Query recent and relevant telemetry (traces/spans) directly from the LangWatch LLM Ops platform, using natural language.
 - **[Neon](https://github.com/neondatabase/mcp-server-neon)** - Interact with the Neon serverless Postgres platform
 - **[Obsidian Markdown Notes](https://github.com/calclavia/mcp-obsidian)** - Read and search through Markdown notes in Obsidian vaults
 - **[Prisma](https://pris.ly/docs/mcp-server)** - Manage and interact with Prisma Postgres databases


### PR DESCRIPTION
I've added a link to the https://github.com/langwatch MCP server that we maintain.

## Motivation and Context
Adds to the growing list of companies getting behind MCP. I'm an employee at LangWatch, and one of the engineers that wrote the MCP server 👋🏻.

## How Has This Been Tested?
I read the markdown with my own two eyes.

## Breaking Changes
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
None, I don't think.
