### PR TITLE
docs: fix improper usage of the term "endpoint"

### DIFF
--- a/docs/docs/concepts/prompts.mdx
+++ b/docs/docs/concepts/prompts.mdx
@@ -41,7 +41,7 @@ Each prompt is defined with:
 
 ## Discovering prompts
 
-Clients can discover available prompts through the `prompts/list` endpoint:
+Clients can discover available prompts by sending a `prompts/list` request:
 
 ```typescript
 // Request

--- a/docs/docs/concepts/resources.mdx
+++ b/docs/docs/concepts/resources.mdx
@@ -78,7 +78,7 @@ Clients can discover available resources through two main methods:
 
 ### Direct resources
 
-Servers expose a list of concrete resources via the `resources/list` endpoint. Each resource includes:
+Servers expose a list of resources via the `resources/list` request. Each resource includes:
 
 ```typescript
 {

--- a/docs/docs/concepts/tools.mdx
+++ b/docs/docs/concepts/tools.mdx
@@ -15,8 +15,8 @@ Tools are designed to be **model-controlled**, meaning that tools are exposed fr
 
 Tools in MCP allow servers to expose executable functions that can be invoked by clients and used by LLMs to perform actions. Key aspects of tools include:
 
-- **Discovery**: Clients can list available tools through the `tools/list` endpoint
-- **Invocation**: Tools are called using the `tools/call` endpoint, where servers perform the requested operation and return results
+- **Discovery**: Clients can obtain a list of available tools by sending a `tools/list` request
+- **Invocation**: Tools are called using the `tools/call` request, where servers perform the requested operation and return results
 - **Flexibility**: Tools can range from simple calculations to complex API interactions
 
 Like [resources](/docs/concepts/resources), tools are identified by unique names and can include descriptions to guide their usage. However, unlike resources, tools represent dynamic operations that can modify state or interact with external systems.


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

The "concepts" section of the User Guide docs uses the word "endpoint" when discussing different message types, which is formally incorrect and potentially misleading/confusing. In this PR, I replace usages like "calling the `tools/list` endpoint" with "sending a `tools/list request`.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
MCP transports generally have roughly one endpoint, although that endpoint accepts different messages/requests. These terms should not be conflated.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
N/A

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
