### PR TITLE
Fix broken link and false positives

### DIFF
--- a/docs/specification/2025-03-26/basic/lifecycle.mdx
+++ b/docs/specification/2025-03-26/basic/lifecycle.mdx
@@ -144,17 +144,17 @@ available during the session.
 
 Key capabilities include:
 
-| Category | Capability     | Description                                                                              |
-| -------- | -------------- | ---------------------------------------------------------------------------------------- |
-| Client   | `roots`        | Ability to provide filesystem [roots](/specification/2025-03-26/client/roots)            |
-| Client   | `sampling`     | Support for LLM [sampling](/specification/2025-03-26/client/sampling) requests           |
-| Client   | `experimental` | Describes support for non-standard experimental features                                 |
-| Server   | `prompts`      | Offers [prompt templates](/specification/2025-03-26/server/prompts)                      |
-| Server   | `resources`    | Provides readable [resources](/specification/2025-03-26/server/resources)                |
-| Server   | `tools`        | Exposes callable [tools](/specification/2025-03-26/server/tools)                         |
-| Server   | `logging`      | Emits structured [log messages](/specification/2025-03-26/server/utilities/logging)      |
-| Server   | `completions`  | Supports argument [autocompletion](/specification/2025-03-26/server/utilites/completion) |
-| Server   | `experimental` | Describes support for non-standard experimental features                                 |
+| Category | Capability     | Description                                                                               |
+| -------- | -------------- | ----------------------------------------------------------------------------------------- |
+| Client   | `roots`        | Ability to provide filesystem [roots](/specification/2025-03-26/client/roots)             |
+| Client   | `sampling`     | Support for LLM [sampling](/specification/2025-03-26/client/sampling) requests            |
+| Client   | `experimental` | Describes support for non-standard experimental features                                  |
+| Server   | `prompts`      | Offers [prompt templates](/specification/2025-03-26/server/prompts)                       |
+| Server   | `resources`    | Provides readable [resources](/specification/2025-03-26/server/resources)                 |
+| Server   | `tools`        | Exposes callable [tools](/specification/2025-03-26/server/tools)                          |
+| Server   | `logging`      | Emits structured [log messages](/specification/2025-03-26/server/utilities/logging)       |
+| Server   | `completions`  | Supports argument [autocompletion](/specification/2025-03-26/server/utilities/completion) |
+| Server   | `experimental` | Describes support for non-standard experimental features                                  |
 
 Capability objects can describe sub-capabilities like:
 

--- a/docs/specification/draft/changelog.mdx
+++ b/docs/specification/draft/changelog.mdx
@@ -11,17 +11,17 @@ the previous revision, [2025-03-26](/specification/2025-03-26).
 
 1. Removed support for JSON-RPC **[batching](https://www.jsonrpc.org/specification#batch)**
    (PR [#416](https://github.com/modelcontextprotocol/specification/pull/416))
-2. Added support for [structured tool output](server/tools#structured-content)
+2. Added support for [structured tool output](./server/tools#structured-content)
    (PR [#371](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/371))
-3. Classified MCP servers as [OAuth Resource Servers](basic/authorization#authorization-server-discovery),
+3. Classified MCP servers as [OAuth Resource Servers](./basic/authorization#authorization-server-discovery),
    adding protected resource metadata to discover the corresponding Authorization server.
    (PR [#338](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/338))
-4. Clarified [security considerations](basic/authorization#security-considerations) and best practices
-   in the authorization spec and in a new [security best practices page](basic/security_best_practices).
-5. Added support for **[elicitation](client/elicitation)**, enabling servers to request additional
+4. Clarified [security considerations](./basic/authorization#security-considerations) and best practices
+   in the authorization spec and in a new [security best practices page](./basic/security_best_practices).
+5. Added support for **[elicitation](./client/elicitation)**, enabling servers to request additional
    information from users during interactions.
    (PR [#382](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/382))
-6. Added support for **[resource links](/specification/draft/server/tools#resource-links)** in
+6. Added support for **[resource links](./server/tools#resource-links)** in
    tool call results. (PR [#603](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/603))
 
 ## Other schema changes

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -252,7 +252,7 @@ or data. In this case, the tool will return a URI that can be subscribed to or f
 
 #### Embedded Resources
 
-[Resources](resources) **MAY** be embedded to provide additional context
+[Resources](./resources) **MAY** be embedded to provide additional context
 or data using a suitable [URI scheme](./resources#common-uri-schemes). Servers that use embedded resources **SHOULD** implement the `resources` capability:
 
 ```json


### PR DESCRIPTION
This commit fixes the following [errors](https://github.com/modelcontextprotocol/modelcontextprotocol/actions/runs/15607888378/job/43961633953) from `npm run check:doc:links` (aka `mintlify broken-links`):

  ```
  Checking for broken links...

  specification/2025-03-26/basic/lifecycle.mdx
    /specification/2025-03-26/server/utilites/completion

  specification/draft/changelog.mdx
    server/tools#structured-content
    basic/authorization#authorization-server-discovery
    basic/authorization#security-considerations
    basic/security_best_practices
    client/elicitation

  specification/draft/server/tools.mdx
    resources

  7 broken links found.
  ```

The link in `specification/2025-03-26/basic/lifecycle.mdx` was legitimately broken ("utilites" => "utilities").  The remainder were not actually broken, but `mintlify broken-links` does not like unqualified relative paths, so this commit prefixes those with "./".
