### PR TITLE
chore: Follow-up on `RFC8707` in authorization.mdx

### DIFF
--- a/docs/specification/draft/basic/authorization.mdx
+++ b/docs/specification/draft/basic/authorization.mdx
@@ -204,23 +204,16 @@ to explicitly specify the target resource for which the token is being requested
 
 For the purposes of this specification, the canonical URI of an MCP server is defined as the resource identifier as specified in
 [RFC 8707 Section 2](https://www.rfc-editor.org/rfc/rfc8707.html#section-2) and aligns with the `resource` parameter in
-[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728). This URI:
-
-1. **MUST** be an absolute URI, as specified by [Section 4.3 of RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-4.3).
-1. **MUST** include the fully qualified domain name (FQDN) of the server.
-1. **MUST** include any non-default port if applicable (e.g., `https://mcp.example.com:8443`).
-1. **MUST NOT** include a fragment component.
-1. **SHOULD** use lowercase for the scheme and host components as per [RFC 3986 Section 6.2.2.1](https://www.rfc-editor.org/rfc/rfc3986#section-6.2.2.1), which defines this as the canonical form for comparison purposes.
-1. **SHOULD NOT** include a query component unless necessary for MCP server identification.
-1. **SHOULD NOT** include path components beyond what is necessary to uniquely identify the MCP server.
+[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728).
 
 MCP clients **SHOULD** provide the most specific URI that they can for the MCP server they intend to access, following the guidance in [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707). While the canonical form uses lowercase scheme and host components, implementations **SHOULD** accept uppercase scheme and host components for robustness and interoperability.
 
 Examples of valid canonical URIs:
 
+- `https://mcp.example.com/mcp`
 - `https://mcp.example.com`
 - `https://mcp.example.com:8443`
-- `https://mcp.example.com/server` (when path component is necessary to identify individual MCP server)
+- `https://mcp.example.com/server/mcp` (when path component is necessary to identify individual MCP server)
 
 Examples of invalid canonical URIs:
 


### PR DESCRIPTION
Per https://github.com/modelcontextprotocol/modelcontextprotocol/pull/734#discussion_r2150768593