### PR TITLE
Rename ResourceReference to ResourceTemplateReference in draft spec

### DIFF
--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -339,7 +339,7 @@
                                     "$ref": "#/definitions/PromptReference"
                                 },
                                 {
-                                    "$ref": "#/definitions/ResourceReference"
+                                    "$ref": "#/definitions/ResourceTemplateReference"
                                 }
                             ]
                         }
@@ -1806,25 +1806,6 @@
             ],
             "type": "object"
         },
-        "ResourceReference": {
-            "description": "A reference to a resource or resource template definition.",
-            "properties": {
-                "type": {
-                    "const": "ref/resource",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI or URI template of the resource.",
-                    "format": "uri-template",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "type",
-                "uri"
-            ],
-            "type": "object"
-        },
         "ResourceTemplate": {
             "description": "A template description for resources available on the server.",
             "properties": {
@@ -1853,6 +1834,25 @@
             "required": [
                 "name",
                 "uriTemplate"
+            ],
+            "type": "object"
+        },
+        "ResourceTemplateReference": {
+            "description": "A reference to a resource or resource template definition.",
+            "properties": {
+                "type": {
+                    "const": "ref/resource",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI or URI template of the resource.",
+                    "format": "uri-template",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type",
+                "uri"
             ],
             "type": "object"
         },

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -1117,7 +1117,7 @@ export interface ModelHint {
 export interface CompleteRequest extends Request {
   method: "completion/complete";
   params: {
-    ref: PromptReference | ResourceReference;
+    ref: PromptReference | ResourceTemplateReference;
     /**
      * The argument's information
      */
@@ -1157,7 +1157,7 @@ export interface CompleteResult extends Result {
 /**
  * A reference to a resource or resource template definition.
  */
-export interface ResourceReference {
+export interface ResourceTemplateReference {
   type: "ref/resource";
   /**
    * The URI or URI template of the resource.


### PR DESCRIPTION
This change renames the ResourceReference interface to ResourceTemplateReference
to better reflect its purpose in the MCP specification. The interface is used
specifically for referencing resource templates rather than resources themselves.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
