### PR TITLE
Documentation: Define 1st vs 3rd party MCP servers

### DIFF
--- a/docs/specification/draft/basic/security_best_practices.mdx
+++ b/docs/specification/draft/basic/security_best_practices.mdx
@@ -10,6 +10,65 @@ This document provides security considerations for the Model Context Protocol (M
 
 The primary audience for this document includes developers implementing MCP authorization flows, MCP server operators, and security professionals evaluating MCP-based systems. This document should be read alongside the MCP Authorization specification and [OAuth 2.0 security best practices](https://datatracker.ietf.org/doc/html/rfc9700).
 
+### 1.2 Common Terminology & Context
+
+Common terminology and context are essential for understanding the security considerations in this document. The following sections define key terms and provide a reference diagram to illustrate the architecture of MCP implementations.
+
+#### 1.2.1 Terminology Reference
+
+**First-Party Hosted MCP Server**
+: An MCP server operated by the same entity that controls & hosts both the protected resources and the authorization infrastructure. In this model, the MCP server, authorization server, and resource servers all operate under unified administrative control and share the same security boundaries. Unlike MCP Proxy Servers, first-party hosted servers do not act as external OAuth clients to third-party APIs. Instead, they directly manage authentication, authorization, and access control for the resources they protect. This architecture is typically used in scenarios where the MCP server is part of a larger platform or service, allowing for tighter integration with the platform's security model and user management. Examples include a SaaS platform's MCP server that provides access to that platform's proprietary APIs and data, where the platform operator has full control over the entire authentication and authorization flow. This architecture follows the OAuth 2.0 first-party application pattern and avoids the security complexities inherent in multi-party trust scenarios.
+
+**MCP Proxy Server**
+: An MCP server that connects MCP clients to third-party APIs, offering MCP features while delegating operations and acting as a single OAuth client to the third-party API server.
+
+#### 1.2.2 Terminology Reference Diagram
+
+The following diagram illustrates the architecture of MCP implementations, highlighting the roles of MCP Proxy Servers and First-Party Hosted MCP Servers.
+
+```mermaid
+graph TD
+    %% Actors
+    ProxyUser["Proxy Client<br>(Uses MCP Proxy Server)"]
+    DirectUser["Direct Client<br>(Uses First-Party MCP Server)"]
+
+    %% External MCP Components
+    MCPProxyServer["MCP Proxy Server<br>(Sits outside the Provider)"]
+
+    %% Provider / Host Components (Grouped in Subgraph)
+    subgraph HostResourceServer ["Host (Resource Server)"]
+        direction LR
+        ProviderMCPServer["First-Party MCP Server<br>(Hosted by Provider)"]
+        ProviderAPIServices["API Services<br>(Hosted by Provider)"]
+        AuthorizationServer["Authorization Server(Hosted by Provider)"]
+        Note1["AuthN/Authorization is part of the<br>resource provider's infrastructure &<br>shares the same security context and audience."]
+        style Note1 fill:#f9f9f9,stroke:#2E8B57,stroke-dasharray: 5 5,textColor:#333
+
+        %% Connections within the subgraph
+        ProviderMCPServer -.->|Direct Interaction| ProviderAPIServices
+        ProviderAPIServices -.-> AuthorizationServer
+        ProviderMCPServer -.-> AuthorizationServer
+    end
+
+    %% Connections from Users to Components
+    ProxyUser --> MCPProxyServer
+    MCPProxyServer -.->|Acts as Third-Party<br>Client| ProviderAPIServices
+
+    DirectUser --> ProviderMCPServer
+    DirectUser --> ProviderAPIServices
+
+    %% Styling (optional, but can improve readability)
+    classDef proxyActor fill:#f9f9f9,stroke:#d2691e,stroke-width:2px
+    classDef directActor fill:#f9f9f9,stroke:#2E8B57,stroke-width:2px
+    classDef mcpproxy fill:#fff0e6,stroke:#d2691e,stroke-width:2px
+    classDef hostcomponent fill:#d4f8d4,stroke:#2E8B57,stroke-width:2px
+
+    class ProxyUser proxyActor;
+    class DirectUser directActor;
+    class MCPProxyServer mcpproxy;
+    class ProviderMCPServer,ProviderAPIServices,AuthorizationServer hostcomponent;
+```
+
 ## 2. Attacks and Mitigations
 
 This section gives a detailed description of attacks on MCP implementations, along with potential countermeasures.
@@ -19,9 +78,6 @@ This section gives a detailed description of attacks on MCP implementations, alo
 Attackers can exploit MCP servers proxying other resource servers, creating "[confused deputy](https://en.wikipedia.org/wiki/Confused_deputy_problem)" vulnerabilities.
 
 #### 2.1.1 Terminology
-
-**MCP Proxy Server**
-: An MCP server that connects MCP clients to third-party APIs, offering MCP features while delegating operations and acting as a single OAuth client to the third-party API server.
 
 **Third-Party Authorization Server**
 : Authorization server that protects the third-party API. It may lack dynamic client registration support, requiring MCP proxy to use a static client ID for all requests.


### PR DESCRIPTION
This pull request adds definitions for "First-Party Hosted MCP Server" and "MCP Proxy Server", along with a clarifying architecture diagram, to the security best practices documentation. Adding this terminology helps to set the basis for further discussions on best practices.

## Motivation and Context

The operational context of an MCP Server significantly impacts its security considerations. An MCP Server can either directly manage access to resources owned and controlled by the same entity operating the server ("First-Party Hosted") or act as an intermediary to connect MCP clients to third-party APIs ("MCP Proxy").

Understanding this distinction is critical for applying relevant security best practices. For example:
*   **Authentication and Authorization:** While MCP leverages OAuth 2.1 for interactions between the Host/Client and the Server, the nature of the backend resource affects the overall authorization chain. A First-Party Hosted server is acting as the host of its own resources based on the authenticated identity, while an MCP Proxy server might delegate operations to a third-party API, requiring it to manage credentials (potentially Non-Human Identities - NHIs) for that third-party system . This introduces complexities in delegated authority and trust management
*  **Threat Modeling:** Different deployment models are susceptible to different risks. A First-Party Hosted model primarily focuses on securing the direct interactions and access controls to owned resources. A Proxy model, however, introduces supply chain risks related to the third-party API and specific threats related to the proxy's management and use of credentials for that third party. Mitigations discussed in sources like the OWASP Agentic AI Threats document, such as securing tool execution and managing NHIs, need to be applied considering these specific architectural patterns.
*   **Principle of Least Privilege:** Applying least privilege requires understanding the full chain of access. For a First-Party server, this means restricting the client's access to the server's capabilities. For a Proxy, it additionally means ensuring the proxy itself has only the minimum necessary permissions on the third-party system it interacts with.

Adding these definitions and the diagram provides essential common terminology and context, making the security considerations discussed further in the document clearer and helping implementers understand which best practices apply to their specific MCP deployment scenario.

## How Has This Been Tested?
This change is purely documentation to provide clarity on architectural patterns. It does not involve code changes or require technical testing scenarios.

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x ] I have added or updated documentation as needed

## Additional context
Adding this terminology helps to set the basis for further discussions on best practices.