### PR TITLE
add structured output to changelog, removed stale batching ref in docs

### DIFF
--- a/docs/specification/draft/basic/index.mdx
+++ b/docs/specification/draft/basic/index.mdx
@@ -91,13 +91,6 @@ The receiver **MUST NOT** send a response.
 
 - Notifications **MUST NOT** include an ID.
 
-### Batching
-
-JSON-RPC also defines a means to
-[batch multiple requests and notifications](https://www.jsonrpc.org/specification#batch),
-by sending them in an array. MCP implementations **MAY** support sending JSON-RPC
-batches, but **MUST** support receiving JSON-RPC batches.
-
 ## Auth
 
 MCP provides an [Authorization](/specification/draft/basic/authorization) framework for use with HTTP.

--- a/docs/specification/draft/changelog.mdx
+++ b/docs/specification/draft/changelog.mdx
@@ -9,7 +9,9 @@ the previous revision, [2025-03-26](/specification/2025-03-26).
 
 1. Removed support for JSON-RPC **[batching](https://www.jsonrpc.org/specification#batch)**
    (PR [#416](https://github.com/modelcontextprotocol/specification/pull/416)) 
-2. TODO
+2. Added support for [structured tool output](https://modelcontextprotocol.io/specification/draft/server/tools#structured-content)
+   (PR [#371](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/371))
+3. TODO
 
 ## Other schema changes
 

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -248,7 +248,7 @@ For backwards compatibility, a tool that returns structured content SHOULD also 
 #### Output Schema
 
 Tools may also provide an output schema for validation of structured results.
-If an output schema provided:
+If an output schema is provided:
 * Servers **MUST** provide structured results that conform to this schema.
 * Clients **SHOULD** validate structured results against this schema.
 


### PR DESCRIPTION
Add structured output support to changelog (note: internal path points to `draft/`)

drive-bys:
* removed stale reference to batching from `draft/basic/index.mdx`
* fixed typo on `draft/server/tools.mdx`