### PR TITLE
add _meta key format guidance to schema.ts

### DIFF
--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -29,7 +29,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "annotations": {
@@ -78,7 +78,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "blob": {
@@ -157,7 +157,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "content": {
@@ -393,7 +393,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "completion": {
@@ -514,7 +514,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "content": {
@@ -611,7 +611,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "action": {
@@ -645,7 +645,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "annotations": {
@@ -745,7 +745,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "description": {
@@ -769,7 +769,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "annotations": {
@@ -857,7 +857,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "capabilities": {
@@ -894,7 +894,7 @@
                     "properties": {
                         "_meta": {
                             "additionalProperties": {},
-                            "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                            "description": "See \"Notes on _meta usage\", above.",
                             "type": "object"
                         }
                     },
@@ -976,7 +976,7 @@
                     "properties": {
                         "_meta": {
                             "additionalProperties": {},
-                            "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                            "description": "See \"Notes on _meta usage\", above.",
                             "type": "object"
                         }
                     },
@@ -1007,6 +1007,7 @@
                     "properties": {
                         "_meta": {
                             "additionalProperties": {},
+                            "description": "See \"Notes on _meta usage\", above.",
                             "properties": {
                                 "progressToken": {
                                     "$ref": "#/definitions/ProgressToken",
@@ -1074,7 +1075,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "nextCursor": {
@@ -1120,7 +1121,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "nextCursor": {
@@ -1166,7 +1167,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "nextCursor": {
@@ -1197,6 +1198,7 @@
                     "properties": {
                         "_meta": {
                             "additionalProperties": {},
+                            "description": "See \"Notes on _meta usage\", above.",
                             "properties": {
                                 "progressToken": {
                                     "$ref": "#/definitions/ProgressToken",
@@ -1219,7 +1221,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "roots": {
@@ -1261,7 +1263,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "nextCursor": {
@@ -1379,7 +1381,7 @@
                     "properties": {
                         "_meta": {
                             "additionalProperties": {},
-                            "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                            "description": "See \"Notes on _meta usage\", above.",
                             "type": "object"
                         }
                     },
@@ -1442,7 +1444,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "nextCursor": {
@@ -1464,6 +1466,7 @@
                     "properties": {
                         "_meta": {
                             "additionalProperties": {},
+                            "description": "See \"Notes on _meta usage\", above.",
                             "properties": {
                                 "progressToken": {
                                     "$ref": "#/definitions/ProgressToken",
@@ -1549,7 +1552,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "arguments": {
@@ -1614,7 +1617,7 @@
                     "properties": {
                         "_meta": {
                             "additionalProperties": {},
-                            "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                            "description": "See \"Notes on _meta usage\", above.",
                             "type": "object"
                         }
                     },
@@ -1696,7 +1699,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "contents": {
@@ -1728,6 +1731,7 @@
                     "properties": {
                         "_meta": {
                             "additionalProperties": {},
+                            "description": "See \"Notes on _meta usage\", above.",
                             "properties": {
                                 "progressToken": {
                                     "$ref": "#/definitions/ProgressToken",
@@ -1757,7 +1761,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "annotations": {
@@ -1801,7 +1805,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "mimeType": {
@@ -1824,7 +1828,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "annotations": {
@@ -1880,7 +1884,7 @@
                     "properties": {
                         "_meta": {
                             "additionalProperties": {},
-                            "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                            "description": "See \"Notes on _meta usage\", above.",
                             "type": "object"
                         }
                     },
@@ -1897,7 +1901,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "annotations": {
@@ -1983,7 +1987,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 }
             },
@@ -2002,7 +2006,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "name": {
@@ -2032,7 +2036,7 @@
                     "properties": {
                         "_meta": {
                             "additionalProperties": {},
-                            "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                            "description": "See \"Notes on _meta usage\", above.",
                             "type": "object"
                         }
                     },
@@ -2297,7 +2301,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "annotations": {
@@ -2323,7 +2327,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "mimeType": {
@@ -2351,7 +2355,7 @@
             "properties": {
                 "_meta": {
                     "additionalProperties": {},
-                    "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                    "description": "See \"Notes on _meta usage\", above.",
                     "type": "object"
                 },
                 "annotations": {
@@ -2469,7 +2473,7 @@
                     "properties": {
                         "_meta": {
                             "additionalProperties": {},
-                            "description": "Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.",
+                            "description": "See \"Notes on _meta usage\", above.",
                             "type": "object"
                         }
                     },

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -13,6 +13,31 @@ export const LATEST_PROTOCOL_VERSION = "DRAFT-2025-v2";
 export const JSONRPC_VERSION = "2.0";
 
 /**
+ * Notes on _meta usage:
+ * 
+ * The _meta property/parameter name is reserved by MCP to allow clients and servers 
+ * to attach additional metadata to their notifications.
+ * 
+ * Certain key names are reserved by MCP for protocol-level metadata, as specified below; 
+ * implementations must not make assumptions about values at these keys.
+ * 
+ * Definitions in this schema may additionally reserve particular names for 
+ * purpose-specific metadata, as declared in those definitions.
+ * 
+ * Key name format:
+ * 
+ * Valid _meta keys have two segments: an optional prefix and a name. 
+ * 
+ * Prefix: 
+ *   - If specified, the prefix must be a DNS subdomain: a series of DNS labels separated by dots (.), not longer than 253 characters in total, followed by a slash (/).
+ *   - The modelcontextprotocol.[*]/ and mcp.[*]/ prefixes are reserved for MCP use (where [*] stands for any top-level domain).
+ *
+ * Name:
+ *  - Unless empty, must begin and end with an alphanumeric character ([a-z0-9A-Z]),
+ *  - Could contain dashes (-), underscores (_), dots (.), and alphanumerics in between.
+ */
+
+/**
  * A progress token, used to associate progress notifications with the original request.
  */
 export type ProgressToken = string | number;
@@ -25,6 +50,9 @@ export type Cursor = string;
 export interface Request {
   method: string;
   params?: {
+    /**
+     * See "Notes on _meta usage", above.
+     */
     _meta?: {
       /**
        * If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications.
@@ -40,7 +68,7 @@ export interface Notification {
   method: string;
   params?: {
     /**
-     * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+     * See "Notes on _meta usage", above.
      */
     _meta?: { [key: string]: unknown };
     [key: string]: unknown;
@@ -49,7 +77,7 @@ export interface Notification {
 
 export interface Result {
   /**
-   * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+   * See "Notes on _meta usage", above.
    */
   _meta?: { [key: string]: unknown };
   [key: string]: unknown;
@@ -487,7 +515,7 @@ export interface Resource extends BaseMetadata {
   size?: number;
 
   /**
-   * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+   * See "Notes on _meta usage", above.
    */
   _meta?: { [key: string]: unknown };
 }
@@ -521,7 +549,7 @@ export interface ResourceTemplate extends BaseMetadata {
   annotations?: Annotations;
 
   /**
-   * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+   * See "Notes on _meta usage", above.
    */
   _meta?: { [key: string]: unknown };
 }
@@ -542,7 +570,7 @@ export interface ResourceContents {
   mimeType?: string;
 
   /**
-   * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+   * See "Notes on _meta usage", above.
    */
   _meta?: { [key: string]: unknown };
 }
@@ -620,7 +648,7 @@ export interface Prompt extends BaseMetadata {
   arguments?: PromptArgument[];
 
   /**
-   * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+   * See "Notes on _meta usage", above.
    */
   _meta?: { [key: string]: unknown };
 }
@@ -680,7 +708,7 @@ export interface EmbeddedResource {
   annotations?: Annotations;
 
   /**
-   * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+   * See "Notes on _meta usage", above.
    */
   _meta?: { [key: string]: unknown };
 }
@@ -847,7 +875,7 @@ export interface Tool extends BaseMetadata {
   annotations?: ToolAnnotations;
 
   /**
-   * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+   * See "Notes on _meta usage", above.
    */
   _meta?: { [key: string]: unknown };
 }
@@ -1021,7 +1049,7 @@ export interface TextContent {
   annotations?: Annotations;
 
   /**
-   * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+   * See "Notes on _meta usage", above.
    */
   _meta?: { [key: string]: unknown };
 }
@@ -1050,7 +1078,7 @@ export interface ImageContent {
   annotations?: Annotations;
 
   /**
-   * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+   * See "Notes on _meta usage", above.
    */
   _meta?: { [key: string]: unknown };
 }
@@ -1079,7 +1107,7 @@ export interface AudioContent {
   annotations?: Annotations;
 
   /**
-   * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+   * See "Notes on _meta usage", above.
    */
   _meta?: { [key: string]: unknown };
 }
@@ -1281,7 +1309,7 @@ export interface Root {
   name?: string;
 
   /**
-   * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+   * See "Notes on _meta usage", above.
    */
   _meta?: { [key: string]: unknown };
 }


### PR DESCRIPTION
To accompany the expanded presence of the `_meta` property in the schema, add language to `schema.ts` which 
* specifies a key name format (patterned after [kubernetes labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)
* reserves certain key ranges for MCP protocol use

## Additional context
Couldn't find an obvious/good place to add this in the docs themselves, as `_meta` is cross-cutting and the current doc structure lacks a home for such things atm. Adding to the schema file for now.