### PR TITLE
Add optional `subscribable` field to Resource interface to indicate subscription support

### DIFF
--- a/docs/specification/draft/server/resources.mdx
+++ b/docs/specification/draft/server/resources.mdx
@@ -205,7 +205,12 @@ capability **SHOULD** send a notification:
 ### Subscriptions
 
 The protocol supports optional subscriptions to resource changes. Clients can subscribe
-to specific resources and receive notifications when they change:
+to specific resources and receive notifications when they change.
+
+Servers **MAY** indicate which resources support subscriptions by setting the `subscribable` 
+field to `true` in the resource definition. Clients **MAY** attempt 
+to subscribe to any resource regardless of this field's value. Servers will not send 
+notifications for resources that don't support updates.
 
 **Subscribe Request:**
 
@@ -231,6 +236,7 @@ to specific resources and receive notifications when they change:
   }
 }
 ```
+
 
 ## Message Flow
 
@@ -268,6 +274,7 @@ A resource definition includes:
 - `description`: Optional description
 - `mimeType`: Optional MIME type
 - `size`: Optional size in bytes
+- `subscribable`: Optional boolean indicating whether this resource supports update subscriptions.
 
 ### Resource Contents
 

--- a/docs/specification/draft/server/resources.mdx
+++ b/docs/specification/draft/server/resources.mdx
@@ -207,9 +207,9 @@ capability **SHOULD** send a notification:
 The protocol supports optional subscriptions to resource changes. Clients can subscribe
 to specific resources and receive notifications when they change.
 
-Servers **MAY** indicate which resources support subscriptions by setting the `subscribable` 
-field to `true` in the resource definition. Clients **MAY** attempt 
-to subscribe to any resource regardless of this field's value. Servers will not send 
+Servers **MAY** indicate which resources support subscriptions by setting the `subscribable`
+field to `true` in the resource definition. Clients **MAY** attempt
+to subscribe to any resource regardless of this field's value. Servers will not send
 notifications for resources that don't support updates.
 
 **Subscribe Request:**
@@ -236,7 +236,6 @@ notifications for resources that don't support updates.
   }
 }
 ```
-
 
 ## Message Flow
 

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -1765,6 +1765,10 @@
                     "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
                     "type": "integer"
                 },
+                "subscribable": {
+                    "description": "Whether this Resource supports subscriptions for updates.\n\nClients MAY attempt to subscribe to any resource regardless of this value. It can be used as a hint to improve\nuser experience by indicating which resources are likely to send update notifications.",
+                    "type": "boolean"
+                },
                 "uri": {
                     "description": "The URI of this resource.",
                     "format": "uri",

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -484,6 +484,15 @@ export interface Resource {
    * This can be used by Hosts to display file sizes and estimate context window usage.
    */
   size?: number;
+
+  /**
+   * Whether this Resource supports subscriptions for updates.
+   * 
+   * Clients MAY attempt to subscribe to any resource regardless of this value. It can be used as a hint to improve
+   * user experience by indicating which resources are likely to send update notifications.
+   * 
+   */
+  subscribable?: boolean;
 }
 
 /**


### PR DESCRIPTION
Add optional `subscribable` field to Resource interface to indicate subscription support. 

## Motivation and Context

Currently, clients must attempt to subscribe to resources without knowing if they support updates. This adds an optional hint field to help clients provide better UX by indicating which resources are likely to send update notifications.

## How Has This Been Tested?

N/A.

## Breaking Changes

No.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context

The existing `resource/subscribe` capability operates on a "best effort" basis - clients receive no confirmation when subscribing, and simply may or may not receive future notifications. This change complements that pattern by adding an optional hint field.

The `subscribable` field provides lightweight guidance without imposing new requirements:
- `true` indicates the resource supports subscriptions and will send update notifications.
- `false` indicates subscriptions are not supported for this resource (although subscribing is not an error).
- Omitted (undefined) maintains current behavior - clients may attempt subscriptions without knowing the outcome.

This maintains the protocol's flexible subscription model while giving clients additional information to improve user experience.
