### PR TITLE
move version header doc to transports

### DIFF
--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -138,15 +138,12 @@ supports. This **SHOULD** be the _latest_ version supported by the server.
 If the client does not support the version in the server's response, it **SHOULD**
 disconnect.
 
+<Note>
 If using HTTP, the client **MUST** include the `MCP-Protocol-Version:
-<protocol-version>` HTTP header during any subsequent requests to the MCP
-server, allowing the MCP server to respond based on the MCP protocol version. 
-
-The protocol version sent by the client **SHOULD** be the one negotiated during [initialization](https://modelcontextprotocol.io/specification/draft/basic/lifecycle#initialization).
-
-If the server receives a request with a missing, invalid, or unsupported
-MCP-Protocol-VERSION, it **MUST** respond with `400 Bad Request`.
-For example: `MCP-Protocol-Version: 2024-11-05`
+<protocol-version>` HTTP header on all subsequent requests to the MCP
+server.
+For details, see [the Protocol Version Header section in Transports](/specification/draft/basic/transports#protocol-version-header).
+</Note>
 #### Capability Negotiation
 
 Client and server capabilities establish which optional protocol features will be

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -237,6 +237,20 @@ sequenceDiagram
 
 ```
 
+### Protocol Version Header
+
+If using HTTP, the client **MUST** include the `MCP-Protocol-Version:
+<protocol-version>` HTTP header on all subsequent requests to the MCP
+server, allowing the MCP server to respond based on the MCP protocol version.
+
+The protocol version sent by the client **SHOULD** be the one [negotiated during 
+initialization](/specification/draft/basic/lifecycle#version-negotiation).
+
+For example: `MCP-Protocol-Version: 2025-03-26`
+
+If the server receives a request with a missing, invalid, or unsupported
+MCP-Protocol-VERSION, it **MUST** respond with `400 Bad Request`.
+
 ### Backwards Compatibility
 
 Clients and servers can maintain backwards compatibility with the deprecated [HTTP+SSE

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -243,7 +243,7 @@ If using HTTP, the client **MUST** include the `MCP-Protocol-Version:
 <protocol-version>` HTTP header on all subsequent requests to the MCP
 server, allowing the MCP server to respond based on the MCP protocol version.
 
-The protocol version sent by the client **SHOULD** be the one [negotiated during 
+The protocol version sent by the client **SHOULD** be the one [negotiated during
 initialization](/specification/draft/basic/lifecycle#version-negotiation).
 
 For example: `MCP-Protocol-Version: 2025-03-26`


### PR DESCRIPTION
Move new version header requirement originated in #548 to the HTTP Transport section, where it's more prominent. Add note and reference link to Lifecycle/Version Negotiation, where it was originally. (Change suggested by @halter73 [here](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/548#issuecomment-2946709354))

## Motivation and Context
> I think it fits better alongside the requirements for the Mcp-Session-Id header, and it would be less likely to get missed by transport authors.
