### PR TITLE
docs: stdio transport - explicit use of stderr for logging

### DIFF
--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -26,8 +26,9 @@ In the **stdio** transport:
   to its standard output (`stdout`).
 - Messages are individual JSON-RPC requests, notifications, or responses.
 - Messages are delimited by newlines, and **MUST NOT** contain embedded newlines.
-- The server **MAY** write UTF-8 strings to its standard error (`stderr`) for logging
-  purposes. Clients **MAY** capture, forward, or ignore this logging.
+- The server **MAY** write UTF-8 strings to its standard error (`stderr`) for any
+  logging purposes including informational, debug, and error messages.
+- The client **MAY** capture, forward, or ignore the server's `stderr` output.
 - The server **MUST NOT** write anything to its `stdout` that is not a valid MCP message.
 - The client **MUST NOT** write anything to the server's `stdin` that is not a valid MCP
   message.
@@ -49,14 +50,10 @@ sequenceDiagram
 
 ## Streamable HTTP
 
-<Info>
-
-This replaces the [HTTP+SSE
+<Info>This replaces the [HTTP+SSE
 transport](/specification/2024-11-05/basic/transports#http-with-sse) from
 protocol version 2024-11-05. See the [backwards compatibility](#backwards-compatibility)
-guide below.
-
-</Info>
+guide below.</Info>
 
 In the **Streamable HTTP** transport, the server operates as an independent process that
 can handle multiple client connections. This transport uses HTTP POST and GET requests.
@@ -236,25 +233,6 @@ sequenceDiagram
     deactivate Server
 
 ```
-
-### Protocol Version Header
-
-If using HTTP, the client **MUST** include the `MCP-Protocol-Version:
-<protocol-version>` HTTP header on all subsequent requests to the MCP
-server, allowing the MCP server to respond based on the MCP protocol version.
-
-For example: `MCP-Protocol-Version: 2025-03-26`
-
-The protocol version sent by the client **SHOULD** be the one [negotiated during
-initialization](/specification/draft/basic/lifecycle#version-negotiation).
-
-For backwards compatibility, if the server does _not_ receive an `MCP-Protocol-Version`
-header, and has no other way to identify the version - for example, by relying on the
-protocol version negotiated during initialization - the server **SHOULD** assume protocol
-version `2025-03-26`.
-
-If the server receives a request with an invalid or unsupported
-`MCP-Protocol-Version`, it **MUST** respond with `400 Bad Request`.
 
 ### Backwards Compatibility
 


### PR DESCRIPTION
Small but explicit addition to the 'stdio' transport that makes it clear that servers may use `stderr` for all types of logging, including informational, debug and error messages.


## Motivation and Context

It is not immediately clear from the specification, and not clear from detailed reading, that the `stderr` stream for `stdio` servers can be used not only for errors messages, but for any logging.

The fact that `stderr` is essentially overloaded to be an output stream for the server is not immediately obvious, as it is a fairly non-conventional approach (although I understand why it has been adopted). This note makes it clear to implementors that it is an accepted pattern to use `stderr` as a log/output stream, and also to client implementors that they should _not_ assume that messages to `stderr` actually imply errors (for example, the MCP inspector could use this spec to decide to not show `stderr` in red, or at least note that the output might not indicate errors).

Logging informational / debug / error messages to stdout has become increasingly conventional in MCP servers but is not inutitive to new adopters, although the pattern has been used in many applications (e.g. the Docker daemon uses stderr for logging as stdout is used for container stdout).

(Evidence)
- https://github.com/modelcontextprotocol/modelcontextprotocol/issues/177

## How Has This Been Tested?

No functional changes.

## Breaking Changes

No breaking changes - this already appears to be a common pattter.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

- https://github.com/modelcontextprotocol/modelcontextprotocol/issues/177