### PR TITLE
add ResourceLink to CallToolResult

### DIFF
--- a/docs/specification/draft/changelog.mdx
+++ b/docs/specification/draft/changelog.mdx
@@ -21,7 +21,8 @@ the previous revision, [2025-03-26](/specification/2025-03-26).
 5. Added support for **[elicitation](client/elicitation)**, enabling servers to request additional
    information from users during interactions.
    (PR [#382](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/382))
-6. Added support for **[linked resources](http://localhost:3001/specification/draft/server/tools#linked-resources)** in tool call results. (PR [#603](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/603))
+6. Added support for **[linked resources](/specification/draft/server/tools#linked-resources)** in 
+   tool call results. (PR [#603](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/603))
 
 ## Other schema changes
 

--- a/docs/specification/draft/changelog.mdx
+++ b/docs/specification/draft/changelog.mdx
@@ -21,6 +21,7 @@ the previous revision, [2025-03-26](/specification/2025-03-26).
 5. Added support for **[elicitation](client/elicitation)**, enabling servers to request additional
    information from users during interactions.
    (PR [#382](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/382))
+6. Added support for **[linked resources](http://localhost:3001/specification/draft/server/tools#linked-resources)** in tool call results. (PR [#603](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/603))
 
 ## Other schema changes
 

--- a/docs/specification/draft/changelog.mdx
+++ b/docs/specification/draft/changelog.mdx
@@ -21,7 +21,7 @@ the previous revision, [2025-03-26](/specification/2025-03-26).
 5. Added support for **[elicitation](client/elicitation)**, enabling servers to request additional
    information from users during interactions.
    (PR [#382](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/382))
-6. Added support for **[linked resources](/specification/draft/server/tools#linked-resources)** in 
+6. Added support for **[resource links](/specification/draft/server/tools#resource-links)** in
    tool call results. (PR [#603](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/603))
 
 ## Other schema changes

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -230,14 +230,14 @@ Tool results may contain [**structured**](#structured-content) or **unstructured
 }
 ```
 
-#### Linked Resources
+#### Resource Links
 
-[Resources](/specification/draft/server/resources) **MAY** be linked, to provide additional context
-or data, behind a URI that can be subscribed to or fetched by the client:
+A tool **MAY** return links to [Resources](/specification/draft/server/resources), to provide additional context
+or data. In this case, the tool will return a URI that can be subscribed to or fetched by the client:
 
 ```json
 {
-  "type": "linked_resource",
+  "type": "resource_link",
   "uri": "file:///project/src/main.rs",
   "name": "main.rs",
   "description": "Primary application entry point",
@@ -246,13 +246,13 @@ or data, behind a URI that can be subscribed to or fetched by the client:
 ```
 
 <Info>
-  Linked resources returned by tools are not guaranteed to appear in the results
+  Resource links returned by tools are not guaranteed to appear in the results
   of a `resources/list` request.
 </Info>
 
 #### Embedded Resources
 
-[Resources](/specification/draft/server/resources) **MAY** be embedded, to provide additional context
+A tool **MAY** return embedded [Resource contents](/specification/draft/server/resources), to provide additional context
 or data, along with a URI that can be subscribed to or fetched again by the client later:
 
 ```json

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -233,21 +233,32 @@ Tool results may contain [**structured**](#structured-content) or **unstructured
 #### Linked Resources
 
 [Resources](/specification/draft/server/resources) **MAY** be linked, to provide additional context
-or data, behind a URI that can be subscribed to or fetched again by the client later:
+or data, behind a URI that can be subscribed to or fetched by the client:
 
+```json
+{
+  "type": "linked_resource",
+  "uri": "file:///project/src/main.rs",
+  "name": "main.rs",
+  "description": "Primary application entry point",
+  "mimeType": "text/x-rust"
+}
+```
+
+<Info>Linked resources returned by tools are not guaranteed to appear in the results of a `resources/list` request.</Info>
 
 #### Embedded Resources
 
 [Resources](/specification/draft/server/resources) **MAY** be embedded, to provide additional context
-or data, behind a URI that can be subscribed to or fetched again by the client later:
+or data, along with a URI that can be subscribed to or fetched again by the client later:
 
 ```json
 {
   "type": "resource",
   "resource": {
-    "uri": "resource://example",
-    "mimeType": "text/plain",
-    "text": "Resource content"
+    "uri": "file:///project/src/main.rs",
+    "mimeType": "text/x-rust",
+    "text": "fn main() {\n    println!(\"Hello world!\");\n}"
   }
 }
 ```

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -245,7 +245,10 @@ or data, behind a URI that can be subscribed to or fetched by the client:
 }
 ```
 
-<Info>Linked resources returned by tools are not guaranteed to appear in the results of a `resources/list` request.</Info>
+<Info>
+  Linked resources returned by tools are not guaranteed to appear in the results
+  of a `resources/list` request.
+</Info>
 
 #### Embedded Resources
 

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -230,6 +230,12 @@ Tool results may contain [**structured**](#structured-content) or **unstructured
 }
 ```
 
+#### Linked Resources
+
+[Resources](/specification/draft/server/resources) **MAY** be linked, to provide additional context
+or data, behind a URI that can be subscribed to or fetched again by the client later:
+
+
 #### Embedded Resources
 
 [Resources](/specification/draft/server/resources) **MAY** be embedded, to provide additional context

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -1018,7 +1018,7 @@
                     "type": "integer"
                 },
                 "type": {
-                    "const": "linkedresource",
+                    "const": "linked_resource",
                     "type": "string"
                 },
                 "uri": {

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -995,7 +995,7 @@
             "type": "object"
         },
         "LinkedResource": {
-            "description": "A reference to a resource descriptor, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render linked resources for the benefit\nof the LLM and/or the user.",
+            "description": "A resource that the server is capable of reading, embedded into a prompt or tool call result.\n\nNote: linked resources are not guaranteed to appear in the results of `resources/list` requests.",
             "properties": {
                 "annotations": {
                     "$ref": "#/definitions/Annotations",

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -406,7 +406,7 @@
                     "$ref": "#/definitions/AudioContent"
                 },
                 {
-                    "$ref": "#/definitions/LinkedResource"
+                    "$ref": "#/definitions/ResourceLink"
                 },
                 {
                     "$ref": "#/definitions/EmbeddedResource"
@@ -991,46 +991,6 @@
                 "id",
                 "jsonrpc",
                 "result"
-            ],
-            "type": "object"
-        },
-        "LinkedResource": {
-            "description": "A resource that the server is capable of reading, embedded into a prompt or tool call result.\n\nNote: linked resources are not guaranteed to appear in the results of `resources/list` requests.",
-            "properties": {
-                "annotations": {
-                    "$ref": "#/definitions/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "description": {
-                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
-                    "type": "string"
-                },
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "A human-readable name for this resource.\n\nThis can be used by clients to populate UI elements.",
-                    "type": "string"
-                },
-                "size": {
-                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
-                    "type": "integer"
-                },
-                "type": {
-                    "const": "linked_resource",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "type",
-                "uri"
             ],
             "type": "object"
         },
@@ -1768,6 +1728,46 @@
                 }
             },
             "required": [
+                "uri"
+            ],
+            "type": "object"
+        },
+        "ResourceLink": {
+            "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of `resources/list` requests.",
+            "properties": {
+                "annotations": {
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "description": {
+                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "A human-readable name for this resource.\n\nThis can be used by clients to populate UI elements.",
+                    "type": "string"
+                },
+                "size": {
+                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+                    "type": "integer"
+                },
+                "type": {
+                    "const": "resource_link",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "type",
                 "uri"
             ],
             "type": "object"

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -406,10 +406,10 @@
                     "$ref": "#/definitions/AudioContent"
                 },
                 {
-                    "$ref": "#/definitions/EmbeddedResource"
+                    "$ref": "#/definitions/LinkedResource"
                 },
                 {
-                    "$ref": "#/definitions/LinkedResource"
+                    "$ref": "#/definitions/EmbeddedResource"
                 }
             ]
         },
@@ -995,7 +995,7 @@
             "type": "object"
         },
         "LinkedResource": {
-            "description": "A resource descriptor, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render linked resources for the benefit\nof the LLM and/or the user.",
+            "description": "A reference to a resource descriptor, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render linked resources for the benefit\nof the LLM and/or the user.",
             "properties": {
                 "resource": {
                     "$ref": "#/definitions/Resource"

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -132,23 +132,7 @@
                 "content": {
                     "description": "A list of content objects that represent the unstructured result of the tool call.",
                     "items": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/definitions/TextContent"
-                            },
-                            {
-                                "$ref": "#/definitions/ImageContent"
-                            },
-                            {
-                                "$ref": "#/definitions/AudioContent"
-                            },
-                            {
-                                "$ref": "#/definitions/EmbeddedResource"
-                            },
-                            {
-                                "$ref": "#/definitions/ResourceReference"
-                            }
-                        ]
+                        "$ref": "#/definitions/ContentBlock"
                     },
                     "type": "array"
                 },
@@ -409,6 +393,25 @@
                 "completion"
             ],
             "type": "object"
+        },
+        "ContentBlock": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/TextContent"
+                },
+                {
+                    "$ref": "#/definitions/ImageContent"
+                },
+                {
+                    "$ref": "#/definitions/AudioContent"
+                },
+                {
+                    "$ref": "#/definitions/EmbeddedResource"
+                },
+                {
+                    "$ref": "#/definitions/LinkedResource"
+                }
+            ]
         },
         "CreateMessageRequest": {
             "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
@@ -991,6 +994,23 @@
             ],
             "type": "object"
         },
+        "LinkedResource": {
+            "description": "A resource descriptor, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render linked resources for the benefit\nof the LLM and/or the user.",
+            "properties": {
+                "resource": {
+                    "$ref": "#/definitions/Resource"
+                },
+                "type": {
+                    "const": "linkedresource",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "resource",
+                "type"
+            ],
+            "type": "object"
+        },
         "ListPromptsRequest": {
             "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
             "properties": {
@@ -1559,20 +1579,7 @@
             "description": "Describes a message returned as part of a prompt.\n\nThis is similar to `SamplingMessage`, but also supports the embedding of\nresources from the MCP server.",
             "properties": {
                 "content": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/TextContent"
-                        },
-                        {
-                            "$ref": "#/definitions/ImageContent"
-                        },
-                        {
-                            "$ref": "#/definitions/AudioContent"
-                        },
-                        {
-                            "$ref": "#/definitions/EmbeddedResource"
-                        }
-                    ]
+                    "$ref": "#/definitions/ContentBlock"
                 },
                 "role": {
                     "$ref": "#/definitions/Role"

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -997,17 +997,40 @@
         "LinkedResource": {
             "description": "A reference to a resource descriptor, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render linked resources for the benefit\nof the LLM and/or the user.",
             "properties": {
-                "resource": {
-                    "$ref": "#/definitions/Resource"
+                "annotations": {
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "description": {
+                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "A human-readable name for this resource.\n\nThis can be used by clients to populate UI elements.",
+                    "type": "string"
+                },
+                "size": {
+                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+                    "type": "integer"
                 },
                 "type": {
                     "const": "linkedresource",
                     "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
                 }
             },
             "required": [
-                "resource",
-                "type"
+                "name",
+                "type",
+                "uri"
             ],
             "type": "object"
         },

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -144,6 +144,9 @@
                             },
                             {
                                 "$ref": "#/definitions/EmbeddedResource"
+                            },
+                            {
+                                "$ref": "#/definitions/ResourceReference"
                             }
                         ]
                     },

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -638,12 +638,9 @@ export interface PromptMessage {
 }
 
 /**
+ * A resource that the server is capable of reading, embedded into a prompt or tool call result.
  *
- * A reference to a resource descriptor, embedded into a prompt or tool call result.
- *
- * It is up to the client how best to render linked resources for the benefit
- * of the LLM and/or the user.
- *
+ * Note: linked resources are not guaranteed to appear in the results of `resources/list` requests.
  */
 export interface LinkedResource extends Resource {
   type: "linked_resource";

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -634,7 +634,7 @@ export type Role = "user" | "assistant";
  */
 export interface PromptMessage {
   role: Role;
-  content: TextContent | ImageContent | AudioContent | EmbeddedResource;
+  content: ContentBlock;
 }
 
 /**
@@ -651,6 +651,19 @@ export interface EmbeddedResource {
    * Optional annotations for the client.
    */
   annotations?: Annotations;
+}
+
+/**
+ *
+ * A resource descriptor, embedded into a prompt or tool call result.
+ *
+ * It is up to the client how best to render linked resources for the benefit
+ * of the LLM and/or the user.
+ *
+ */
+export interface LinkedResource {
+  type: "linkedresource";
+  resource: Resource;
 }
 
 /**
@@ -682,7 +695,7 @@ export interface CallToolResult extends Result {
   /**
    * A list of content objects that represent the unstructured result of the tool call.
    */
-  content: (TextContent | ImageContent | AudioContent | EmbeddedResource | ResourceReference)[];
+  content: ContentBlock[];
 
   /**
    * An optional JSON object that represents the structured result of the tool call.
@@ -952,6 +965,14 @@ export interface Annotations {
    */
   priority?: number;
 }
+
+/**  */
+export type ContentBlock =
+  | TextContent
+  | ImageContent
+  | AudioContent
+  | EmbeddedResource
+  | LinkedResource;
 
 /**
  * Text provided to or from an LLM.
@@ -1291,7 +1312,7 @@ export interface EnumSchema {
   title?: string;
   description?: string;
   enum: string[];
-  enumNames?: string[];  // Display names for enum values
+  enumNames?: string[]; // Display names for enum values
 }
 
 /**
@@ -1335,7 +1356,11 @@ export type ClientNotification =
   | InitializedNotification
   | RootsListChangedNotification;
 
-export type ClientResult = EmptyResult | CreateMessageResult | ListRootsResult | ElicitResult;
+export type ClientResult =
+  | EmptyResult
+  | CreateMessageResult
+  | ListRootsResult
+  | ElicitResult;
 
 /* Server messages */
 export type ServerRequest =

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -638,12 +638,12 @@ export interface PromptMessage {
 }
 
 /**
- * A resource that the server is capable of reading, embedded into a prompt or tool call result.
+ * A resource that the server is capable of reading, included in a prompt or tool call result.
  *
- * Note: linked resources are not guaranteed to appear in the results of `resources/list` requests.
+ * Note: resource links returned by tools are not guaranteed to appear in the results of `resources/list` requests.
  */
-export interface LinkedResource extends Resource {
-  type: "linked_resource";
+export interface ResourceLink extends Resource {
+  type: "resource_link";
 }
 
 /**
@@ -966,7 +966,7 @@ export type ContentBlock =
   | TextContent
   | ImageContent
   | AudioContent
-  | LinkedResource
+  | ResourceLink
   | EmbeddedResource;
 
 /**

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -638,6 +638,20 @@ export interface PromptMessage {
 }
 
 /**
+ *
+ * A reference to a resource descriptor, embedded into a prompt or tool call result.
+ *
+ * It is up to the client how best to render linked resources for the benefit
+ * of the LLM and/or the user.
+ *
+ */
+export interface LinkedResource {
+  type: "linkedresource";
+  resource: Resource;
+}
+
+
+/**
  * The contents of a resource, embedded into a prompt or tool call result.
  *
  * It is up to the client how best to render embedded resources for the benefit
@@ -652,20 +666,6 @@ export interface EmbeddedResource {
    */
   annotations?: Annotations;
 }
-
-/**
- *
- * A resource descriptor, embedded into a prompt or tool call result.
- *
- * It is up to the client how best to render linked resources for the benefit
- * of the LLM and/or the user.
- *
- */
-export interface LinkedResource {
-  type: "linkedresource";
-  resource: Resource;
-}
-
 /**
  * An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.
  */
@@ -971,8 +971,8 @@ export type ContentBlock =
   | TextContent
   | ImageContent
   | AudioContent
-  | EmbeddedResource
-  | LinkedResource;
+  | LinkedResource
+  | EmbeddedResource;
 
 /**
  * Text provided to or from an LLM.

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -646,7 +646,7 @@ export interface PromptMessage {
  *
  */
 export interface LinkedResource extends Resource {
-  type: "linkedresource";
+  type: "linked_resource";
 }
 
 /**

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -638,6 +638,20 @@ export interface PromptMessage {
 }
 
 /**
+ *
+ * A reference to a resource descriptor, embedded into a prompt or tool call result.
+ *
+ * It is up to the client how best to render linked resources for the benefit
+ * of the LLM and/or the user.
+ *
+ */
+export interface LinkedResource {
+  type: "linkedresource";
+  resource: Resource;
+}
+
+
+/**
  * The contents of a resource, embedded into a prompt or tool call result.
  *
  * It is up to the client how best to render embedded resources for the benefit
@@ -652,20 +666,6 @@ export interface EmbeddedResource {
    */
   annotations?: Annotations;
 }
-
-/**
- *
- * A resource descriptor, embedded into a prompt or tool call result.
- *
- * It is up to the client how best to render linked resources for the benefit
- * of the LLM and/or the user.
- *
- */
-export interface LinkedResource {
-  type: "linkedresource";
-  resource: Resource;
-}
-
 /**
  * An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.
  */

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -682,7 +682,7 @@ export interface CallToolResult extends Result {
   /**
    * A list of content objects that represent the unstructured result of the tool call.
    */
-  content: (TextContent | ImageContent | AudioContent | EmbeddedResource)[];
+  content: (TextContent | ImageContent | AudioContent | EmbeddedResource | ResourceReference)[];
 
   /**
    * An optional JSON object that represents the structured result of the tool call.

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -645,11 +645,9 @@ export interface PromptMessage {
  * of the LLM and/or the user.
  *
  */
-export interface LinkedResource {
+export interface LinkedResource extends Resource {
   type: "linkedresource";
-  resource: Resource;
 }
-
 
 /**
  * The contents of a resource, embedded into a prompt or tool call result.

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -638,20 +638,6 @@ export interface PromptMessage {
 }
 
 /**
- *
- * A reference to a resource descriptor, embedded into a prompt or tool call result.
- *
- * It is up to the client how best to render linked resources for the benefit
- * of the LLM and/or the user.
- *
- */
-export interface LinkedResource {
-  type: "linkedresource";
-  resource: Resource;
-}
-
-
-/**
  * The contents of a resource, embedded into a prompt or tool call result.
  *
  * It is up to the client how best to render embedded resources for the benefit
@@ -666,6 +652,20 @@ export interface EmbeddedResource {
    */
   annotations?: Annotations;
 }
+
+/**
+ *
+ * A resource descriptor, embedded into a prompt or tool call result.
+ *
+ * It is up to the client how best to render linked resources for the benefit
+ * of the LLM and/or the user.
+ *
+ */
+export interface LinkedResource {
+  type: "linkedresource";
+  resource: Resource;
+}
+
 /**
  * An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.
  */


### PR DESCRIPTION
Enables tool calls to return `ResourceLink`s (in addition to full `EmbeddedResource`s) in results. 

## Motivation and Context
Returning resource links enables interaction flows where returning resource content inline is impractical. 

`ResourceLink` reuses the `Resource` structure unchanged, but adds a necessary type tag for disambiguation in `ContentBlock` arrays.

## How Has This Been Tested?
No testing yet.

## Breaking Changes
Older clients will not be able to interpret the new content type.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [] Documentation update **TODO**

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
