### PR TITLE
duplicated section numbers in draft authorization specification

### DIFF
--- a/docs/specification/draft/basic/authorization.mdx
+++ b/docs/specification/draft/basic/authorization.mdx
@@ -69,7 +69,7 @@ This section describes the mechanisms by which MCP servers advertise their assoc
 authorization servers to MCP clients, as well as the discovery process through which MCP
 clients can determine authorization server endpoints and supported capabilities.
 
-### 2.3.1 Authorization Server Location
+#### 2.3.1 Authorization Server Location
 
 MCP servers **MUST** implement the OAuth 2.0 Protected Resource Metadata ([RFC9728](https://datatracker.ietf.org/doc/html/rfc9728))
 specification to indicate the locations of authorization servers. The Protected Resource Metadata document returned by the MCP server **MUST** include
@@ -92,7 +92,7 @@ MCP clients **MUST** be able to parse `WWW-Authenticate` headers and respond app
 MCP clients **MUST** follow the OAuth 2.0 Authorization Server Metadata [RFC8414](https://datatracker.ietf.org/doc/html/rfc8414)
 specification to obtain the information required to interact with the authorization server.
 
-#### 2.3.4 Sequence Diagram
+#### 2.3.3 Sequence Diagram
 The following diagram outlines an example flow:
 
 ```mermaid
@@ -122,7 +122,7 @@ sequenceDiagram
     Note over C,M: MCP communication continues with valid token
 ```
 
-#### 2.4 MCP specific headers for discovery
+### 2.4 MCP specific headers for discovery
 
 MCP clients **SHOULD** include the `MCP-Protocol-Version: <protocol-version>` HTTP header during
 any request to the MCP server allowing the MCP server to respond based on the MCP protocol version.
@@ -281,7 +281,7 @@ An attacker who has gained access to an authorization code contained in an autho
 To mitigate this, MCP clients **MUST** implement PKCE according to [OAuth 2.1 Section 7.5.2](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12#section-7.5.2).
 PKCE helps prevent authorization code interception and injection attacks by requiring clients to create a secret verifier-challenge pair, ensuring that only the original requestor can exchange an authorization code for tokens.
 
-### 3.3 Open Redirection
+### 3.4 Open Redirection
 
 An attacker may craft malicious redirect URIs to direct users to phishing sites.
 
@@ -296,7 +296,7 @@ Authorization servers **MUST** take precautions to prevent redirecting user agen
 
 Authorization servers **SHOULD** only automatically redirect the user agent if it trusts the redirection URI. If the URI is not trusted, the authorization server MAY inform the user and rely on the user to make the correct decision.
 
-### 3.4 Confused Deputy Problem
+### 3.5 Confused Deputy Problem
 
 Attackers can exploit MCP servers acting as intermediaries to third-party APIs, leading to confused deputy vulnerabilities.
 By using stolen authorization codes, they can obtain access tokens without user consent.


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Fixing a typo (duplicated section numbers in `authorization.mdx` .

## How Has This Been Tested?
No tests needed.

## Breaking Changes
No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
