### PR TITLE
feat: Add differential sync support via changedIds and get methods

### DIFF
--- a/docs/specification/draft/changelog.mdx
+++ b/docs/specification/draft/changelog.mdx
@@ -23,6 +23,11 @@ the previous revision, [2025-03-26](/specification/2025-03-26).
    (PR [#382](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/382))
 6. Added support for **[resource links](/specification/draft/server/tools#resource-links)** in
    tool call results. (PR [#603](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/603))
+7. Added support for **differential synchronization** with `get` methods and `changedIds` notifications:
+   - Added [`tools/get`](/specification/draft/server/tools#getting-a-tool) method to retrieve individual tool definitions
+   - Added [`resources/get`](/specification/draft/server/resources#getting-resource-metadata) method to retrieve individual resource metadata
+   - Added [`prompts/getDefinition`](/specification/draft/server/prompts#getting-a-prompt-definition) method to retrieve individual prompt definitions
+   - Enhanced `*_list_changed` notifications with optional `changedIds` parameter for efficient sync
 
 ## Other schema changes
 

--- a/docs/specification/draft/changelog.mdx
+++ b/docs/specification/draft/changelog.mdx
@@ -28,6 +28,11 @@ the previous revision, [2025-03-26](/specification/2025-03-26).
    - Added [`resources/get`](/specification/draft/server/resources#getting-resource-metadata) method to retrieve individual resource metadata
    - Added [`prompts/getDefinition`](/specification/draft/server/prompts#getting-a-prompt-definition) method to retrieve individual prompt definitions
    - Enhanced `*_list_changed` notifications with optional `changedIds` parameter for efficient sync
+8. Added support for **batch retrieval** in list methods to avoid N+1 query problems:
+   - Enhanced [`tools/list`](/specification/draft/server/tools#listing-tools) with optional `names` parameter for batch retrieval
+   - Enhanced [`resources/list`](/specification/draft/server/resources#listing-resources) with optional `uris` parameter for batch retrieval
+   - Enhanced [`prompts/list`](/specification/draft/server/prompts#listing-prompts) with optional `names` parameter for batch retrieval
+   - Added `listByIds` capability flags for servers to advertise batch retrieval support
 
 ## Other schema changes
 

--- a/docs/specification/draft/server/prompts.mdx
+++ b/docs/specification/draft/server/prompts.mdx
@@ -37,7 +37,8 @@ Servers that support prompts **MUST** declare the `prompts` capability during
   "capabilities": {
     "prompts": {
       "listChanged": true,
-      "getDefinition": true
+      "getDefinition": true,
+      "listByIds": true
     }
   }
 }
@@ -45,6 +46,7 @@ Servers that support prompts **MUST** declare the `prompts` capability during
 
 - `listChanged` indicates whether the server will emit notifications when the list of available prompts changes.
 - `getDefinition` indicates whether the server supports retrieving individual prompt definitions.
+- `listByIds` indicates whether the server supports retrieving multiple prompts by name in a single list request.
 
 ## Protocol Messages
 
@@ -65,6 +67,27 @@ supports [pagination](/specification/draft/server/utilities/pagination).
   }
 }
 ```
+
+**Batch Retrieval Request:**
+
+If the server supports the `listByIds` capability, clients can request specific prompts by name:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "prompts/list",
+  "params": {
+    "names": ["code_review", "explain_error"]
+  }
+}
+```
+
+When `names` is provided:
+- The server returns only the requested prompts that exist
+- Any `cursor` parameter in the request SHOULD be ignored
+- The response MUST NOT include `nextCursor` (as this is not a paginated operation)
+- Non-existent prompts are silently omitted from the response
 
 **Response:**
 

--- a/docs/specification/draft/server/prompts.mdx
+++ b/docs/specification/draft/server/prompts.mdx
@@ -36,14 +36,15 @@ Servers that support prompts **MUST** declare the `prompts` capability during
 {
   "capabilities": {
     "prompts": {
-      "listChanged": true
+      "listChanged": true,
+      "getDefinition": true
     }
   }
 }
 ```
 
-`listChanged` indicates whether the server will emit notifications when the list of
-available prompts changes.
+- `listChanged` indicates whether the server will emit notifications when the list of available prompts changes.
+- `getDefinition` indicates whether the server supports retrieving individual prompt definitions.
 
 ## Protocol Messages
 
@@ -133,6 +134,50 @@ auto-completed through [the completion API](/specification/draft/server/utilitie
 }
 ```
 
+### Getting a Prompt Definition
+
+To retrieve a specific prompt definition without expanding it, clients send a `prompts/getDefinition` request. This method requires the server to declare the `getDefinition` capability:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "prompts/getDefinition",
+  "params": {
+    "name": "code_review"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "prompt": {
+      "name": "code_review",
+      "title": "Request Code Review",
+      "description": "Asks the LLM to analyze code quality and suggest improvements",
+      "arguments": [
+        {
+          "name": "code",
+          "description": "The code to review",
+          "required": true
+        }
+      ]
+    }
+  }
+}
+```
+
+<Note>
+This method returns only the prompt definition, not the expanded messages. To get the expanded prompt with messages, use `prompts/get`.
+</Note>
+
 ### List Changed Notification
 
 When the list of available prompts changes, servers that declared the `listChanged`
@@ -144,6 +189,20 @@ capability **SHOULD** send a notification:
   "method": "notifications/prompts/list_changed"
 }
 ```
+
+If the server also supports the `getDefinition` capability, it **MAY** include a `changedIds` parameter to enable efficient differential synchronization:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/prompts/list_changed",
+  "params": {
+    "changedIds": ["code_review", "explain_error"]
+  }
+}
+```
+
+When `changedIds` is provided, clients can use `prompts/getDefinition` to fetch only the changed prompt definitions instead of re-fetching the entire list.
 
 ## Message Flow
 
@@ -160,11 +219,18 @@ sequenceDiagram
     Client->>Server: prompts/get
     Server-->>Client: Prompt content
 
-    opt listChanged
+    opt listChanged (full refresh)
       Note over Client,Server: Changes
       Server--)Client: prompts/list_changed
       Client->>Server: prompts/list
       Server-->>Client: Updated prompts
+    end
+
+    opt listChanged with getDefinition (differential sync)
+      Note over Client,Server: Changes
+      Server--)Client: prompts/list_changed with changedIds
+      Client->>Server: prompts/getDefinition (for each changed ID)
+      Server-->>Client: Individual prompt definitions
     end
 ```
 

--- a/docs/specification/draft/server/resources.mdx
+++ b/docs/specification/draft/server/resources.mdx
@@ -38,21 +38,22 @@ Servers that support resources **MUST** declare the `resources` capability:
   "capabilities": {
     "resources": {
       "subscribe": true,
-      "listChanged": true
+      "listChanged": true,
+      "get": true
     }
   }
 }
 ```
 
-The capability supports two optional features:
+The capability supports three optional features:
 
 - `subscribe`: whether the client can subscribe to be notified of changes to individual
   resources.
 - `listChanged`: whether the server will emit notifications when the list of available
   resources changes.
+- `get`: whether the server supports retrieving individual resource metadata.
 
-Both `subscribe` and `listChanged` are optional&mdash;servers can support neither,
-either, or both:
+All three features are optional&mdash;servers can support any combination:
 
 ```json
 {
@@ -160,6 +161,45 @@ To retrieve resource contents, clients send a `resources/read` request:
 }
 ```
 
+### Getting Resource Metadata
+
+To retrieve metadata for a specific resource, clients send a `resources/get` request. This method requires the server to declare the `get` capability:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "resources/get",
+  "params": {
+    "uri": "file:///project/src/main.rs"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "resource": {
+      "uri": "file:///project/src/main.rs",
+      "name": "main.rs",
+      "title": "Rust Software Application Main File",
+      "description": "Primary application entry point",
+      "mimeType": "text/x-rust"
+    }
+  }
+}
+```
+
+<Note>
+This method returns only the resource metadata, not the content. To read the actual content, use `resources/read`.
+</Note>
+
 ### Resource Templates
 
 Resource templates allow servers to expose parameterized resources using
@@ -207,6 +247,20 @@ capability **SHOULD** send a notification:
   "method": "notifications/resources/list_changed"
 }
 ```
+
+If the server also supports the `get` capability, it **MAY** include a `changedIds` parameter to enable efficient differential synchronization:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/resources/list_changed",
+  "params": {
+    "changedIds": ["file:///project/src/main.rs", "file:///project/src/lib.rs"]
+  }
+}
+```
+
+When `changedIds` is provided, clients can use `resources/get` to fetch only the changed resource metadata instead of re-fetching the entire list.
 
 ### Subscriptions
 

--- a/docs/specification/draft/server/resources.mdx
+++ b/docs/specification/draft/server/resources.mdx
@@ -39,21 +39,23 @@ Servers that support resources **MUST** declare the `resources` capability:
     "resources": {
       "subscribe": true,
       "listChanged": true,
-      "get": true
+      "get": true,
+      "listByIds": true
     }
   }
 }
 ```
 
-The capability supports three optional features:
+The capability supports four optional features:
 
 - `subscribe`: whether the client can subscribe to be notified of changes to individual
   resources.
 - `listChanged`: whether the server will emit notifications when the list of available
   resources changes.
 - `get`: whether the server supports retrieving individual resource metadata.
+- `listByIds`: whether the server supports retrieving multiple resources by URI in a single list request.
 
-All three features are optional&mdash;servers can support any combination:
+All four features are optional&mdash;servers can support any combination:
 
 ```json
 {
@@ -102,6 +104,27 @@ supports [pagination](/specification/draft/server/utilities/pagination).
   }
 }
 ```
+
+**Batch Retrieval Request:**
+
+If the server supports the `listByIds` capability, clients can request specific resources by URI:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "resources/list",
+  "params": {
+    "uris": ["file:///project/src/main.rs", "file:///project/src/lib.rs"]
+  }
+}
+```
+
+When `uris` is provided:
+- The server returns only the requested resources that exist
+- Any `cursor` parameter in the request SHOULD be ignored
+- The response MUST NOT include `nextCursor` (as this is not a paginated operation)
+- Non-existent resources are silently omitted from the response
 
 **Response:**
 

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -44,7 +44,8 @@ Servers that support tools **MUST** declare the `tools` capability:
   "capabilities": {
     "tools": {
       "listChanged": true,
-      "get": true
+      "get": true,
+      "listByIds": true
     }
   }
 }
@@ -52,6 +53,7 @@ Servers that support tools **MUST** declare the `tools` capability:
 
 - `listChanged` indicates whether the server will emit notifications when the list of available tools changes.
 - `get` indicates whether the server supports retrieving individual tool definitions.
+- `listByIds` indicates whether the server supports retrieving multiple tools by name in a single list request.
 
 ## Protocol Messages
 
@@ -72,6 +74,27 @@ To discover available tools, clients send a `tools/list` request. This operation
   }
 }
 ```
+
+**Batch Retrieval Request:**
+
+If the server supports the `listByIds` capability, clients can request specific tools by name:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/list",
+  "params": {
+    "names": ["get_weather", "calculate_tax"]
+  }
+}
+```
+
+When `names` is provided:
+- The server returns only the requested tools that exist
+- Any `cursor` parameter in the request SHOULD be ignored
+- The response MUST NOT include `nextCursor` (as this is not a paginated operation)
+- Non-existent tools are silently omitted from the response
 
 **Response:**
 

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -43,14 +43,15 @@ Servers that support tools **MUST** declare the `tools` capability:
 {
   "capabilities": {
     "tools": {
-      "listChanged": true
+      "listChanged": true,
+      "get": true
     }
   }
 }
 ```
 
-`listChanged` indicates whether the server will emit notifications when the list of
-available tools changes.
+- `listChanged` indicates whether the server will emit notifications when the list of available tools changes.
+- `get` indicates whether the server supports retrieving individual tool definitions.
 
 ## Protocol Messages
 
@@ -139,6 +140,49 @@ To invoke a tool, clients send a `tools/call` request:
 }
 ```
 
+### Getting a Tool
+
+To retrieve a specific tool definition, clients send a `tools/get` request. This method requires the server to declare the `get` capability:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "tools/get",
+  "params": {
+    "name": "get_weather"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "tool": {
+      "name": "get_weather",
+      "title": "Weather Information Provider",
+      "description": "Get current weather information for a location",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "location": {
+            "type": "string",
+            "description": "City name or zip code"
+          }
+        },
+        "required": ["location"]
+      }
+    }
+  }
+}
+```
+
 ### List Changed Notification
 
 When the list of available tools changes, servers that declared the `listChanged`
@@ -150,6 +194,20 @@ capability **SHOULD** send a notification:
   "method": "notifications/tools/list_changed"
 }
 ```
+
+If the server also supports the `get` capability, it **MAY** include a `changedIds` parameter to enable efficient differential synchronization:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/tools/list_changed",
+  "params": {
+    "changedIds": ["get_weather", "calculate_tax"]
+  }
+}
+```
+
+When `changedIds` is provided, clients can use `tools/get` to fetch only the changed tools instead of re-fetching the entire list.
 
 ## Message Flow
 
@@ -171,10 +229,15 @@ sequenceDiagram
     Server-->>Client: Tool result
     Client->>LLM: Process result
 
-    Note over Client,Server: Updates
+    Note over Client,Server: Updates (full refresh)
     Server--)Client: tools/list_changed
     Client->>Server: tools/list
     Server-->>Client: Updated tools
+
+    Note over Client,Server: Updates (differential sync)
+    Server--)Client: tools/list_changed with changedIds
+    Client->>Server: tools/get (for each changed ID)
+    Server-->>Client: Individual tool definitions
 ```
 
 ## Data Types

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -1189,13 +1189,29 @@
                     "type": "string"
                 },
                 "params": {
-                    "properties": {
-                        "cursor": {
-                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                            "type": "string"
+                    "allOf": [
+                        {
+                            "properties": {
+                                "cursor": {
+                                    "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "properties": {
+                                "names": {
+                                    "description": "An optional array of prompt names to retrieve.\nIf provided, the server should return only the prompts with these names.\nPagination is ignored when this parameter is present.",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object"
                         }
-                    },
-                    "type": "object"
+                    ]
                 }
             },
             "required": [
@@ -1281,13 +1297,29 @@
                     "type": "string"
                 },
                 "params": {
-                    "properties": {
-                        "cursor": {
-                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                            "type": "string"
+                    "allOf": [
+                        {
+                            "properties": {
+                                "cursor": {
+                                    "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "properties": {
+                                "uris": {
+                                    "description": "An optional array of resource URIs to retrieve.\nIf provided, the server should return only the resources with these URIs.\nPagination is ignored when this parameter is present.",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object"
                         }
-                    },
-                    "type": "object"
+                    ]
                 }
             },
             "required": [
@@ -1377,13 +1409,29 @@
                     "type": "string"
                 },
                 "params": {
-                    "properties": {
-                        "cursor": {
-                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                            "type": "string"
+                    "allOf": [
+                        {
+                            "properties": {
+                                "cursor": {
+                                    "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "properties": {
+                                "names": {
+                                    "description": "An optional array of tool names to retrieve.\nIf provided, the server should return only the tools with these names.\nPagination is ignored when this parameter is present.",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object"
                         }
-                    },
-                    "type": "object"
+                    ]
                 }
             },
             "required": [
@@ -2240,6 +2288,10 @@
                             "description": "Whether this server supports retrieving individual prompt definitions.",
                             "type": "boolean"
                         },
+                        "listByIds": {
+                            "description": "Whether this server supports retrieving multiple prompts by name in a single list request.",
+                            "type": "boolean"
+                        },
                         "listChanged": {
                             "description": "Whether this server supports notifications for changes to the prompt list.",
                             "type": "boolean"
@@ -2252,6 +2304,10 @@
                     "properties": {
                         "get": {
                             "description": "Whether this server supports retrieving individual resource metadata.",
+                            "type": "boolean"
+                        },
+                        "listByIds": {
+                            "description": "Whether this server supports retrieving multiple resources by URI in a single list request.",
                             "type": "boolean"
                         },
                         "listChanged": {
@@ -2270,6 +2326,10 @@
                     "properties": {
                         "get": {
                             "description": "Whether this server supports retrieving individual tool definitions.",
+                            "type": "boolean"
+                        },
+                        "listByIds": {
+                            "description": "Whether this server supports retrieving multiple tools by name in a single list request.",
                             "type": "boolean"
                         },
                         "listChanged": {

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -707,6 +707,50 @@
             ],
             "type": "object"
         },
+        "GetPromptDefinitionRequest": {
+            "description": "Used by the client to get a prompt definition by name.",
+            "properties": {
+                "method": {
+                    "const": "prompts/getDefinition",
+                    "type": "string"
+                },
+                "params": {
+                    "properties": {
+                        "name": {
+                            "description": "The name of the prompt to retrieve.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object"
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "GetPromptDefinitionResult": {
+            "description": "The server's response to a prompts/getDefinition request from the client.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+                    "type": "object"
+                },
+                "prompt": {
+                    "$ref": "#/definitions/Prompt",
+                    "description": "The requested prompt definition."
+                }
+            },
+            "required": [
+                "prompt"
+            ],
+            "type": "object"
+        },
         "GetPromptRequest": {
             "description": "Used by the client to get a prompt provided by the server.",
             "properties": {
@@ -761,6 +805,95 @@
             },
             "required": [
                 "messages"
+            ],
+            "type": "object"
+        },
+        "GetResourceRequest": {
+            "description": "Used by the client to get resource metadata by URI.",
+            "properties": {
+                "method": {
+                    "const": "resources/get",
+                    "type": "string"
+                },
+                "params": {
+                    "properties": {
+                        "uri": {
+                            "description": "The URI of the resource to retrieve.",
+                            "format": "uri",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "uri"
+                    ],
+                    "type": "object"
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "GetResourceResult": {
+            "description": "The server's response to a resources/get request from the client.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+                    "type": "object"
+                },
+                "resource": {
+                    "$ref": "#/definitions/Resource",
+                    "description": "The requested resource metadata."
+                }
+            },
+            "required": [
+                "resource"
+            ],
+            "type": "object"
+        },
+        "GetToolRequest": {
+            "description": "Used by the client to get a tool definition by name.",
+            "properties": {
+                "method": {
+                    "const": "tools/get",
+                    "type": "string"
+                },
+                "params": {
+                    "properties": {
+                        "name": {
+                            "description": "The name of the tool to retrieve.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object"
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ],
+            "type": "object"
+        },
+        "GetToolResult": {
+            "description": "The server's response to a tools/get request from the client.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+                    "type": "object"
+                },
+                "tool": {
+                    "$ref": "#/definitions/Tool",
+                    "description": "The requested tool definition."
+                }
+            },
+            "required": [
+                "tool"
             ],
             "type": "object"
         },
@@ -1613,12 +1746,13 @@
                     "type": "string"
                 },
                 "params": {
-                    "additionalProperties": {},
                     "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-                            "type": "object"
+                        "changedIds": {
+                            "description": "An optional array of prompt names that have changed.\nIf provided, the client can use prompts/getDefinition to fetch individual prompts instead of re-fetching the entire list.\nIf not provided, the client should re-fetch the entire list.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         }
                     },
                     "type": "object"
@@ -1880,12 +2014,13 @@
                     "type": "string"
                 },
                 "params": {
-                    "additionalProperties": {},
                     "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-                            "type": "object"
+                        "changedIds": {
+                            "description": "An optional array of resource URIs that have changed.\nIf provided, the client can use resources/get to fetch individual resources instead of re-fetching the entire list.\nIf not provided, the client should re-fetch the entire list.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         }
                     },
                     "type": "object"
@@ -2101,6 +2236,10 @@
                 "prompts": {
                     "description": "Present if the server offers any prompt templates.",
                     "properties": {
+                        "getDefinition": {
+                            "description": "Whether this server supports retrieving individual prompt definitions.",
+                            "type": "boolean"
+                        },
                         "listChanged": {
                             "description": "Whether this server supports notifications for changes to the prompt list.",
                             "type": "boolean"
@@ -2111,6 +2250,10 @@
                 "resources": {
                     "description": "Present if the server offers any resources to read.",
                     "properties": {
+                        "get": {
+                            "description": "Whether this server supports retrieving individual resource metadata.",
+                            "type": "boolean"
+                        },
                         "listChanged": {
                             "description": "Whether this server supports notifications for changes to the resource list.",
                             "type": "boolean"
@@ -2125,6 +2268,10 @@
                 "tools": {
                     "description": "Present if the server offers any tools to call.",
                     "properties": {
+                        "get": {
+                            "description": "Whether this server supports retrieving individual tool definitions.",
+                            "type": "boolean"
+                        },
                         "listChanged": {
                             "description": "Whether this server supports notifications for changes to the tool list.",
                             "type": "boolean"
@@ -2469,12 +2616,13 @@
                     "type": "string"
                 },
                 "params": {
-                    "additionalProperties": {},
                     "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-                            "type": "object"
+                        "changedIds": {
+                            "description": "An optional array of tool names that have changed.\nIf provided, the client can use tools/get to fetch individual tools instead of re-fetching the entire list.\nIf not provided, the client should re-fetch the entire list.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
                         }
                     },
                     "type": "object"

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -246,6 +246,10 @@ export interface ServerCapabilities {
      * Whether this server supports retrieving individual prompt definitions.
      */
     getDefinition?: boolean;
+    /**
+     * Whether this server supports retrieving multiple prompts by name in a single list request.
+     */
+    listByIds?: boolean;
   };
   /**
    * Present if the server offers any resources to read.
@@ -263,6 +267,10 @@ export interface ServerCapabilities {
      * Whether this server supports retrieving individual resource metadata.
      */
     get?: boolean;
+    /**
+     * Whether this server supports retrieving multiple resources by URI in a single list request.
+     */
+    listByIds?: boolean;
   };
   /**
    * Present if the server offers any tools to call.
@@ -276,6 +284,10 @@ export interface ServerCapabilities {
      * Whether this server supports retrieving individual tool definitions.
      */
     get?: boolean;
+    /**
+     * Whether this server supports retrieving multiple tools by name in a single list request.
+     */
+    listByIds?: boolean;
   };
 }
 
@@ -369,6 +381,14 @@ export interface PaginatedResult extends Result {
  */
 export interface ListResourcesRequest extends PaginatedRequest {
   method: "resources/list";
+  params?: PaginatedRequest['params'] & {
+    /**
+     * An optional array of resource URIs to retrieve.
+     * If provided, the server should return only the resources with these URIs.
+     * Pagination is ignored when this parameter is present.
+     */
+    uris?: string[];
+  };
 }
 
 /**
@@ -616,6 +636,14 @@ export interface BlobResourceContents extends ResourceContents {
  */
 export interface ListPromptsRequest extends PaginatedRequest {
   method: "prompts/list";
+  params?: PaginatedRequest['params'] & {
+    /**
+     * An optional array of prompt names to retrieve.
+     * If provided, the server should return only the prompts with these names.
+     * Pagination is ignored when this parameter is present.
+     */
+    names?: string[];
+  };
 }
 
 /**
@@ -775,6 +803,14 @@ export interface PromptListChangedNotification extends Notification {
  */
 export interface ListToolsRequest extends PaginatedRequest {
   method: "tools/list";
+  params?: PaginatedRequest['params'] & {
+    /**
+     * An optional array of tool names to retrieve.
+     * If provided, the server should return only the tools with these names.
+     * Pagination is ignored when this parameter is present.
+     */
+    names?: string[];
+  };
 }
 
 /**

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -242,6 +242,10 @@ export interface ServerCapabilities {
      * Whether this server supports notifications for changes to the prompt list.
      */
     listChanged?: boolean;
+    /**
+     * Whether this server supports retrieving individual prompt definitions.
+     */
+    getDefinition?: boolean;
   };
   /**
    * Present if the server offers any resources to read.
@@ -255,6 +259,10 @@ export interface ServerCapabilities {
      * Whether this server supports notifications for changes to the resource list.
      */
     listChanged?: boolean;
+    /**
+     * Whether this server supports retrieving individual resource metadata.
+     */
+    get?: boolean;
   };
   /**
    * Present if the server offers any tools to call.
@@ -264,6 +272,10 @@ export interface ServerCapabilities {
      * Whether this server supports notifications for changes to the tool list.
      */
     listChanged?: boolean;
+    /**
+     * Whether this server supports retrieving individual tool definitions.
+     */
+    get?: boolean;
   };
 }
 
@@ -403,10 +415,42 @@ export interface ReadResourceResult extends Result {
 }
 
 /**
+ * Used by the client to get resource metadata by URI.
+ */
+export interface GetResourceRequest extends Request {
+  method: "resources/get";
+  params: {
+    /**
+     * The URI of the resource to retrieve.
+     * @format uri
+     */
+    uri: string;
+  };
+}
+
+/**
+ * The server's response to a resources/get request from the client.
+ */
+export interface GetResourceResult extends Result {
+  /**
+   * The requested resource metadata.
+   */
+  resource: Resource;
+}
+
+/**
  * An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This may be issued by servers without any previous subscription from the client.
  */
 export interface ResourceListChangedNotification extends Notification {
   method: "notifications/resources/list_changed";
+  params?: {
+    /**
+     * An optional array of resource URIs that have changed.
+     * If provided, the client can use resources/get to fetch individual resources instead of re-fetching the entire list.
+     * If not provided, the client should re-fetch the entire list.
+     */
+    changedIds?: string[];
+  };
 }
 
 /**
@@ -610,6 +654,29 @@ export interface GetPromptResult extends Result {
 }
 
 /**
+ * Used by the client to get a prompt definition by name.
+ */
+export interface GetPromptDefinitionRequest extends Request {
+  method: "prompts/getDefinition";
+  params: {
+    /**
+     * The name of the prompt to retrieve.
+     */
+    name: string;
+  };
+}
+
+/**
+ * The server's response to a prompts/getDefinition request from the client.
+ */
+export interface GetPromptDefinitionResult extends Result {
+  /**
+   * The requested prompt definition.
+   */
+  prompt: Prompt;
+}
+
+/**
  * A prompt or prompt template that the server offers.
  */
 export interface Prompt extends BaseMetadata {
@@ -692,6 +759,14 @@ export interface EmbeddedResource {
  */
 export interface PromptListChangedNotification extends Notification {
   method: "notifications/prompts/list_changed";
+  params?: {
+    /**
+     * An optional array of prompt names that have changed.
+     * If provided, the client can use prompts/getDefinition to fetch individual prompts instead of re-fetching the entire list.
+     * If not provided, the client should re-fetch the entire list.
+     */
+    changedIds?: string[];
+  };
 }
 
 /* Tools */
@@ -752,10 +827,41 @@ export interface CallToolRequest extends Request {
 }
 
 /**
+ * Used by the client to get a tool definition by name.
+ */
+export interface GetToolRequest extends Request {
+  method: "tools/get";
+  params: {
+    /**
+     * The name of the tool to retrieve.
+     */
+    name: string;
+  };
+}
+
+/**
+ * The server's response to a tools/get request from the client.
+ */
+export interface GetToolResult extends Result {
+  /**
+   * The requested tool definition.
+   */
+  tool: Tool;
+}
+
+/**
  * An optional notification from the server to the client, informing it that the list of tools it offers has changed. This may be issued by servers without any previous subscription from the client.
  */
 export interface ToolListChangedNotification extends Notification {
   method: "notifications/tools/list_changed";
+  params?: {
+    /**
+     * An optional array of tool names that have changed.
+     * If provided, the client can use tools/get to fetch individual tools instead of re-fetching the entire list.
+     * If not provided, the client should re-fetch the entire list.
+     */
+    changedIds?: string[];
+  };
 }
 
 /**


### PR DESCRIPTION
This PR introduces a comprehensive mechanism for efficient state synchronization by enhancing `*_list_changed` notifications and adding corresponding methods for batch and single-item retrieval.

### Motivation and Context

The current `draft` specification defines `*_list_changed` notifications, but they are simple, parameter-less signals. This forces clients to perform a full `list` request to re-fetch an entire collection of items even if only one has changed. This approach is highly inefficient, creating unnecessary network traffic and processing load, and it does not scale well.

This proposal fixes this inefficiency by introducing a true differential synchronization pattern. It consists of two coordinated enhancements:

1.  **Smarter Notifications:** We formalize an optional `changedIds` parameter on the `*_list_changed` notifications. This allows a server to tell the client *exactly* which items have been added, updated, or removed.
2.  **Actionable Retrieval Methods:** We add `get` (for single items) and enhance `list` (for batches of items by ID) methods. These give the client the necessary tools to act on the `changedIds` and fetch only the data that has actually changed.

Together, these changes enable a robust and performant state-syncing mechanism, which is critical for real-world applications.

### How Has This Been Tested?

This is a change to the protocol specification and its documentation. The "tests" for this repository are validation scripts that ensure the schema is well-formed.

- The TypeScript schema (`schema.ts`) has been validated with `tsc` (`npm run check:schema:ts`).
- The generated JSON schema (`schema.json`) has been verified to be in sync with the TypeScript source (`npm run check:schema:json`).
- All documentation has been checked for formatting and broken links (`npm run check:docs`).

### Breaking Changes

There are **no breaking changes**.

- All new request parameters (`changedIds`, `names`, and `uris`) are optional. Servers that do not send them and clients that do not understand them will continue to function correctly using the existing full-refresh pattern.
- The new `get` methods and `listByIds` capabilities are entirely new and opt-in for servers.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

### Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling *(Defined in the documentation how servers should behave)*
- [x] I have added or updated documentation as needed

### Additional context

This proposal is the result of implementing a client manager against the current `draft` spec and identifying this performance bottleneck.

Key design decisions included:

1.  **Two-Part Solution:** Recognizing that both the notifications and the retrieval methods needed enhancement to create a complete solution for differential sync.
2.  **Optional `changedIds`:** Making this parameter optional ensures full backward compatibility with the existing simple notification signal.
3.  **Both Single `get` and Batch `list`:** This provides a simple path for all servers to support basic differential sync (`get`), while also offering a highly optimized path for performance-critical servers (`listByIds`).
4.  **Using `prompts/getDefinition`:** A new method name was chosen for retrieving a prompt's definition to avoid ambiguity with the existing `prompts/get` method, which *executes* a prompt template.