### PR TITLE
add compatibility language to version header requirement

### DIFF
--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -243,13 +243,18 @@ If using HTTP, the client **MUST** include the `MCP-Protocol-Version:
 <protocol-version>` HTTP header on all subsequent requests to the MCP
 server, allowing the MCP server to respond based on the MCP protocol version.
 
+For example: `MCP-Protocol-Version: 2025-03-26`
+
 The protocol version sent by the client **SHOULD** be the one [negotiated during
 initialization](/specification/draft/basic/lifecycle#version-negotiation).
 
-For example: `MCP-Protocol-Version: 2025-03-26`
+For backwards compatibility, if the server does _not_ receive an `MCP-Protocol-Version`
+header, and has no other way to identify the version - for example, by relying on the
+protocol version negotiated during initialization - the server **SHOULD** assume protocol
+version `2025-03-26`.
 
-If the server receives a request with a missing, invalid, or unsupported
-MCP-Protocol-VERSION, it **MUST** respond with `400 Bad Request`.
+If the server receives a request with an invalid or unsupported
+`MCP-Protocol-Version`, it **MUST** respond with `400 Bad Request`.
 
 ### Backwards Compatibility
 


### PR DESCRIPTION
The original definition for the new version header requirement (#548, #658) breaks backward compatibility by requiring servers to reject requests from old clients. Here we add a compatibility condition that lets servers assume protocol version `03-26-2025` if the header is missing and the server has no other information about what protocol version the client is using.