### PR TITLE
Consolidate check scripts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,8 @@ jobs:
 
       - run: npm ci
 
-      - run: npm run validate:schema
+      - name: Check TypeScript definitions
+        run: npm run check:schema:ts
 
-      - run: npm run generate:json
       - name: Verify that `npm run generate:json` did not change outputs (if it did, please re-run it and re-commit!)
-        run: git diff --exit-code
+        run: npm run check:schema:json

--- a/.github/workflows/markdown-format.yml
+++ b/.github/workflows/markdown-format.yml
@@ -25,4 +25,7 @@ jobs:
         run: npm ci
 
       - name: Check markdown formatting
-        run: npm run format:check
+        run: npm run check:docs:format
+
+      - name: Check markdown links
+        run: npm run check:docs:links

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,7 @@ npm install  # install dependencies
 ## Making Changes
 
 Note that schema changes are made to `schema.ts`, and `schema.json` is generated from
-`schema.ts`. You should validate your `schema.ts` changes first and then generate the
-`schema.json`.
+`schema.ts`.
 
 1. Create a new branch:
 
@@ -42,30 +41,26 @@ Note that schema changes are made to `schema.ts`, and `schema.json` is generated
 git checkout -b feature/your-feature-name
 ```
 
-2. Make your changes
-3. Validate your changes:
+2. Make your changes.
+
+3. Validate schema changes and generate `schema.json`:
 
 ```bash
-npm run validate:schema    # validate schema
+npm run check:schema:ts
+npm run generate:json
 ```
 
-4. Generate the `schema.json`:
+4. Validate documentation changes and apply formatting:
 
 ```bash
-npm run generate:json      # generate JSON schema
+npm run check:docs
+npm run format
 ```
 
-5. Run docs locally (optional):
+5. Preview documentation locally (optional):
 
 ```bash
 npm run serve:docs
-```
-
-6. Format/lint your changes:
-
-```bash
-npm run format:check   # check formatting
-npm run format         # apply formatting
 ```
 
 ### Documentation Guidelines
@@ -77,7 +72,7 @@ When contributing to the documentation:
 - Include code examples where appropriate
 - Use proper MDX formatting and components
 - Test all links and code samples
-  - You may run `npm run check-links` to look for broken internal links.
+  - You may run `npm run check:docs:links` to look for broken internal links.
 - Use appropriate headings: "When to use", "Steps", and "Tips" for tutorials
 - Place new pages in appropriate sections (concepts, tutorials, etc.)
 - Update `docs.json` when adding new pages

--- a/package.json
+++ b/package.json
@@ -21,12 +21,16 @@
     ]
   },
   "scripts": {
-    "validate:schema": "tsc",
+    "check": "npm run check:schema && npm run check:docs",
+    "check:schema": "npm run check:schema:ts && npm run check:schema:json",
+    "check:schema:ts": "tsc",
+    "check:schema:json": "for f in schema/*/schema.ts; do typescript-json-schema --defaultNumberType integer --required --skipLibCheck \"$f\" \"*\" | cat | cmp \"${f%ts}json\" - || exit 1; done",
+    "check:docs": "npm run check:docs:format && npm run check:docs:links",
+    "check:docs:format": "prettier --check \"**/*.{md,mdx}\"",
+    "check:docs:links": "cd docs && mintlify broken-links",
     "generate:json": "for f in schema/*/schema.ts; do typescript-json-schema --defaultNumberType integer --required --skipLibCheck \"$f\" \"*\" -o \"${f%ts}json\"; done",
-    "serve:docs": "cd docs && mintlify dev",
     "format": "prettier --write \"**/*.{md,mdx}\"",
-    "format:check": "prettier --check \"**/*.{md,mdx}\"",
-    "check-links": "cd docs && mintlify broken-links"
+    "serve:docs": "cd docs && mintlify dev"
   },
   "devDependencies": {
     "ajv": "^8.17.1",


### PR DESCRIPTION
Prior to this commit, we defined a `validate:schema` script to check schema TypeScript definitions, and a `format:check` script to check Markdown formatting with Prettier.  Also, we had CI-only action that checked whether `schema.json` files matched their `schema.ts`.

This commit makes the following changes:

* Introduce a `check:schema:json` that can be run locally to check that `schema.json` files matched their `schema.ts`.
* Rename `validate:schema` to `check:schema:ts` to match the above.
* Introduce a `check:docs:links` script to check links via Mintlify. This script can catch broken links like those fixed by #601.
* Rename `format:check` to `check:docs:format` to match the above.
* Introduce `check`, `check:schema`, and `check:doc` macro scripts.
