### PR TITLE
Add `Resource.supportsDirectRead`

### DIFF
--- a/docs/docs/concepts/resources.mdx
+++ b/docs/docs/concepts/resources.mdx
@@ -76,10 +76,12 @@ Servers expose a list of concrete resources via the `resources/list` endpoint. E
 
 ```typescript
 {
-  uri: string;           // Unique identifier for the resource
-  name: string;          // Human-readable name
-  description?: string;  // Optional description
-  mimeType?: string;     // Optional MIME type
+  uri: string;                   // Unique identifier for the resource
+  name: string;                  // Human-readable name
+  description?: string;          // Optional description
+  mimeType?: string;             // Optional MIME type
+  size?: number;                 // Size of the raw resource content (in bytes)
+  supportsDirectRead?: boolean;  // Whether the resource may be read directly via URI
 }
 ```
 
@@ -120,6 +122,8 @@ The server responds with a list of resource contents:
 <Tip>
   Servers may return multiple resources in response to one `resources/read` request. This could be used, for example, to return a list of files inside a directory when the directory is read.
 </Tip>
+
+Alternatively, if the resource's `supportsDirectRead` property is true, then the resource content may also be read by fetching its URI. This approach can be more performant than reading via `resources/read`.
 
 ## Resource updates
 

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -1752,6 +1752,10 @@
                     "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
                     "type": "integer"
                 },
+                "supportsDirectRead": {
+                    "description": "Indicates whether the resource content may also be read directly via its URI. Reading the resource directly can be more performant than reading via resources/read. The resource may still be read via resources/read regardless of this value.",
+                    "type": "boolean"
+                },
                 "uri": {
                     "description": "The URI of this resource.",
                     "format": "uri",
@@ -2279,7 +2283,7 @@
                     "type": "string"
                 },
                 "outputSchema": {
-                    "description": "An optional JSON Schema object defining the structure of the tool's output returned in \nthe structuredContent field of a CallToolResult.",
+                    "description": "An optional JSON Schema object defining the structure of the tool's output returned in\nthe structuredContent field of a CallToolResult.",
                     "properties": {
                         "properties": {
                             "additionalProperties": {

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -484,6 +484,11 @@ export interface Resource {
    * This can be used by Hosts to display file sizes and estimate context window usage.
    */
   size?: number;
+
+  /**
+   * Indicates whether the resource content may also be read directly via its URI. Reading the resource directly can be more performant than reading via resources/read. The resource may still be read via resources/read regardless of this value.
+   */
+  supportsDirectRead?: boolean;
 }
 
 /**
@@ -705,7 +710,7 @@ export interface CallToolResult extends Result {
    * Whether the tool call ended in an error.
    *
    * If not set, this is assumed to be false (the call was successful).
-   * 
+   *
    * Any errors that originate from the tool SHOULD be reported inside the result
    * object, with `isError` set to true, _not_ as an MCP protocol-level error
    * response. Otherwise, the LLM would not be able to see that an error occurred
@@ -816,7 +821,7 @@ export interface Tool {
   };
 
   /**
-   * An optional JSON Schema object defining the structure of the tool's output returned in 
+   * An optional JSON Schema object defining the structure of the tool's output returned in
    * the structuredContent field of a CallToolResult.
    */
   outputSchema?: {
@@ -1258,7 +1263,7 @@ export interface ElicitRequest extends Request {
  * Restricted schema definitions that only allow primitive types
  * without nested objects or arrays.
  */
-export type PrimitiveSchemaDefinition = 
+export type PrimitiveSchemaDefinition =
   | StringSchema
   | NumberSchema
   | BooleanSchema
@@ -1307,7 +1312,7 @@ export interface ElicitResult extends Result {
    * - "cancel": User dismissed without making an explicit choice
    */
   action: "accept" | "decline" | "cancel";
-  
+
   /**
    * The submitted form data, only present when action is "accept".
    * Contains values matching the requested schema.


### PR DESCRIPTION
## Motivation and Context

When reading a binary resource via `resources/read`, the resource content must be encoded into Base64 and wrapped in JSON on the server, and then must be decoded on the client.  Base64 increases payload size by 33%, so this process can add significant overhead for large resources.

This PR adds a `supportsDirectRead` boolean property to `Resource`, which indicates whether the resource content may also be read directly via its URI, thereby avoiding the overhead.  Though the resource may still be read via `resources/read` regardless of the property's value.

It's also worth mentioning that if a client SDK's `resources/read` API method accepts a resource object (as returned by `resources/list`), then the API method can transparently take advantage of this optimization.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Not tested.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Closes #527.

### Alternative approach: `directUri`

An alternative approach could be to add a `directUri` string property.  If present, this URI could be fetched directly.  It could be the same value as `uri`, or it could be different to support an alternative URI for direct downloads.
