### PR TITLE
feature: Async support using Resource

### DIFF
--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -20,6 +20,40 @@
             },
             "type": "object"
         },
+        "AsyncOperation": {
+            "description": "Information about an asynchronous operation.",
+            "properties": {
+                "errorMessage": {
+                    "description": "Error message if the operation failed.",
+                    "type": "string"
+                },
+                "expiryTime": {
+                    "description": "Time in seconds when the operation will expire.",
+                    "type": "integer"
+                },
+                "requestId": {
+                    "description": "The ID of the request that created this operation.",
+                    "type": [
+                        "string",
+                        "integer"
+                    ]
+                },
+                "resourceUri": {
+                    "description": "The URI of the resource that will contain the result when ready.",
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/OperationStatus",
+                    "description": "Current status of the operation."
+                }
+            },
+            "required": [
+                "requestId",
+                "resourceUri",
+                "status"
+            ],
+            "type": "object"
+        },
         "AudioContent": {
             "description": "Audio provided to or from an LLM.",
             "properties": {
@@ -92,6 +126,58 @@
             ],
             "type": "object"
         },
+        "CallToolAsyncRequest": {
+            "description": "Used by the client to invoke a tool asynchronously.",
+            "properties": {
+                "method": {
+                    "const": "tools/callAsync",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/definitions/CallToolAsyncRequestParams"
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "CallToolAsyncRequestParams": {
+            "description": "Parameters for calling a tool asynchronously.",
+            "properties": {
+                "arguments": {
+                    "additionalProperties": {},
+                    "description": "Arguments to pass to the tool.",
+                    "type": "object"
+                },
+                "keepAlive": {
+                    "description": "Number of seconds to keep the result available.",
+                    "type": "integer"
+                },
+                "name": {
+                    "description": "Name of the tool to call.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        },
+        "CallToolAsyncResult": {
+            "description": "The server's response to an asynchronous tool call request.",
+            "properties": {
+                "operation": {
+                    "$ref": "#/definitions/AsyncOperation",
+                    "description": "Information about the asynchronous operation."
+                }
+            },
+            "required": [
+                "operation"
+            ],
+            "type": "object"
+        },
         "CallToolRequest": {
             "description": "Used by the client to invoke a tool provided by the server.",
             "properties": {
@@ -161,6 +247,52 @@
             },
             "required": [
                 "content"
+            ],
+            "type": "object"
+        },
+        "CancelOperationRequest": {
+            "description": "Used by the client to cancel an operation.",
+            "properties": {
+                "method": {
+                    "const": "operations/cancel",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/definitions/CancelOperationRequestParams"
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "CancelOperationRequestParams": {
+            "description": "Parameters for cancelling an operation.",
+            "properties": {
+                "requestId": {
+                    "description": "The ID of the request to cancel.",
+                    "type": [
+                        "string",
+                        "integer"
+                    ]
+                }
+            },
+            "required": [
+                "requestId"
+            ],
+            "type": "object"
+        },
+        "CancelOperationResult": {
+            "description": "The server's response to an operation cancellation request.",
+            "properties": {
+                "operation": {
+                    "$ref": "#/definitions/AsyncOperation",
+                    "description": "The updated state of the operation."
+                }
+            },
+            "required": [
+                "operation"
             ],
             "type": "object"
         },
@@ -643,6 +775,52 @@
             "required": [
                 "enum",
                 "type"
+            ],
+            "type": "object"
+        },
+        "GetOperationRequest": {
+            "description": "Used by the client to check an operation's status.",
+            "properties": {
+                "method": {
+                    "const": "operations/get",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/definitions/GetOperationRequestParams"
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "GetOperationRequestParams": {
+            "description": "Parameters for getting the status of an operation.",
+            "properties": {
+                "requestId": {
+                    "description": "The ID of the request to check.",
+                    "type": [
+                        "string",
+                        "integer"
+                    ]
+                }
+            },
+            "required": [
+                "requestId"
+            ],
+            "type": "object"
+        },
+        "GetOperationResult": {
+            "description": "The server's response to an operation status check.",
+            "properties": {
+                "operation": {
+                    "$ref": "#/definitions/AsyncOperation",
+                    "description": "The current state of the operation."
+                }
+            },
+            "required": [
+                "operation"
             ],
             "type": "object"
         },
@@ -1401,6 +1579,18 @@
             ],
             "type": "object"
         },
+        "OperationStatus": {
+            "description": "The status of an asynchronous operation.",
+            "enum": [
+                "ACTIVE",
+                "DELETE_UNSUCCESSFUL",
+                "DELETING",
+                "FAILED",
+                "PENDING",
+                "UPDATING"
+            ],
+            "type": "string"
+        },
         "PaginatedRequest": {
             "properties": {
                 "method": {
@@ -1685,6 +1875,9 @@
                             },
                             {
                                 "$ref": "#/definitions/BlobResourceContents"
+                            },
+                            {
+                                "$ref": "#/definitions/ToolResultResourceContents"
                             }
                         ]
                     },
@@ -2359,6 +2552,29 @@
             },
             "required": [
                 "method"
+            ],
+            "type": "object"
+        },
+        "ToolResultResourceContents": {
+            "description": "Tool result contents of a resource.",
+            "properties": {
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "toolResult": {
+                    "$ref": "#/definitions/CallToolResult",
+                    "description": "The result of a tool call."
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "toolResult",
+                "uri"
             ],
             "type": "object"
         },

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -388,7 +388,7 @@ export interface ReadResourceRequest extends Request {
  * The server's response to a resources/read request from the client.
  */
 export interface ReadResourceResult extends Result {
-  contents: (TextResourceContents | BlobResourceContents)[];
+  contents: (TextResourceContents | BlobResourceContents | ToolResultResourceContents)[];
 }
 
 /**
@@ -685,6 +685,145 @@ export interface ListToolsRequest extends PaginatedRequest {
  */
 export interface ListToolsResult extends PaginatedResult {
   tools: Tool[];
+}
+
+/**
+ * The status of an asynchronous operation.
+ */
+export type OperationStatus = "PENDING" | "ACTIVE" | "UPDATING" | "FAILED" | "DELETING" | "DELETE_UNSUCCESSFUL";
+
+/**
+ * Information about an asynchronous operation.
+ */
+export interface AsyncOperation {
+  /**
+   * The ID of the request that created this operation.
+   */
+  requestId: string | number;
+  
+  /**
+   * Current status of the operation.
+   */
+  status: OperationStatus;
+  
+  /**
+   * The URI of the resource that will contain the result when ready.
+   */
+  resourceUri: string;
+  
+  /**
+   * Time in seconds when the operation will expire.
+   */
+  expiryTime?: number;
+  
+  /**
+   * Error message if the operation failed.
+   */
+  errorMessage?: string;
+}
+
+/**
+ * Tool result contents of a resource.
+ */
+export interface ToolResultResourceContents extends ResourceContents {
+  /**
+   * The result of a tool call.
+   */
+  toolResult: CallToolResult;
+}
+
+/**
+ * Parameters for calling a tool asynchronously.
+ */
+export interface CallToolAsyncRequestParams {
+  /**
+   * Name of the tool to call.
+   */
+  name: string;
+  
+  /**
+   * Arguments to pass to the tool.
+   */
+  arguments?: { [key: string]: unknown };
+  
+  /**
+   * Number of seconds to keep the result available.
+   */
+  keepAlive?: number;
+}
+
+/**
+ * Used by the client to invoke a tool asynchronously.
+ */
+export interface CallToolAsyncRequest {
+  method: "tools/callAsync";
+  params: CallToolAsyncRequestParams;
+}
+
+/**
+ * The server's response to an asynchronous tool call request.
+ */
+export interface CallToolAsyncResult {
+  /**
+   * Information about the asynchronous operation.
+   */
+  operation: AsyncOperation;
+}
+
+/**
+ * Parameters for getting the status of an operation.
+ */
+export interface GetOperationRequestParams {
+  /**
+   * The ID of the request to check.
+   */
+  requestId: string | number;
+}
+
+/**
+ * Used by the client to check an operation's status.
+ */
+export interface GetOperationRequest {
+  method: "operations/get";
+  params: GetOperationRequestParams;
+}
+
+/**
+ * The server's response to an operation status check.
+ */
+export interface GetOperationResult {
+  /**
+   * The current state of the operation.
+   */
+  operation: AsyncOperation;
+}
+
+/**
+ * Parameters for cancelling an operation.
+ */
+export interface CancelOperationRequestParams {
+  /**
+   * The ID of the request to cancel.
+   */
+  requestId: string | number;
+}
+
+/**
+ * Used by the client to cancel an operation.
+ */
+export interface CancelOperationRequest {
+  method: "operations/cancel";
+  params: CancelOperationRequestParams;
+}
+
+/**
+ * The server's response to an operation cancellation request.
+ */
+export interface CancelOperationResult {
+  /**
+   * The updated state of the operation.
+   */
+  operation: AsyncOperation;
 }
 
 /**


### PR DESCRIPTION
Added support for long-running operations by making use of `Resource` and it's subscribe/notify features. Some other approaches and discussions are out there already https://github.com/modelcontextprotocol/modelcontextprotocol/pull/617 and https://github.com/modelcontextprotocol/modelcontextprotocol/pull/549

## Motivation and Context
* Client → Server - CallToolAsyncRequest
* Server → Client - CallToolAsyncResult(AsyncOperation)
* Client → Server(poll) - GetOperationRequest
* Server → Client - GetOperationResult(resourceUri and status)
* Once status is ACTIVE → Client can read the resource using resourceUri

![pLN1Rjim3BtxAuYSEY1DxWPIr73Sma2N5ccwox23gh2EC5dI93bR4FJVHrbssWrU0lIINHoRv2CV7oNcsdbcVLFBnD2luC8mvI6N0fN_m_I8TeisIMOpA9NmWdcX5SncIOo5owik90MljNHJpgJCt4vns2jMunYOhPgQGjqOlYEQJ8ejlYOH19U4ZvbIo0cveXmjUeckaHxssg1jQwRGsk_xxzSaKTeZw92cOmbG_4BUa3Lm](https://github.com/user-attachments/assets/caefd790-ef3f-4032-b7d0-49e312479774)

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
Non breaking change

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
