### PR TITLE
docs: Remove /servers README-redundant examples from /examples

### DIFF
--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -38,39 +38,11 @@ These official reference servers demonstrate core MCP features and SDK usage:
 
 ## Official integrations
 
-These MCP servers are maintained by companies for their platforms:
+Visit the [MCP Servers Repository (Official Integrations section)](https://github.com/modelcontextprotocol/servers?tab=readme-ov-file#%EF%B8%8F-official-integrations) for a list of MCP servers maintained by companies for their platforms.
 
-- **[Apify](https://mcp.apify.com)** - Use thousands community Actors for web data extraction and automation jobs
-- **[Axiom](https://github.com/axiomhq/mcp-server-axiom)** - Query and analyze logs, traces, and event data using natural language
-- **[Browserbase](https://github.com/browserbase/mcp-server-browserbase)** - Automate browser interactions in the cloud
-- **[BrowserStack](https://github.com/browserstack/mcp-server)** - Access BrowserStack's [Test Platform](https://www.browserstack.com/test-platform) to debug, write and fix tests, do accessibility testing and more.
-- **[Cloudflare](https://github.com/cloudflare/mcp-server-cloudflare)** - Deploy and manage resources on the Cloudflare developer platform
-- **[E2B](https://github.com/e2b-dev/mcp-server)** - Execute code in secure cloud sandboxes
-- **[Neon](https://github.com/neondatabase/mcp-server-neon)** - Interact with the Neon serverless Postgres platform
-- **[Obsidian Markdown Notes](https://github.com/calclavia/mcp-obsidian)** - Read and search through Markdown notes in Obsidian vaults
-- **[Prisma](https://pris.ly/docs/mcp-server)** - Manage and interact with Prisma Postgres databases
-- **[Qdrant](https://github.com/qdrant/mcp-server-qdrant/)** - Implement semantic memory using the Qdrant vector search engine
-- **[Raygun](https://github.com/MindscapeHQ/mcp-server-raygun)** - Access crash reporting and monitoring data
-- **[Search1API](https://github.com/fatwang2/search1api-mcp)** - Unified API for search, crawling, and sitemaps
-- **[Snyk](https://github.com/snyk/snyk-ls/tree/main/mcp_extension)** - Enhance security posture by embedding [Snyk](https://snyk.io) vulnerability scanning directly into agentic workflows.
-- **[Stripe](https://github.com/stripe/agent-toolkit)** - Interact with the Stripe API
-- **[Tinybird](https://github.com/tinybirdco/mcp-tinybird)** - Interface with the Tinybird serverless ClickHouse platform
-- **[Weaviate](https://github.com/weaviate/mcp-server-weaviate)** - Enable Agentic RAG through your Weaviate collection(s)
+## Community implementations
 
-## Community highlights
-
-A growing ecosystem of community-developed servers extends MCP's capabilities:
-
-- **[Docker](https://github.com/ckreiling/mcp-server-docker)** - Manage containers, images, volumes, and networks
-- **[Kubernetes](https://github.com/Flux159/mcp-server-kubernetes)** - Manage pods, deployments, and services
-- **[Linear](https://github.com/jerhadf/linear-mcp-server)** - Project management and issue tracking
-- **[Snowflake](https://github.com/datawiz168/mcp-snowflake-service)** - Interact with Snowflake databases
-- **[Spotify](https://github.com/varunneal/spotify-mcp)** - Control Spotify playback and manage playlists
-- **[Todoist](https://github.com/abhiz123/todoist-mcp-server)** - Task management integration
-
-> **Note:** Community servers are untested and should be used at your own risk. They are not affiliated with or endorsed by Anthropic.
-
-For a complete list of community servers, visit the [MCP Servers Repository](https://github.com/modelcontextprotocol/servers).
+Visit the [MCP Servers Repository (Community section)](https://github.com/modelcontextprotocol/servers?tab=readme-ov-file#-community-servers) for a list of MCP servers maintained by community members.
 
 ## Getting started
 
@@ -121,12 +93,6 @@ To use an MCP server with Claude, add it to your configuration:
 
 ## Additional resources
 
-- [MCP Servers Repository](https://github.com/modelcontextprotocol/servers) - Complete collection of reference implementations and community servers
-- [Awesome MCP Servers](https://github.com/punkpeye/awesome-mcp-servers) - Curated list of MCP servers
-- [MCP CLI](https://github.com/wong2/mcp-cli) - Command-line inspector for testing MCP servers
-- [MCP Get](https://mcp-get.com) - Tool for installing and managing MCP servers
-- [Pipedream MCP](https://mcp.pipedream.com) - MCP servers with built-in auth for 3,000+ APIs and 10,000+ tools
-- [Supergateway](https://github.com/supercorp-ai/supergateway) - Run MCP stdio servers over SSE
-- [Zapier MCP](https://zapier.com/mcp) - MCP Server with over 7,000+ apps and 30,000+ actions
+Visit the [MCP Servers Repository (Resources section)](https://github.com/modelcontextprotocol/servers?tab=readme-ov-file#-resources) for a collection of other resources and projects related to MCP.
 
 Visit our [GitHub Discussions](https://github.com/orgs/modelcontextprotocol/discussions) to engage with the MCP community.


### PR DESCRIPTION
The lists on this [examples page](https://modelcontextprotocol.io/examples) are not necessary, as they are entirely redundant with the [/servers README](https://github.com/modelcontextprotocol/servers). Their presence results in maintenance of an arbitrary second list that doesn't serve any meaningful purpose besides creating surface area for folks to try marketing their products (and potential confusion when some get merged and some don't).

This change links out to the corresponding sections in the /servers README.

I've kept the reference servers here as the categorization of them isn't present anywhere else, plus there is no maintenance concern with them given that new reference servers are not being added + there is no "marketing" incentive for people to open PR's to add more of them.

Tested by running locally and clicking the new links:

![image](https://github.com/user-attachments/assets/579b555c-8025-4c58-b31b-003c141eff53)
