### PR TITLE
Add Protocol Layering section to Architecture doc

### DIFF
--- a/docs/specification/draft/architecture/index.mdx
+++ b/docs/specification/draft/architecture/index.mdx
@@ -121,29 +121,19 @@ MCP organizes functionality into distinct layers similar to network protocol sta
 │ APPLICATION LAYER                               │
 │ MCP Protocol Features                           │
 │ • Tools, Resources, Prompts                     │
-│ • Elicitation, Sampling                         │  
+│ • Elicitation, Sampling                         │
 │ • Business logic and user interactions          │
-│ • Example: Progress notifications, data queries │
 └─────────────────────────────────────────────────┘
 ┌─────────────────────────────────────────────────┐
-│ SESSION LAYER                                   │
-│ Authentication & Session Management             │
-│ • OAuth 2.1 flows (above transport layer)       │
-│ • API keys and credentials                      │
-│ • Session establishment and lifecycle           │
-│ • Example: Bearer tokens, user permissions      │
-└─────────────────────────────────────────────────┘
-┌─────────────────────────────────────────────────┐
-│ TRANSPORT LAYER                                 │
-│ Message Delivery                                │
-│ • STDIO, HTTP, Custom transports                │
+│ TRANSPORT & SECURITY LAYER                      │
+│ Message Delivery & Authentication               │
+│ • STDIO (env vars), HTTP (OAuth), Custom        │
 │ • JSON-RPC message framing                      │
-│ • Connection management                         │
-│ • Example: SSE connections, process pipes       │
+│ • Connection management and credentials         │
 └─────────────────────────────────────────────────┘
 ```
 
-For example: Credential validation happens at the session layer (establishing trust), while requesting user preferences happens at the application layer (using that established trust).
+For example: Credential validation happens at the transport & security layer (establishing trust), while requesting user preferences happens at the application layer (using that established trust).
 
 ## Capability Negotiation
 

--- a/docs/specification/draft/architecture/index.mdx
+++ b/docs/specification/draft/architecture/index.mdx
@@ -112,9 +112,9 @@ implementation:
    - Protocol designed for future extensibility
    - Backwards compatibility is maintained
 
-## Layer Separation in MCP
+## Protocol Layering
 
-MCP follows established network architecture principles by operating at distinct layers of the protocol stack:
+MCP organizes functionality into distinct layers similar to network protocol stacks. While not mapping directly to OSI layers, this separation provides clear boundaries for different responsibilities:
 
 ```
 ┌─────────────────────────────────────────────────┐

--- a/docs/specification/draft/architecture/index.mdx
+++ b/docs/specification/draft/architecture/index.mdx
@@ -112,6 +112,34 @@ implementation:
    - Protocol designed for future extensibility
    - Backwards compatibility is maintained
 
+## Layer Separation in MCP
+
+MCP follows established network architecture principles by operating at distinct layers of the protocol stack:
+
+```
+┌─────────────────────────────────────────────────┐
+│ APPLICATION LAYER                               │
+│ MCP Protocol Features                           │
+│ • Tools, Resources, Prompts                     │
+│ • Elicitation, Sampling                         │  
+│ • Business logic and user interactions          │
+└─────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────┐
+│ SESSION LAYER                                   │
+│ Authentication & Session Management             │
+│ • OAuth 2.1 flows                               │
+│ • API keys and credentials                      │
+│ • Session establishment and lifecycle           │
+└─────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────┐
+│ TRANSPORT LAYER                                 │
+│ Message Delivery                                │
+│ • STDIO, HTTP, Custom transports                │
+│ • JSON-RPC message framing                      │
+│ • Connection management                         │
+└─────────────────────────────────────────────────┘
+```
+
 ## Capability Negotiation
 
 The Model Context Protocol uses a capability-based negotiation system where clients and

--- a/docs/specification/draft/architecture/index.mdx
+++ b/docs/specification/draft/architecture/index.mdx
@@ -123,13 +123,15 @@ MCP organizes functionality into distinct layers similar to network protocol sta
 │ • Tools, Resources, Prompts                     │
 │ • Elicitation, Sampling                         │  
 │ • Business logic and user interactions          │
+│ • Example: Progress notifications, data queries │
 └─────────────────────────────────────────────────┘
 ┌─────────────────────────────────────────────────┐
 │ SESSION LAYER                                   │
 │ Authentication & Session Management             │
-│ • OAuth 2.1 flows                               │
+│ • OAuth 2.1 flows (above transport layer)       │
 │ • API keys and credentials                      │
 │ • Session establishment and lifecycle           │
+│ • Example: Bearer tokens, user permissions      │
 └─────────────────────────────────────────────────┘
 ┌─────────────────────────────────────────────────┐
 │ TRANSPORT LAYER                                 │
@@ -137,8 +139,11 @@ MCP organizes functionality into distinct layers similar to network protocol sta
 │ • STDIO, HTTP, Custom transports                │
 │ • JSON-RPC message framing                      │
 │ • Connection management                         │
+│ • Example: SSE connections, process pipes       │
 └─────────────────────────────────────────────────┘
 ```
+
+For example: Credential validation happens at the session layer (establishing trust), while requesting user preferences happens at the application layer (using that established trust).
 
 ## Capability Negotiation
 


### PR DESCRIPTION
Adds protocol layering section to architecture documentation to clarify design decisions and feature placement within MCP.

## Motivation and Context
The current MCP architecture documentation focuses on components and design principles but doesn't necessarily explain where different features belong within the protocol's organizational structure.

Adding a layering diagram could provide clearer guidance for understanding architectural decisions, such as:
- Why can't Elicitation be used for API keys/credentials?
- Should authentication happen at the transport or application level?
- Where do new features belong when extending MCP?

While this only separates functionality into 2 broad categories, it seems like most MCP features do fall into either "business logic" vs "transport/auth," so this separation could still provide meaningful architectural guidance.

## How Has This Been Tested?
Checked for alignment between this addition and the existing spec + security best practices.

## Breaking Changes
None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Inspired by question from @calclavia about whether Elicitation should allow for passing secrets/API keys.
