### PR TITLE
Update capabilities section to require full enumeration

### DIFF
--- a/docs/specification/draft/architecture/index.mdx
+++ b/docs/specification/draft/architecture/index.mdx
@@ -118,6 +118,15 @@ The Model Context Protocol uses a capability-based negotiation system where clie
 servers explicitly declare their supported features during initialization. Capabilities
 determine which protocol features and primitives are available during a session.
 
+<Info>
+  As of the 2025-03-26 draft, both client and server SHOULD enumerate all
+  features they support in their `capabilities` object, not just a minimal
+  subset. This enables each side to tailor requests and responses to the other's
+  capabilities. The set of capabilities is open/extensible. Clients SHOULD
+  include any server features they support (e.g., tools, resources) if relevant,
+  and vice versa.
+</Info>
+
 - Servers declare capabilities like resource subscriptions, tool support, and prompt
   templates
 - Clients declare capabilities like sampling support and notification handling

--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -150,25 +150,101 @@ For details, see [the Protocol Version Header section in Transports](/specificat
 Client and server capabilities establish which optional protocol features will be
 available during the session.
 
+<Info>
+  As of the 2025-03-26 draft, both client and server SHOULD enumerate all
+  features they support in their `capabilities` object, not just a minimal
+  subset. This enables each side to tailor requests and responses to the other's
+  capabilities (e.g., fallback to text if the client does not support embedded
+  resources). The set of capabilities is open/extensible. Clients SHOULD include
+  any server features they support (e.g., tools, resources) if relevant, and
+  vice versa.
+</Info>
+
 Key capabilities include:
 
-| Category | Capability     | Description                                                                        |
-| -------- | -------------- | ---------------------------------------------------------------------------------- |
-| Client   | `roots`        | Ability to provide filesystem [roots](/specification/draft/client/roots)           |
-| Client   | `sampling`     | Support for LLM [sampling](/specification/draft/client/sampling) requests          |
-| Client   | `elicitation`  | Support for server [elicitation](/specification/draft/client/elicitation) requests |
-| Client   | `experimental` | Describes support for non-standard experimental features                           |
-| Server   | `prompts`      | Offers [prompt templates](/specification/draft/server/prompts)                     |
-| Server   | `resources`    | Provides readable [resources](/specification/draft/server/resources)               |
-| Server   | `tools`        | Exposes callable [tools](/specification/draft/server/tools)                        |
-| Server   | `logging`      | Emits structured [log messages](/specification/draft/server/utilities/logging)     |
-| Server   | `experimental` | Describes support for non-standard experimental features                           |
+| Category | Capability     | Description                                                                                         |
+| -------- | -------------- | --------------------------------------------------------------------------------------------------- |
+| Client   | `roots`        | Ability to provide filesystem [roots](/specification/draft/client/roots)                            |
+| Client   | `sampling`     | Support for LLM [sampling](/specification/draft/client/sampling) requests                           |
+| Client   | `elicitation`  | Support for server [elicitation](/specification/draft/client/elicitation) requests                  |
+| Client   | `logging`      | Support for receiving [log messages](/specification/draft/server/utilities/logging) from the server |
+| Client   | `completions`  | Support for [argument autocompletion](/specification/draft/server/utilities/completion)             |
+| Client   | `prompts`      | Support for [prompt templates](/specification/draft/server/prompts)                                 |
+| Client   | `resources`    | Support for [resources](/specification/draft/server/resources)                                      |
+| Client   | `tools`        | Support for [tools](/specification/draft/server/tools)                                              |
+| Client   | `experimental` | Describes support for non-standard experimental features                                            |
+| Server   | `prompts`      | Offers [prompt templates](/specification/draft/server/prompts)                                      |
+| Server   | `resources`    | Provides readable [resources](/specification/draft/server/resources)                                |
+| Server   | `tools`        | Exposes callable [tools](/specification/draft/server/tools)                                         |
+| Server   | `logging`      | Emits structured [log messages](/specification/draft/server/utilities/logging)                      |
+| Server   | `roots`        | Offers [roots](/specification/draft/client/roots)                                                   |
+| Server   | `sampling`     | Offers [sampling](/specification/draft/client/sampling)                                             |
+| Server   | `elicitation`  | Offers [elicitation](/specification/draft/client/elicitation)                                       |
+| Server   | `completions`  | Offers [argument autocompletion](/specification/draft/server/utilities/completion)                  |
+| Server   | `experimental` | Describes support for non-standard experimental features                                            |
 
 Capability objects can describe sub-capabilities like:
 
-- `listChanged`: Support for list change notifications (for prompts, resources, and
-  tools)
+- `listChanged`: Support for list change notifications (for prompts, resources, and tools)
 - `subscribe`: Support for subscribing to individual items' changes (resources only)
+
+### Example: Full Capabilities Declaration
+
+Client `initialize` request:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2025-03-26",
+    "capabilities": {
+      "roots": { "listChanged": true },
+      "sampling": {},
+      "elicitation": {},
+      "logging": {},
+      "completions": {},
+      "prompts": { "listChanged": true },
+      "resources": { "subscribe": true, "listChanged": true },
+      "tools": { "listChanged": true },
+      "experimental": { "customFeature": {} }
+    },
+    "clientInfo": {
+      "name": "ExampleClient",
+      "version": "1.0.0"
+    }
+  }
+}
+```
+
+Server `initialize` response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": "2025-03-26",
+    "capabilities": {
+      "logging": {},
+      "prompts": { "listChanged": true },
+      "resources": { "subscribe": true, "listChanged": true },
+      "tools": { "listChanged": true },
+      "roots": { "listChanged": true },
+      "sampling": {},
+      "elicitation": {},
+      "completions": {},
+      "experimental": { "customServerFeature": {} }
+    },
+    "serverInfo": {
+      "name": "ExampleServer",
+      "version": "1.0.0"
+    },
+    "instructions": "Optional instructions for the client"
+  }
+}
+```
 
 ### Operation
 

--- a/docs/specification/draft/client/elicitation.mdx
+++ b/docs/specification/draft/client/elicitation.mdx
@@ -41,6 +41,15 @@ Applications **SHOULD**:
 
 ## Capabilities
 
+<Info>
+  As of the 2025-03-26 draft, clients SHOULD enumerate all features they support
+  in their `capabilities` object, not just a minimal subset. The set of
+  capabilities is open/extensible. Clients SHOULD include any server features
+  they support (e.g., tools, resources) if relevant, and vice versa. See
+  [discussion
+  #604](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/604).
+</Info>
+
 Clients that support elicitation **MUST** declare the `elicitation` capability during
 [initialization](/specification/draft/basic/lifecycle#initialization):
 

--- a/docs/specification/draft/server/prompts.mdx
+++ b/docs/specification/draft/server/prompts.mdx
@@ -27,6 +27,15 @@ model.
 
 ## Capabilities
 
+<Info>
+  As of the 2025-03-26 draft, servers SHOULD enumerate all features they support
+  in their `capabilities` object, not just a minimal subset. The set of
+  capabilities is open/extensible. Servers SHOULD include any client features
+  they support (e.g., roots, sampling, elicitation) if relevant, and vice versa.
+  See [discussion
+  #604](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/604).
+</Info>
+
 Servers that support prompts **MUST** declare the `prompts` capability during
 [initialization](/specification/draft/basic/lifecycle#initialization):
 

--- a/docs/specification/draft/server/resources.mdx
+++ b/docs/specification/draft/server/resources.mdx
@@ -29,6 +29,15 @@ interaction model.
 
 ## Capabilities
 
+<Info>
+  As of the 2025-03-26 draft, servers SHOULD enumerate all features they support
+  in their `capabilities` object, not just a minimal subset. The set of
+  capabilities is open/extensible. Servers SHOULD include any client features
+  they support (e.g., roots, sampling, elicitation) if relevant, and vice versa.
+  See [discussion
+  #604](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/604).
+</Info>
+
 Servers that support resources **MUST** declare the `resources` capability:
 
 ```json
@@ -317,7 +326,7 @@ need to map to an actual physical filesystem.
 
 MCP servers **MAY** identify file:// resources with an
 [XDG MIME type](https://specifications.freedesktop.org/shared-mime-info-spec/0.14/ar01s02.html#id-1.3.14),
-like `inode/directory`, to represent non-regular files (such as directories) that don’t
+like `inode/directory`, to represent non-regular files (such as directories) that don't
 otherwise have a standard MIME type.
 
 ### git://

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -35,6 +35,15 @@ Applications **SHOULD**:
 
 ## Capabilities
 
+<Info>
+  As of the 2025-03-26 draft, servers SHOULD enumerate all features they support
+  in their `capabilities` object, not just a minimal subset. The set of
+  capabilities is open/extensible. Servers SHOULD include any client features
+  they support (e.g., roots, sampling, elicitation) if relevant, and vice versa.
+  See [discussion
+  #604](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/604).
+</Info>
+
 Servers that support tools **MUST** declare the `tools` capability:
 
 ```json

--- a/docs/specification/draft/server/utilities/logging.mdx
+++ b/docs/specification/draft/server/utilities/logging.mdx
@@ -18,13 +18,14 @@ needs&mdash;the protocol itself does not mandate any specific user interaction m
 
 Servers that emit log message notifications **MUST** declare the `logging` capability:
 
-```json
-{
-  "capabilities": {
-    "logging": {}
-  }
-}
-```
+<Info>
+  As of the 2025-03-26 draft, servers SHOULD enumerate all features they support
+  in their `capabilities` object, not just a minimal subset. The set of
+  capabilities is open/extensible. Servers SHOULD include any client features
+  they support (e.g., roots, sampling, elicitation) if relevant, and vice versa.
+  See [discussion
+  #604](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/604).
+</Info>
 
 ## Log Levels
 

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -195,8 +195,15 @@
             "type": "object"
         },
         "ClientCapabilities": {
-            "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
+            "additionalProperties": {},
+            "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.\n\nClients SHOULD enumerate all features they support, not just a minimal subset. This enables servers to tailor responses to client capabilities (e.g., fallback to text if the client does not support embedded resources).\n\nThe set of capabilities is open/extensible. Clients SHOULD include any server features they support (e.g., tools, resources) if relevant, and vice versa.",
             "properties": {
+                "completions": {
+                    "additionalProperties": true,
+                    "description": "Present if the client supports argument autocompletion suggestions.",
+                    "properties": {},
+                    "type": "object"
+                },
                 "elicitation": {
                     "additionalProperties": true,
                     "description": "Present if the client supports elicitation from the server.",
@@ -210,6 +217,36 @@
                         "type": "object"
                     },
                     "description": "Experimental, non-standard capabilities that the client supports.",
+                    "type": "object"
+                },
+                "logging": {
+                    "additionalProperties": true,
+                    "description": "Present if the client supports receiving log messages from the server.",
+                    "properties": {},
+                    "type": "object"
+                },
+                "prompts": {
+                    "description": "Present if the client supports prompt templates.",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this client supports notifications for changes to the prompt list.",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
+                "resources": {
+                    "description": "Present if the client supports resources.",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether the client supports notifications for changes to the resource list.",
+                            "type": "boolean"
+                        },
+                        "subscribe": {
+                            "description": "Whether the client supports subscribing to resource updates.",
+                            "type": "boolean"
+                        }
+                    },
                     "type": "object"
                 },
                 "roots": {
@@ -226,6 +263,16 @@
                     "additionalProperties": true,
                     "description": "Present if the client supports sampling from an LLM.",
                     "properties": {},
+                    "type": "object"
+                },
+                "tools": {
+                    "description": "Present if the client supports tools.",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether the client supports notifications for changes to the tool list.",
+                            "type": "boolean"
+                        }
+                    },
                     "type": "object"
                 }
             },
@@ -1984,11 +2031,18 @@
             "type": "object"
         },
         "ServerCapabilities": {
-            "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
+            "additionalProperties": {},
+            "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.\n\nServers SHOULD enumerate all features they support, not just a minimal subset. This enables clients to tailor requests to server capabilities.\n\nThe set of capabilities is open/extensible. Servers SHOULD include any client features they support (e.g., roots, sampling, elicitation) if relevant, and vice versa.",
             "properties": {
                 "completions": {
                     "additionalProperties": true,
                     "description": "Present if the server supports argument autocompletion suggestions.",
+                    "properties": {},
+                    "type": "object"
+                },
+                "elicitation": {
+                    "additionalProperties": true,
+                    "description": "Present if the server supports elicitation from the client.",
                     "properties": {},
                     "type": "object"
                 },
@@ -2029,6 +2083,22 @@
                             "type": "boolean"
                         }
                     },
+                    "type": "object"
+                },
+                "roots": {
+                    "description": "Present if the server supports roots (e.g., for file system access).",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether the server supports notifications for changes to the roots list.",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
+                "sampling": {
+                    "additionalProperties": true,
+                    "description": "Present if the server supports sampling from an LLM.",
+                    "properties": {},
                     "type": "object"
                 },
                 "tools": {

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -201,6 +201,10 @@ export interface InitializedNotification extends Notification {
 
 /**
  * Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.
+ *
+ * Clients SHOULD enumerate all features they support, not just a minimal subset. This enables servers to tailor responses to client capabilities (e.g., fallback to text if the client does not support embedded resources).
+ *
+ * The set of capabilities is open/extensible. Clients SHOULD include any server features they support (e.g., tools, resources) if relevant, and vice versa.
  */
 export interface ClientCapabilities {
   /**
@@ -224,10 +228,57 @@ export interface ClientCapabilities {
    * Present if the client supports elicitation from the server.
    */
   elicitation?: object;
+  /**
+   * Present if the client supports receiving log messages from the server.
+   */
+  logging?: object;
+  /**
+   * Present if the client supports argument autocompletion suggestions.
+   */
+  completions?: object;
+  /**
+   * Present if the client supports prompt templates.
+   */
+  prompts?: {
+    /**
+     * Whether this client supports notifications for changes to the prompt list.
+     */
+    listChanged?: boolean;
+  };
+  /**
+   * Present if the client supports resources.
+   */
+  resources?: {
+    /**
+     * Whether the client supports subscribing to resource updates.
+     */
+    subscribe?: boolean;
+    /**
+     * Whether the client supports notifications for changes to the resource list.
+     */
+    listChanged?: boolean;
+  };
+  /**
+   * Present if the client supports tools.
+   */
+  tools?: {
+    /**
+     * Whether the client supports notifications for changes to the tool list.
+     */
+    listChanged?: boolean;
+  };
+  /**
+   * [Extensible] Any additional capabilities may be included.
+   */
+  [key: string]: unknown;
 }
 
 /**
  * Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.
+ *
+ * Servers SHOULD enumerate all features they support, not just a minimal subset. This enables clients to tailor requests to server capabilities.
+ *
+ * The set of capabilities is open/extensible. Servers SHOULD include any client features they support (e.g., roots, sampling, elicitation) if relevant, and vice versa.
  */
 export interface ServerCapabilities {
   /**
@@ -273,6 +324,27 @@ export interface ServerCapabilities {
      */
     listChanged?: boolean;
   };
+  /**
+   * Present if the server supports roots (e.g., for file system access).
+   */
+  roots?: {
+    /**
+     * Whether the server supports notifications for changes to the roots list.
+     */
+    listChanged?: boolean;
+  };
+  /**
+   * Present if the server supports sampling from an LLM.
+   */
+  sampling?: object;
+  /**
+   * Present if the server supports elicitation from the client.
+   */
+  elicitation?: object;
+  /**
+   * [Extensible] Any additional capabilities may be included.
+   */
+  [key: string]: unknown;
 }
 
 /**


### PR DESCRIPTION
## Motivation and Context

TL;DR: This updates the spec to this:

````
### Example: Full Capabilities Declaration

Client `initialize` request:

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "initialize",
  "params": {
    "protocolVersion": "2025-03-26",
    "capabilities": {
      "roots": { "listChanged": true },
      "sampling": {},
      "elicitation": {},
      "logging": {},
      "completions": {},
      "prompts": { "listChanged": true },
      "resources": { "subscribe": true, "listChanged": true },
      "tools": { "listChanged": true },
      "experimental": { "customFeature": {} }
    },
    "clientInfo": {
      "name": "ExampleClient",
      "version": "1.0.0"
    }
  }
}
```

Server `initialize` response:

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "protocolVersion": "2025-03-26",
    "capabilities": {
      "logging": {},
      "prompts": { "listChanged": true },
      "resources": { "subscribe": true, "listChanged": true },
      "tools": { "listChanged": true },
      "roots": { "listChanged": true },
      "sampling": {},
      "elicitation": {},
      "completions": {},
      "experimental": { "customServerFeature": {} }
    },
    "serverInfo": {
      "name": "ExampleServer",
      "version": "1.0.0"
    },
    "instructions": "Optional instructions for the client"
  }
}
```
````

This is for "progressive enhancement". For example, if a client doesn't support resources, then a tool should not respond with an embedded resource, but rather the value itself. But there's no way for a server to know whether a client supports resources without this change.

As the spec evolves and clients add support for more of the spec, there will always be features which the server/client may not support and for which a fallback may be appropriate.

## How Has This Been Tested?

I have not tested this, but I would expect SDKs update their mechanism to list client capabilities to include those within this spec.

## Breaking Changes

This adds some `SHOULD`s in places I think are appropriate.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/604
