### PR TITLE
Mark `schema.json` files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 package-lock.json linguist-generated=true
+schema/*/schema.json linguist-generated=true


### PR DESCRIPTION
Diffs for `schema.json` files can be large and add visual noise when reviewing PRs.

This change collapses diffs by default on GitHub for `schema.json` files.
