### PR TITLE
Hesreallyhim/spec nit capabilities prompts

### DIFF
--- a/schema/2025-03-26/schema.json
+++ b/schema/2025-03-26/schema.json
@@ -1803,7 +1803,7 @@
                     "type": "object"
                 },
                 "prompts": {
-                    "description": "Present if the server offers any prompt templates.",
+                    "description": "Present if the server offers any prompts or prompt templates.",
                     "properties": {
                         "listChanged": {
                             "description": "Whether this server supports notifications for changes to the prompt list.",

--- a/schema/2025-03-26/schema.ts
+++ b/schema/2025-03-26/schema.ts
@@ -239,7 +239,7 @@ export interface ServerCapabilities {
    */
   completions?: object;
   /**
-   * Present if the server offers any prompt templates.
+   * Present if the server offers any prompts or prompt templates.
    */
   prompts?: {
     /**

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -1995,7 +1995,7 @@
                     "type": "object"
                 },
                 "prompts": {
-                    "description": "Present if the server offers any prompt templates.",
+                    "description": "Present if the server offers any prompts or prompt templates.",
                     "properties": {
                         "listChanged": {
                             "description": "Whether this server supports notifications for changes to the prompt list.",

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -243,7 +243,7 @@ export interface ServerCapabilities {
    */
   completions?: object;
   /**
-   * Present if the server offers any prompt templates.
+   * Present if the server offers any prompts or prompt templates.
    */
   prompts?: {
     /**
@@ -1258,7 +1258,7 @@ export interface ElicitRequest extends Request {
  * Restricted schema definitions that only allow primitive types
  * without nested objects or arrays.
  */
-export type PrimitiveSchemaDefinition = 
+export type PrimitiveSchemaDefinition =
   | StringSchema
   | NumberSchema
   | BooleanSchema
@@ -1307,7 +1307,7 @@ export interface ElicitResult extends Result {
    * - "cancel": User dismissed without making an explicit choice
    */
   action: "accept" | "decline" | "cancel";
-  
+
   /**
    * The submitted form data, only present when action is "accept".
    * Contains values matching the requested schema.


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Minor clarification that the "prompts" object in ServerCapabilities should be present if the server supports prompt templates OR just prompts (current version omits the latter).

I believe a server can have prompts without having prompt templates - if that's wrong, then reject this PR (although I believe it's strongly implied elsewhere).

This PR changes:
```
"prompts": {
                    "description": "Present if the server offers any prompt templates.",
...
```
TO:
```
"prompts": {
                    "description": "Present if the server offers any prompts or prompt templates.",
...
```

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
N/A

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No, unless they only followed the existing, slightly narrower requirement, which seems doubtful - OTOH, perhaps this assumption is incorrect.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
