### PR TITLE
chore: add a note about client session ID handling

### DIFF
--- a/docs/specification/2025-03-26/basic/transports.mdx
+++ b/docs/specification/2025-03-26/basic/transports.mdx
@@ -188,6 +188,7 @@ servers which want to establish stateful sessions:
      securely generated UUID, a JWT, or a cryptographic hash).
    - The session ID **MUST** only contain visible ASCII characters (ranging from 0x21 to
      0x7E).
+   - The client **MUST** treat the session ID as a credential and handle it in a secure manner.
 2. If an `Mcp-Session-Id` is returned by the server during initialization, clients using
    the Streamable HTTP transport **MUST** include it in the `Mcp-Session-Id` header on
    all of their subsequent HTTP requests.

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -176,6 +176,7 @@ servers which want to establish stateful sessions:
      securely generated UUID, a JWT, or a cryptographic hash).
    - The session ID **MUST** only contain visible ASCII characters (ranging from 0x21 to
      0x7E).
+   - The client **MUST** treat the session ID as a credential and handle it in a secure manner.
 2. If an `Mcp-Session-Id` is returned by the server during initialization, clients using
    the Streamable HTTP transport **MUST** include it in the `Mcp-Session-Id` header on
    all of their subsequent HTTP requests.


### PR DESCRIPTION
Related issue: https://github.com/modelcontextprotocol-community/working-groups/issues/37

As feedback on my [session hijack](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/641) risk pr, updating  `security_best_practices.md`, it was suggested by @connor4312 that we add a note about client session ID handling, as due care is a requirement.

> It may be worth adding a bullet point under no.1 in [session management](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#session-management) like:
> 
> * The client MUST treat the session ID as a credential and handle it in a secure manner.
> 
> (I'm not sure if MUST/SHOULD verbiage is compatible with the fuzzy requirement of treating it in a 'secure manner')

I agree and have applied this change.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed
