### PR TITLE
Clarify tool error categorization

### DIFF
--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -329,47 +329,48 @@ Providing an output schema helps clients and LLMs understand and properly handle
 
 Tools use two error reporting mechanisms:
 
-1. **Protocol Errors**: Standard JSON-RPC errors for issues like:
+1. **Protocol Errors**. Standard JSON-RPC errors for issues like:
 
-   - Unknown tools
-   - Invalid arguments
-   - Server errors
+   - Unknown tool — error code `-32602` ("Invalid params")
+   - Invalid request params — error code `-32602` ("Invalid params")
+   - Internal errors — error code `-32603` ("Internal error")
 
-2. **Tool Execution Errors**: Reported in tool results with `isError: true`:
+   Example error:
+
+   ```json
+   {
+     "jsonrpc": "2.0",
+     "id": 3,
+     "error": {
+       "code": -32602,
+       "message": "Unknown tool: invalid_tool_name"
+     }
+   }
+   ```
+
+2. **Tool Execution Errors**. Reported in tool results with `isError: true` for issues like:
+
    - API failures
    - Invalid input data
    - Business logic errors
 
-Example protocol error:
+   Example error:
 
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 3,
-  "error": {
-    "code": -32602,
-    "message": "Unknown tool: invalid_tool_name"
-  }
-}
-```
-
-Example tool execution error:
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 4,
-  "result": {
-    "content": [
-      {
-        "type": "text",
-        "text": "Failed to fetch weather data: API rate limit exceeded"
-      }
-    ],
-    "isError": true
-  }
-}
-```
+   ```json
+   {
+     "jsonrpc": "2.0",
+     "id": 4,
+     "result": {
+       "content": [
+         {
+           "type": "text",
+           "text": "Failed to fetch weather data: API rate limit exceeded"
+         }
+       ],
+       "isError": true
+     }
+   }
+   ```
 
 ## Security Considerations
 


### PR DESCRIPTION
Prior to this commit, the tools doc listed "Invalid arguments" as an example of a protocol error.  This was likely meant to refer to the arguments of the JSON-RPC request itself (i.e. `params`), rather than arguments of the tool (i.e. `params.arguments`).

This commit clarifies the wording as "Invalid request params", adds associated error codes (to match [`prompts.mdx`][]), and improves the section's formatting.

[`prompts.mdx`]: https://github.com/modelcontextprotocol/modelcontextprotocol/blob/8fe803b9085ed94be7dad5e4379b5fe773c4922e/docs/specification/draft/server/prompts.mdx?plain=1#L257-L259

Closes #290.
