### PR TITLE
Document `Resource.size` in `concepts/resources.mdx`

### DIFF
--- a/docs/docs/concepts/resources.mdx
+++ b/docs/docs/concepts/resources.mdx
@@ -80,6 +80,7 @@ Servers expose a list of concrete resources via the `resources/list` endpoint. E
   name: string;          // Human-readable name
   description?: string;  // Optional description
   mimeType?: string;     // Optional MIME type
+  size?: number;         // Optional size in bytes
 }
 ```
 


### PR DESCRIPTION
This field was added in #132.

## Motivation and Context

The field was [documented in `server/resources.mdx`](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/fb34d1d6da2287f82cfdf46c1f91b6fb262cdd38/docs/specification/draft/server/resources.mdx?plain=1#L270), but not `concepts/resources.mdx`.

## How Has This Been Tested?

No tests.

## Breaking Changes

No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
