### PR TITLE
Make Prettier ignore the table of client features

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -9,6 +9,8 @@ This page provides an overview of applications that support the Model Context Pr
 
 <div id="feature-support-matrix-wrapper">
 
+{/* prettier-ignore-start */}
+
 | Client                                           | [Resources] | [Prompts] | [Tools] | [Discovery][Discovery] | [Sampling] | Roots | Notes                                                                                           |
 | ------------------------------------------------ | ----------- | --------- | ------- | ---------------------- | ---------- | ----- | ----------------------------------------------------------------------------------------------- |
 | [5ire][5ire]                                     | ❌          | ❌        | ✅      | ❓                     | ❌         | ❌    | Supports tools.                                                                                 |
@@ -65,6 +67,8 @@ This page provides an overview of applications that support the Model Context Pr
 | [Witsy][Witsy]                                   | ❌          | ❌        | ✅      | ❓                     | ❌         | ❌    | Supports tools in Witsy.                                                                        |
 | [Zed][Zed]                                       | ❌          | ✅        | ❌      | ❌                     | ❌         | ❌    | Prompts appear as slash commands                                                                |
 | [Zencoder][Zencoder]                             | ❌          | ❌        | ✅      | ❌                     | ❌         | ❌    | Supports tools                                                                                  |
+
+{/* prettier-ignore-end */}
 
 [5ire]: https://github.com/nanbingxyz/5ire
 [AgentAI]: https://github.com/AdamStrojek/rust-agentai


### PR DESCRIPTION
This prevents Prettier from touching every line in the table when a new client is added with a description that is longer than previously existing descriptions.

For example, see [#706](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/706/commits/b21621fa2ce0d2974105f44376a9e064aa9f3a21).