### PR TITLE
Feat: Add Webhooks as a server capability

### DIFF
--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -96,7 +96,8 @@ The server **MUST** respond with its own capabilities and information:
         "listChanged": true
       },
       "tools": {
-        "listChanged": true
+        "listChanged": true,
+        "webhooksSupported": true
       }
     },
     "serverInfo": {

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -443,8 +443,11 @@ Example tool execution error:
    - Implement proper access controls
    - Rate limit tool invocations
    - Sanitize tool outputs
+   - Verify veracity of webhook URLs to prevent Server-Side Request Forgery or
+     Distributed Denial of Service attacks against internal or 3rd party systems
 
 2. Clients **SHOULD**:
+
    - Prompt for user confirmation on sensitive operations
    - Show tool inputs to the user before calling the server, to avoid malicious or
      accidental data exfiltration
@@ -452,4 +455,7 @@ Example tool execution error:
    - Implement timeouts for tool calls
    - Log tool usage for audit purposes
    - Exercise caution when providing secrets in webhook credentials since they might be
-     susceptible to man-in-the-middle attacks
+     susceptible to Man-in-the-Middle attacks
+
+3. Webhook servers **SHOULD**:
+    - Authenticate the received messages

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -19,6 +19,11 @@ However, implementations are free to expose tools through any interface pattern 
 suits their needs&mdash;the protocol itself does not mandate any specific user
 interaction model.
 
+Servers typically receive tool call requests and respond to the client with the result.
+However, servers may offer webhook support for tool calls. This allows clients to specify
+webhooks in tool call requests and enables servers to transmit tool call responses to the
+webhooks instead of the client.
+
 <Warning>
 For trust & safety and security, there **SHOULD** always
 be a human in the loop with the ability to deny tool invocations.
@@ -39,7 +44,8 @@ Servers that support tools **MUST** declare the `tools` capability:
 {
   "capabilities": {
     "tools": {
-      "listChanged": true
+      "listChanged": true,
+      "webhooksSupported": true
     }
   }
 }
@@ -47,6 +53,9 @@ Servers that support tools **MUST** declare the `tools` capability:
 
 `listChanged` indicates whether the server will emit notifications when the list of
 available tools changes.
+
+`webhooksSupported` indicates whether the server offers support to transmit results to
+the webhooks provided by the client in the tool call request.
 
 ## Protocol Messages
 
@@ -117,6 +126,68 @@ To invoke a tool, clients send a `tools/call` request:
 ```
 
 **Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Current weather in New York:\nTemperature: 72°F\nConditions: Partly cloudy"
+      }
+    ],
+    "isError": false
+  }
+}
+```
+
+#### Calling Tools with Webhooks
+
+To invoke a tool with webhooks, when interacting with a webhook support enabled server,
+clients send a `tools/call` request with a list of webhooks:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "get_weather",
+    "arguments": {
+      "location": "New York"
+    },
+    "webhooks": [
+      {
+        "url": "http://localhost:8000"
+      }
+    ]
+  }
+}
+```
+
+**Acknowledgement to Client:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Response will be forwarded to the webhook."
+      }
+    ],
+    "isError": false
+  }
+}
+```
+
+**Response to Webhook:**
 
 ```json
 {
@@ -380,3 +451,5 @@ Example tool execution error:
    - Validate tool results before passing to LLM
    - Implement timeouts for tool calls
    - Log tool usage for audit purposes
+   - Exercise caution when providing secrets in webhook credentials since they might be
+     susceptible to man-in-the-middle attacks

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -458,4 +458,5 @@ Example tool execution error:
      susceptible to Man-in-the-Middle attacks
 
 3. Webhook servers **SHOULD**:
+
     - Authenticate the received messages

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -48,6 +48,29 @@
             ],
             "type": "object"
         },
+        "AuthenticationInfo": {
+            "description": "Specifies the authentication details that are required for communication with an endpoint.",
+            "properties": {
+                "credentials": {
+                    "description": "Optional credentials that can be used to communicate with the endpoint.\n\nIn case of bearer and apiKey, credentials consist of static string credentials that can be supplied in the header.\nIn case of basic, credentials can consist of static string credentials that can be supplied in the header or a parsable JSON that consists of username and password keys along with their corresponding values.\nIn case of customHeader, credentials consist of a parsable JSON that contains the relevant authentication headers and corresponding values.",
+                    "type": "string"
+                },
+                "strategy": {
+                    "description": "The authentication strategy enforced by the endpoint.",
+                    "enum": [
+                        "apiKey",
+                        "basic",
+                        "bearer",
+                        "customHeader"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "strategy"
+            ],
+            "type": "object"
+        },
         "BlobResourceContents": {
             "properties": {
                 "blob": {
@@ -107,6 +130,12 @@
                         },
                         "name": {
                             "type": "string"
+                        },
+                        "webhooks": {
+                            "items": {
+                                "$ref": "#/definitions/Webhook"
+                            },
+                            "type": "array"
                         }
                     },
                     "required": [
@@ -2024,6 +2053,10 @@
                         "listChanged": {
                             "description": "Whether this server supports notifications for changes to the tool list.",
                             "type": "boolean"
+                        },
+                        "webhooksSupported": {
+                            "description": "Whether this server supports sending tool responses to webhooks",
+                            "type": "boolean"
                         }
                     },
                     "type": "object"
@@ -2386,6 +2419,23 @@
             "required": [
                 "method",
                 "params"
+            ],
+            "type": "object"
+        },
+        "Webhook": {
+            "description": "Specifies a webhook that can receive messages from the server.\n\nIt includes the URL where the webhook is hosted and an optional authentication method that should be used by the server when transmitting to the webhook.",
+            "properties": {
+                "authentication": {
+                    "$ref": "#/definitions/AuthenticationInfo",
+                    "description": "Authentication required to communicate with the webhook."
+                },
+                "url": {
+                    "description": "The URL where the webhook is hosted and to which the message will be transmitted.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "url"
             ],
             "type": "object"
         }

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -272,6 +272,10 @@ export interface ServerCapabilities {
      * Whether this server supports notifications for changes to the tool list.
      */
     listChanged?: boolean;
+    /**
+     * Whether this server supports sending tool responses to webhooks
+     */
+    webhooksSupported?: boolean;
   };
 }
 
@@ -726,6 +730,7 @@ export interface CallToolRequest extends Request {
   params: {
     name: string;
     arguments?: { [key: string]: unknown };
+    webhooks?: Webhook[];
   };
 }
 
@@ -734,6 +739,42 @@ export interface CallToolRequest extends Request {
  */
 export interface ToolListChangedNotification extends Notification {
   method: "notifications/tools/list_changed";
+}
+
+/**
+ * Specifies a webhook that can receive messages from the server.
+ * 
+ * It includes the URL where the webhook is hosted and an optional authentication method that should be used by the server when transmitting to the webhook.
+ */
+export interface Webhook {
+  /**
+   * The URL where the webhook is hosted and to which the message will be transmitted.
+   */
+  url: string;
+
+  /**
+   * Authentication required to communicate with the webhook.
+   */
+  authentication?: AuthenticationInfo;
+}
+
+/**
+ * Specifies the authentication details that are required for communication with an endpoint.
+ */
+export interface AuthenticationInfo {
+  /**
+   * The authentication strategy enforced by the endpoint.
+   */
+  strategy: "bearer" | "apiKey" | "basic" | "customHeader";
+
+  /**
+   * Optional credentials that can be used to communicate with the endpoint.
+   * 
+   * In case of bearer and apiKey, credentials consist of static string credentials that can be supplied in the header.
+   * In case of basic, credentials can consist of static string credentials that can be supplied in the header or a parsable JSON that consists of username and password keys along with their corresponding values.
+   * In case of customHeader, credentials consist of a parsable JSON that contains the relevant authentication headers and corresponding values.
+   */
+  credentials?: string;
 }
 
 /**


### PR DESCRIPTION
Add support for transmitting call tool responses to webhooks. Routing the responses to the webhook will be the responsibility of the transport layer, however, this specification change will standardize how webhooks can be passed from the client to the server and how the server can expose support for webhooks as a capability.

Changes:
- Introduce a new server capability to support webhooks
- Allow MCP clients to pass webhooks as part of tools/call request in CallToolRequestParams
- Introduce interfaces for Webhook and AuthenticationInfo

## Motivation and Context
Discussed in #523 

As MCP expands to support asynchronous communication (https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/491), there will arise scenarios wherein the async execution will take anywhere from a few hours to a few days. The current discussion revolves around modeling long-running executions as resources/streams that require client polling to allow the client to disconnect from the server.

In order to free up the client and reduce load when handling multiple async operations, the recommended approach is often to offer support for webhooks (similar discussion: https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/266). Webhooks offer a lightweight approach that allow the server to send results to the client when the async execution for a tool has been completed. Webhooks can be hosted by standalone servers (common in cloud services) or in some cases, they can be hosted by the client.

- Webhook can act as a mechanism that notifies the client once the async execution has completed before proceeding to retrieve it.
- The pattern of async execution + webhooks can also prove useful in scenarios where storing the response might make sense prior to the client interacting with it.
- Passing webhooks to different servers, that support webhooks, would allow the client to disconnect after the acknowledged response and just track responses sent to the webhook instead of querying different servers for the async responses.

Even though the webhook routing implementation will exist in the transport layer, the server will have the ability to decide whether to offer support for routing responses to webhooks or not. This decision could be based on whether the server comprises of asynchronous tools, whether the server wants to establish connections to the webhooks uris provided by the client (security concerns), if the server wants to risk additional latency of transmitting results to webhook (reliability) etc-.

If a server supports webhook capability, webhooks will be supported for all tools in the server. The client will have the option to pass webhooks as part of the CallToolsRequest. Any request with webhooks will have the final results transmitted to webhooks instead of back to the client. The client will receive an acknowledgement response once the tool call with webhooks has been received by the server.

The tool call implementations should be able to vary their behaviour depending on whether the tool call from the client consists of a webhook or not. This can be achieved by adding information to the request context about whether a webhook was passed in the request or not.

## Examples

- User interacts with a client and tasks it with performing time series forecasting on stock market prices for select securities. The client interacts with a server to perform time series forecasting using ML algorithms. The time series forecasting tool on the server is modeled as asynchronous. The final response is a large dataset since the forecasting granularity is in minutes and over the period of a few months. In such a scenario, the client would provide the server with a webhook to another data store. The webhook stores the response before the client further interacts with the results.
- The user makes use of a client that is linked with their cloud service (Amazon Q, Microsoft Copilot etc-). The webhook is hosted in the user's personal account. Even when the user shuts down their local machines, the account along with the webhook will always be up and running. The user opens their local machine and uses the local client. The local client connects to a server and uses it to trigger a long running task. The user then proceeds to shut down their local client/machine. The long running task will complete on the server and the results will be transmitted to the webhook. The user logs back in after some time. As soon as the local client reconnects to the upstream service (ideally on start up), it will have the response waiting for it.

## How Has This Been Tested?
- Created client and server with a [draft implementation](https://github.com/modelcontextprotocol/python-sdk/pull/777) in python-sdk to test out the changes. Hosted a test webhook locally to receive the responses.
- Unit tests were successful

## Breaking Changes
None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
