### PR TITLE
Update elicitation to include the in-band sub-capability for future proofing

### DIFF
--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -64,7 +64,9 @@ The client **MUST** initiate this phase by sending an `initialize` request conta
         "listChanged": true
       },
       "sampling": {},
-      "elicitation": {}
+      "elicitation": {
+        "inBand": true
+      }
     },
     "clientInfo": {
       "name": "ExampleClient",

--- a/docs/specification/draft/client/elicitation.mdx
+++ b/docs/specification/draft/client/elicitation.mdx
@@ -49,10 +49,19 @@ Clients that support elicitation **MUST** declare the `elicitation` capability d
 ```json
 {
   "capabilities": {
-    "elicitation": {}
+    "elicitation": {
+      "inBand": true
+    }
   }
 }
 ```
+
+The `inBand` sub-capability indicates that the client can handle elicitation requests
+directly within the current session. This means the client can present user interfaces,
+collect user input or other data, and return responses to the server.
+
+The remainder of this document describes in-band elicitation. Future sub-capabilities may
+be added in the future.
 
 ## Protocol Messages
 

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -189,9 +189,13 @@
             "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
             "properties": {
                 "elicitation": {
-                    "additionalProperties": true,
                     "description": "Present if the client supports elicitation from the server.",
-                    "properties": {},
+                    "properties": {
+                        "inBand": {
+                            "description": "Whether the client supports in-band elicitation requests.",
+                            "type": "boolean"
+                        }
+                    },
                     "type": "object"
                 },
                 "experimental": {

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -211,7 +211,12 @@ export interface ClientCapabilities {
   /**
    * Present if the client supports elicitation from the server.
    */
-  elicitation?: object;
+  elicitation?: {
+    /**
+     * Whether the client supports in-band elicitation requests.
+     */
+    inBand?: boolean;
+  };
 }
 
 /**


### PR DESCRIPTION
There has been talk of extending elicitation in the future to support other use cases that are not in-band, schema-based forms. To do this, clients must be capable of indicating that they support various types or modes of elicitation.

This proposal creates an `inBand` sub-capability to encapsulate the existing behavior of elicitation. The core of the specification does not change.

## Motivation and Context

Adding this sub-capability will allow us to add other modes, such as `outOfBand`, more easily without breaking existing clients or server implementations. As discussed with @bhosmer-ant and @pcarleton 

## Breaking Changes

None. Seeks to prevent future breaking changes! 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

FYI @nbarbettini @siwachabhi 