### PR TITLE
Update `npx` target for inspector command

### DIFF
--- a/docs/docs/tools/inspector.mdx
+++ b/docs/docs/tools/inspector.mdx
@@ -30,7 +30,7 @@ A common way to start server packages from [NPM](https://npmjs.com) or [PyPi](ht
 ```bash
 npx -y @modelcontextprotocol/inspector npx <package-name> <args>
 # For example
-npx -y @modelcontextprotocol/inspector npx server-postgres postgres://127.0.0.1/testdb
+npx -y @modelcontextprotocol/inspector npx @modelcontextprotocol/server-filesystem /Users/username/Desktop
 ```
 
   </Tab>


### PR DESCRIPTION
The referenced `server-postgres` package does not exist and was likely intended to be `@modelcontextprotocol/server-postgres`.  However, the `@modelcontextprotocol/server-postgres` package has now been moved to "archived" status.  Therefore, this commit updates the `npx` target to `@modelcontextprotocol/server-filesystem`.

Closes #462
