### PR TITLE
spec: Adds _meta to additional interface types.

### DIFF
--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -27,6 +27,11 @@
         "AudioContent": {
             "description": "Audio provided to or from an LLM.",
             "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "Reserved field for additional metadata.",
+                    "type": "object"
+                },
                 "annotations": {
                     "$ref": "#/definitions/Annotations",
                     "description": "Optional annotations for the client."
@@ -54,6 +59,11 @@
         },
         "BlobResourceContents": {
             "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "Reserved field for additional metadata.",
+                    "type": "object"
+                },
                 "blob": {
                     "description": "A base64-encoded string representing the binary data of the item.",
                     "format": "byte",
@@ -616,6 +626,11 @@
         "EmbeddedResource": {
             "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
             "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "Reserved field for additional metadata.",
+                    "type": "object"
+                },
                 "annotations": {
                     "$ref": "#/definitions/Annotations",
                     "description": "Optional annotations for the client."
@@ -735,6 +750,11 @@
         "ImageContent": {
             "description": "An image provided to or from an LLM.",
             "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "Reserved field for additional metadata.",
+                    "type": "object"
+                },
                 "annotations": {
                     "$ref": "#/definitions/Annotations",
                     "description": "Optional annotations for the client."
@@ -964,6 +984,7 @@
                     "additionalProperties": {},
                     "properties": {
                         "_meta": {
+                            "additionalProperties": {},
                             "properties": {
                                 "progressToken": {
                                     "$ref": "#/definitions/ProgressToken",
@@ -1153,6 +1174,7 @@
                     "additionalProperties": {},
                     "properties": {
                         "_meta": {
+                            "additionalProperties": {},
                             "properties": {
                                 "progressToken": {
                                     "$ref": "#/definitions/ProgressToken",
@@ -1419,6 +1441,7 @@
                     "additionalProperties": {},
                     "properties": {
                         "_meta": {
+                            "additionalProperties": {},
                             "properties": {
                                 "progressToken": {
                                     "$ref": "#/definitions/ProgressToken",
@@ -1502,6 +1525,11 @@
         "Prompt": {
             "description": "A prompt or prompt template that the server offers.",
             "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "Reserved field for additional metadata.",
+                    "type": "object"
+                },
                 "arguments": {
                     "description": "A list of arguments to use for templating the prompt.",
                     "items": {
@@ -1665,6 +1693,7 @@
                     "additionalProperties": {},
                     "properties": {
                         "_meta": {
+                            "additionalProperties": {},
                             "properties": {
                                 "progressToken": {
                                     "$ref": "#/definitions/ProgressToken",
@@ -1692,6 +1721,11 @@
         "Resource": {
             "description": "A known resource that the server is capable of reading.",
             "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "Reserved field for additional metadata.",
+                    "type": "object"
+                },
                 "annotations": {
                     "$ref": "#/definitions/Annotations",
                     "description": "Optional annotations for the client."
@@ -1727,6 +1761,11 @@
         "ResourceContents": {
             "description": "The contents of a specific resource or sub-resource.",
             "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "Reserved field for additional metadata.",
+                    "type": "object"
+                },
                 "mimeType": {
                     "description": "The MIME type of this resource, if known.",
                     "type": "string"
@@ -1745,6 +1784,11 @@
         "ResourceLink": {
             "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of `resources/list` requests.",
             "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "Reserved field for additional metadata.",
+                    "type": "object"
+                },
                 "annotations": {
                     "$ref": "#/definitions/Annotations",
                     "description": "Optional annotations for the client."
@@ -1809,6 +1853,11 @@
         "ResourceTemplate": {
             "description": "A template description for resources available on the server.",
             "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "Reserved field for additional metadata.",
+                    "type": "object"
+                },
                 "annotations": {
                     "$ref": "#/definitions/Annotations",
                     "description": "Optional annotations for the client."
@@ -1905,6 +1954,11 @@
         "Root": {
             "description": "Represents a root directory or file that the server can operate on.",
             "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "Reserved field for additional metadata.",
+                    "type": "object"
+                },
                 "name": {
                     "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
                     "type": "string"
@@ -2195,6 +2249,11 @@
         "TextContent": {
             "description": "Text provided to or from an LLM.",
             "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "Reserved field for additional metadata.",
+                    "type": "object"
+                },
                 "annotations": {
                     "$ref": "#/definitions/Annotations",
                     "description": "Optional annotations for the client."
@@ -2216,6 +2275,11 @@
         },
         "TextResourceContents": {
             "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "Reserved field for additional metadata.",
+                    "type": "object"
+                },
                 "mimeType": {
                     "description": "The MIME type of this resource, if known.",
                     "type": "string"
@@ -2239,6 +2303,11 @@
         "Tool": {
             "description": "Definition for a tool the client can call.",
             "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "Reserved field for additional metadata.",
+                    "type": "object"
+                },
                 "annotations": {
                     "$ref": "#/definitions/ToolAnnotations",
                     "description": "Optional additional tool information."

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -30,6 +30,7 @@ export interface Request {
        * If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications.
        */
       progressToken?: ProgressToken;
+      [key: string]: unknown;
     };
     [key: string]: unknown;
   };
@@ -472,6 +473,11 @@ export interface Resource {
    * This can be used by Hosts to display file sizes and estimate context window usage.
    */
   size?: number;
+
+  /**
+   * Reserved field for additional metadata.
+   */
+  _meta?: { [key: string]: unknown };
 }
 
 /**
@@ -508,6 +514,11 @@ export interface ResourceTemplate {
    * Optional annotations for the client.
    */
   annotations?: Annotations;
+  
+  /**
+   * Reserved field for additional metadata.
+   */
+  _meta?: { [key: string]: unknown };
 }
 
 /**
@@ -524,6 +535,11 @@ export interface ResourceContents {
    * The MIME type of this resource, if known.
    */
   mimeType?: string;
+
+  /**
+   * Reserved field for additional metadata.
+   */
+  _meta?: { [key: string]: unknown };
 }
 
 export interface TextResourceContents extends ResourceContents {
@@ -601,6 +617,11 @@ export interface Prompt {
    * A list of arguments to use for templating the prompt.
    */
   arguments?: PromptArgument[];
+
+  /**
+   * Reserved field for additional metadata.
+   */
+  _meta?: { [key: string]: unknown };
 }
 
 /**
@@ -660,6 +681,11 @@ export interface EmbeddedResource {
    * Optional annotations for the client.
    */
   annotations?: Annotations;
+
+  /**
+   * Reserved field for additional metadata.
+   */
+  _meta?: { [key: string]: unknown };
 }
 /**
  * An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.
@@ -825,6 +851,11 @@ export interface Tool {
    * Optional additional tool information.
    */
   annotations?: ToolAnnotations;
+
+  /**
+   * Reserved field for additional metadata.
+   */
+  _meta?: { [key: string]: unknown };
 }
 
 /* Logging */
@@ -994,6 +1025,11 @@ export interface TextContent {
    * Optional annotations for the client.
    */
   annotations?: Annotations;
+
+  /**
+   * Reserved field for additional metadata.
+   */
+  _meta?: { [key: string]: unknown };
 }
 
 /**
@@ -1018,6 +1054,11 @@ export interface ImageContent {
    * Optional annotations for the client.
    */
   annotations?: Annotations;
+
+  /**
+   * Reserved field for additional metadata.
+   */
+  _meta?: { [key: string]: unknown };
 }
 
 /**
@@ -1042,6 +1083,11 @@ export interface AudioContent {
    * Optional annotations for the client.
    */
   annotations?: Annotations;
+
+  /**
+   * Reserved field for additional metadata.
+   */
+  _meta?: { [key: string]: unknown };
 }
 
 /**
@@ -1243,6 +1289,11 @@ export interface Root {
    * referencing the root in other parts of the application.
    */
   name?: string;
+
+  /**
+   * Reserved field for additional metadata.
+   */
+  _meta?: { [key: string]: unknown };
 }
 
 /**


### PR DESCRIPTION
This adds `_meta` on additional resource types throughout the specification, specifically those that appear as arrays in list results or multi-part content.

## Motivation and Context
See [discussion](https://github.com/orgs/modelcontextprotocol/discussions/419) for motivation.

## How Has This Been Tested?
Since this change merely adds additional optional inert metadata, it should be a safe non-breaking change for all existing clients and servers.

## Breaking Changes
**NONE**

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed