### PR TITLE
Add pointer to Streamable HTTP Transport in the User Guide

### DIFF
--- a/docs/docs/concepts/transports.mdx
+++ b/docs/docs/concepts/transports.mdx
@@ -129,6 +129,14 @@ Use stdio when:
 
 ### Server-Sent Events (SSE)
 
+<Warning>
+
+The SSE Transport has been [**replaced**](http://modelcontextprotocol.io/specification/2025-03-26/changelog#major-changes) with a more
+flexible [Streamable HTTP](http://modelcontextprotocol.io/specification/2025-03-26/basic/transports) transport. Refer to the [Specification](http://modelcontextprotocol.io/specification/2025-03-26/basic/transports)
+and latest SDKs for the most recent information.
+
+</Warning>
+
 SSE transport enables server-to-client streaming with HTTP POST requests for client-to-server communication.
 
 Use SSE when:


### PR DESCRIPTION
Add a warning box to the Concepts/Transports section of the User Guide to note that SSE has been replaced with Streamable HTTP.

## Motivation and Context

Indicate SSE Deprecation in UG whilst it is being updated.

## How Has This Been Tested?

Local serving

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist

- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
