### PR TITLE
[ez] Fix Ruby SDK icon in sidebar navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -258,7 +258,7 @@
         {
           "anchor": "Ruby SDK",
           "href": "https://github.com/modelcontextprotocol/ruby-sdk",
-          "icon": "ruby"
+          "icon": "gem"
         },
         {
           "anchor": "Swift SDK",


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
The "ruby" icon doesn't exist in FontAwesome, causing rendering issues in the sidebar.
This replaces it with a generic "gem" icon for proper display.

## How Has This Been Tested?
Tested by running `npm run serve:docs`

Before:
![Screenshot 2025-06-02 at 14 03 52](https://github.com/user-attachments/assets/2b3937a8-0d53-4a86-b37e-39b5534e7a7d)

After:
![Screenshot 2025-06-02 at 14 03 34](https://github.com/user-attachments/assets/1e5a29cb-c8f4-4287-832a-db03abc4cf80)

## Breaking Changes
N/A
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
N/A
<!-- Add any other context, implementation notes, or design decisions -->
