### PR TITLE
Change `console.error` to a `console.log`

### DIFF
--- a/docs/quickstart/server.mdx
+++ b/docs/quickstart/server.mdx
@@ -693,7 +693,7 @@ Finally, implement the main function to run the server:
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("Weather MCP Server running on stdio");
+  console.log("Weather MCP Server running on stdio");
 }
 
 main().catch((error) => {


### PR DESCRIPTION
While looking at the basic example for an MCP server, I noticed that the "happy path" console log is being written with the `error` method instead of the `log` one

## Motivation and Context

An error log suggests this is not the expected outcome, which might confuse people in general

## How Has This Been Tested?

No testing needed

## Breaking Changes

None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

None