### PR TITLE
added completions to the list of server capabilities (was missing)

### DIFF
--- a/docs/specification/2025-03-26/basic/lifecycle.mdx
+++ b/docs/specification/2025-03-26/basic/lifecycle.mdx
@@ -144,16 +144,17 @@ available during the session.
 
 Key capabilities include:
 
-| Category | Capability     | Description                                                                         |
-| -------- | -------------- | ----------------------------------------------------------------------------------- |
-| Client   | `roots`        | Ability to provide filesystem [roots](/specification/2025-03-26/client/roots)       |
-| Client   | `sampling`     | Support for LLM [sampling](/specification/2025-03-26/client/sampling) requests      |
-| Client   | `experimental` | Describes support for non-standard experimental features                            |
-| Server   | `prompts`      | Offers [prompt templates](/specification/2025-03-26/server/prompts)                 |
-| Server   | `resources`    | Provides readable [resources](/specification/2025-03-26/server/resources)           |
-| Server   | `tools`        | Exposes callable [tools](/specification/2025-03-26/server/tools)                    |
-| Server   | `logging`      | Emits structured [log messages](/specification/2025-03-26/server/utilities/logging) |
-| Server   | `experimental` | Describes support for non-standard experimental features                            |
+| Category | Capability     | Description                                                                              |
+| -------- | -------------- | ---------------------------------------------------------------------------------------- |
+| Client   | `roots`        | Ability to provide filesystem [roots](/specification/2025-03-26/client/roots)            |
+| Client   | `sampling`     | Support for LLM [sampling](/specification/2025-03-26/client/sampling) requests           |
+| Client   | `experimental` | Describes support for non-standard experimental features                                 |
+| Server   | `prompts`      | Offers [prompt templates](/specification/2025-03-26/server/prompts)                      |
+| Server   | `resources`    | Provides readable [resources](/specification/2025-03-26/server/resources)                |
+| Server   | `tools`        | Exposes callable [tools](/specification/2025-03-26/server/tools)                         |
+| Server   | `logging`      | Emits structured [log messages](/specification/2025-03-26/server/utilities/logging)      |
+| Server   | `completions`  | Supports argument [autocompletion](/specification/2025-03-26/server/utilites/completion) |
+| Server   | `experimental` | Describes support for non-standard experimental features                                 |
 
 Capability objects can describe sub-capabilities like:
 

--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -152,17 +152,18 @@ available during the session.
 
 Key capabilities include:
 
-| Category | Capability     | Description                                                                        |
-| -------- | -------------- | ---------------------------------------------------------------------------------- |
-| Client   | `roots`        | Ability to provide filesystem [roots](/specification/draft/client/roots)           |
-| Client   | `sampling`     | Support for LLM [sampling](/specification/draft/client/sampling) requests          |
-| Client   | `elicitation`  | Support for server [elicitation](/specification/draft/client/elicitation) requests |
-| Client   | `experimental` | Describes support for non-standard experimental features                           |
-| Server   | `prompts`      | Offers [prompt templates](/specification/draft/server/prompts)                     |
-| Server   | `resources`    | Provides readable [resources](/specification/draft/server/resources)               |
-| Server   | `tools`        | Exposes callable [tools](/specification/draft/server/tools)                        |
-| Server   | `logging`      | Emits structured [log messages](/specification/draft/server/utilities/logging)     |
-| Server   | `experimental` | Describes support for non-standard experimental features                           |
+| Category | Capability     | Description                                                                          |
+| -------- | -------------- | ------------------------------------------------------------------------------------ |
+| Client   | `roots`        | Ability to provide filesystem [roots](/specification/draft/client/roots)             |
+| Client   | `sampling`     | Support for LLM [sampling](/specification/draft/client/sampling) requests            |
+| Client   | `elicitation`  | Support for server [elicitation](/specification/draft/client/elicitation) requests   |
+| Client   | `experimental` | Describes support for non-standard experimental features                             |
+| Server   | `prompts`      | Offers [prompt templates](/specification/draft/server/prompts)                       |
+| Server   | `resources`    | Provides readable [resources](/specification/draft/server/resources)                 |
+| Server   | `tools`        | Exposes callable [tools](/specification/draft/server/tools)                          |
+| Server   | `logging`      | Emits structured [log messages](/specification/draft/server/utilities/logging)       |
+| Server   | `completions`  | Supports argument [autocompletion](/specification/draft/server/utilities/completion) |
+| Server   | `experimental` | Describes support for non-standard experimental features                             |
 
 Capability objects can describe sub-capabilities like:
 


### PR DESCRIPTION
Added `completions` capability to the Server lifecycle documentation.

## Motivation and Context

Documentation defect.

## How Has This Been Tested?

Local serving.

## Breaking Changes

No

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
