### PR TITLE
Remove references to enumNames

### DIFF
--- a/docs/specification/draft/client/elicitation.mdx
+++ b/docs/specification/draft/client/elicitation.mdx
@@ -267,7 +267,6 @@ The schema is restricted to these primitive types:
      "title": "Display Name",
      "description": "Description text",
      "enum": ["option1", "option2", "option3"],
-     "enumNames": ["Option 1", "Option 2", "Option 3"]
    }
    ```
 

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -639,12 +639,6 @@
                     },
                     "type": "array"
                 },
-                "enumNames": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
                 "title": {
                     "type": "string"
                 },
@@ -2404,4 +2398,3 @@
         }
     }
 }
-

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -1303,7 +1303,6 @@ export interface EnumSchema {
   title?: string;
   description?: string;
   enum: string[];
-  enumNames?: string[];  // Display names for enum values
 }
 
 /**


### PR DESCRIPTION
Remove references to `enumNames` in documentation.

## Motivation and Context
`enumNames` is not part of the JSON Schema specification (it seems like it was a proposal for v5 that was rejected).
There was a discussion about it on [json-schema-org / json-schema-spec](https://github.com/json-schema-org/json-schema-spec/issues/57), the outcome of which was a recommendation to use `oneOf` with `const` if names are required

## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
