### PR TITLE
fix(doc): invalid import in client snippet

### DIFF
--- a/docs/quickstart/client.mdx
+++ b/docs/quickstart/client.mdx
@@ -516,8 +516,8 @@ First, let's set up our imports and create the basic client class in `index.ts`:
 import { Anthropic } from "@anthropic-ai/sdk";
 import {
   MessageParam,
-  Tool,
 } from "@anthropic-ai/sdk/resources/messages/messages.mjs";
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import readline from "readline/promises";


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
The tool class is imported from the wrong module in a [typescript client snippet](https://modelcontextprotocol.io/quickstart/client#basic-client-structure-2)
It should be imported from `@modelcontextprotocol/sdk/types.js` instead of `@anthropic-ai/sdk/resources/messages/messages.mjs`

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Improve the onboarding for nodejs developers

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Yes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

