### PR TITLE
Fix C# client sample not building.

### DIFF
--- a/docs/quickstart/client.mdx
+++ b/docs/quickstart/client.mdx
@@ -1399,6 +1399,7 @@ Then, add the required dependencies to your project:
 dotnet add package ModelContextProtocol --prerelease
 dotnet add package Anthropic.SDK
 dotnet add package Microsoft.Extensions.Hosting
+dotnet add package Microsoft.Extensions.AI
 ```
 
 ## Setting up your API key


### PR DESCRIPTION
Without this package, the C# client quick start does not compile.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Code sample does not compile.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

I tested by copy-pasting the code sample into a local project. This additional package was required to make it compile.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

This makes the sample in the docs match the [sample project in the csharp-sdk repo](https://github.com/modelcontextprotocol/csharp-sdk/blob/main/samples/QuickstartClient/QuickstartClient.csproj#L22). This additional package reference is needed for the [`AsBuilder` extension method](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.ai.chatclientbuilderchatclientextensions.asbuilder) that is [called here](https://github.com/modelcontextprotocol/csharp-sdk/blob/main/samples/QuickstartClient/Program.cs#L32) in the sample.