### PR TITLE
Change link underline color

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -4,7 +4,7 @@
   "name": "Model Context Protocol",
   "colors": {
     "primary": "#09090b",
-    "light": "#FAFAFA",
+    "light": "#607F9F",
     "dark": "#09090b"
   },
   "favicon": "/favicon.svg",


### PR DESCRIPTION
Mintlify uses the theme's "light" color as the underline color for links in both light mode and dark mode.  Prior to this commit, our "light" color was set to `#FAFAFA`, which is indistinguishable from the background color in light mode, `#FFFFFF`.  Thus, in light mode, links were indistinguishable from bolded text.

To address the issue, this commit changes our "light" color to `#607F9F`.  The color was chosen by desaturating the default "light" color of the Willow theme, `#007FFF`:

    #007FFF == hsl(210, 100%, 50%) => hsl(210, 25%, 50%) == #607F9F

| Before | After |
| --- | --- |
| ![before-light](https://github.com/user-attachments/assets/30290e08-7fe7-4a00-b42e-f67846c89afe) | ![after-light](https://github.com/user-attachments/assets/5cff3412-b0cb-47b0-a17c-dc91236e67bb) |
| ![before-dark](https://github.com/user-attachments/assets/5838da8a-c078-4bde-a2b6-112204b28c26) | ![after-dark](https://github.com/user-attachments/assets/13b5d729-4726-4700-9863-8774bea07d2f) |

---

I do not have a color preference.  I chose the color in the most programmatic way that I could.

An alternative approach would be to explicitly style links in light mode to override Mintlify's application of the "light" color.
