### PR TITLE
Relax CallToolUnstructuredResult schema to allow structured content

### DIFF
--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -120,7 +120,7 @@
                     "type": "object"
                 },
                 "content": {
-                    "description": "If the Tool defines an outputSchema, this field MAY be present in the result.\nTools should use this field to provide compatibility with older clients that do not support structured content.\nClients that support structured content should ignore this field.",
+                    "description": "If the Tool defines an outputSchema, this field MAY be present in the result.\n\nTools should use this field to provide compatibility with older clients that do not support structured content.\n\nClients that support structured content should ignore this field.",
                     "items": {
                         "anyOf": [
                             {
@@ -185,6 +185,11 @@
                 "isError": {
                     "description": "Whether the tool call ended in an error.\n\nIf not set, this is assumed to be false (the call was successful).",
                     "type": "boolean"
+                },
+                "structuredContent": {
+                    "additionalProperties": {},
+                    "description": "Structured content may be provided in an unstructured tool result.",
+                    "type": "object"
                 }
             },
             "required": [

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -711,9 +711,9 @@ export interface CallToolUnstructuredResult extends Result {
   content: ContentList;
 
   /**
-   * Structured output must not be provided in an unstructured tool result.
+   * Structured content may be provided in an unstructured tool result.
    */
-  structuredContent: never;
+  structuredContent?: { [key: string]: unknown };
 
   /**
    * Whether the tool call ended in an error.
@@ -736,7 +736,9 @@ export interface CallToolStructuredResult extends Result {
 
   /**
    * If the Tool defines an outputSchema, this field MAY be present in the result.
+   *
    * Tools should use this field to provide compatibility with older clients that do not support structured content.
+   *
    * Clients that support structured content should ignore this field.
    */
   content?: ContentList;


### PR DESCRIPTION
## Summary
- Relaxes the CallToolUnstructuredResult schema to allow optional structured content
- Changes the TypeScript type from `never` to `{ [key: string]: unknown }` (optional)

## Changes
This PR modifies the CallToolUnstructuredResult schema to allow tools to optionally include structured content alongside unstructured content. This provides greater flexibility for tool implementations while maintaining backwards compatibility.

## Test plan
- [ ] Verify that existing tools using CallToolUnstructuredResult continue to work without structured content
- [ ] Test that tools can now include structured content in unstructured results
- [ ] Ensure schema validation passes for both cases

🤖 Generated with [Claude Code](https://claude.ai/code)