### PR TITLE
Adding rtrvr.ai as listed MCP Client

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -49,6 +49,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [oterm][oterm]                              | ❌          | ✅        | ✅      | ❓                     | ✅          | ❌    | Supports tools, prompts and sampling for Ollama.                                                 |
 | [Postman][postman]                          | ✅          | ✅        | ✅      | ❓                     | ❌          | ❌    | Supports tools, resources, prompts, and sampling                                                 |
 | [Roo Code][Roo Code]                        | ✅          | ❌        | ✅      | ❓                     | ❌          | ❌    | Supports tools and resources.                                               |
+| [rtrvr.ai][rtrvr.ai]                        | ✅          | ❌        | ✅      | ❓                     | ❌          | ❌    | Supports tools and resources.                                               |
 | [Slack MCP Client][Slack MCP Client]        | ❌          | ❌        | ✅      | ❓                     | ❌          | ❌    | Supports tools and multiple servers.                                        |
 | [Sourcegraph Cody][Cody]                    | ✅          | ❌        | ❌      | ❓                     | ❌          | ❌    | Supports resources through OpenCTX                                          |
 | [SpinAI][SpinAI]                            | ❌          | ❌        | ✅      | ❓                     | ❌          | ❌    | Supports tools for Typescript AI Agents                                     |
@@ -97,6 +98,7 @@ This page provides an overview of applications that support the Model Context Pr
 [oterm]: https://github.com/ggozad/oterm
 [Postman]: https://postman.com/downloads
 [Roo Code]: https://roocode.com
+[rtrvr.ai]: https://rtrvr.ai
 [Slack MCP Client]: https://github.com/tuannvm/slack-mcp-client
 [Cody]: https://sourcegraph.com/cody
 [SpinAI]: https://spinai.dev
@@ -469,6 +471,17 @@ Programmatically assemble prompts for LLMs using [GenAIScript](https://microsoft
 - Support for MCP tools and resources
 - Integration with development workflows
 - Extensible AI capabilities
+
+### rtrvr.ai
+[rtrvr.ai](https://rtrvr.ai) is AI Web Agent that autonomously runs complex workflows, retrieves data to Sheets, and calls API's/MCP Servers – all with just prompting and within your own browser!
+
+**Key features:**
+- Easy MCP Integration within your browser: Just open the Chrome Extension, add the server URL, and prompt server calls with the web as context!
+- Prompt our agent to execute workflows combining web agentic actions with MCP tool calls; find someone's email on the web and then send them an email with Zapier MCP.
+- Reusable and Schedulable Automations: After running a workflow, easily rerun or put on a schedule to execute in the background while you do other tasks in your browser.
+
+**Learn more:**
+- [rtrvr.ai <=> MCP](https://www.youtube.com/watch?v=L_3JiOYI-kI)
 
 ### Postman
 


### PR DESCRIPTION
Adding rtrvr.ai as listed MCP Client

## Motivation and Context
rtrvr.ai now supports being able to call MCP Servers. So now with our AI Web Agent Chrome Extension, you can combine doing agentic tasks in your browser with calling MCPs!

## How Has This Been Tested?
This is just documentation.

## Breaking Changes
None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
https://www.youtube.com/watch?v=L_3JiOYI-kI
