### PR TITLE
Remove temporary warning and update missed line

### DIFF
--- a/docs/docs/concepts/transports.mdx
+++ b/docs/docs/concepts/transports.mdx
@@ -129,14 +129,6 @@ Use stdio when:
 
 ### Streamable HTTP
 
-<Warning>
-
-The SSE Transport has been [**replaced**](http://modelcontextprotocol.io/specification/2025-03-26/changelog#major-changes) with a more
-flexible [Streamable HTTP](http://modelcontextprotocol.io/specification/2025-03-26/basic/transports) transport. Refer to the [Specification](http://modelcontextprotocol.io/specification/2025-03-26/basic/transports)
-and latest SDKs for the most recent information.
-
-</Warning>
-
 SSE transport enables server-to-client streaming with HTTP POST requests for client-to-server communication.
 
 Use Streamable HTTP when:

--- a/docs/docs/concepts/transports.mdx
+++ b/docs/docs/concepts/transports.mdx
@@ -129,7 +129,7 @@ Use stdio when:
 
 ### Streamable HTTP
 
-SSE transport enables server-to-client streaming with HTTP POST requests for client-to-server communication.
+The Streamable HTTP transport uses HTTP POST requests for client-to-server communication and optional Server-Sent Events (SSE) streams for server-to-client communication.
 
 Use Streamable HTTP when:
 


### PR DESCRIPTION
A couple more tweaks:

- Docs have been updated to reflect the latest streaming transports, so warning is no longer needed.
- Missed the first line still including original SSE reference.