### PR TITLE
Update `clients.mdx` table header links

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -11,7 +11,7 @@ This page provides an overview of applications that support the Model Context Pr
 
 {/* prettier-ignore-start */}
 
-| Client                                           | [Resources] | [Prompts] | [Tools] | [Discovery][Discovery] | [Sampling] | Roots | Notes                                                                                           |
+| Client                                           | [Resources] | [Prompts] | [Tools] | [Discovery] | [Sampling] | [Roots] | Notes                                                                                           |
 | ------------------------------------------------ | ----------- | --------- | ------- | ---------------------- | ---------- | ----- | ----------------------------------------------------------------------------------------------- |
 | [5ire][5ire]                                     | ❌          | ❌        | ✅      | ❓                     | ❌         | ❌    | Supports tools.                                                                                 |
 | [AgentAI][AgentAI]                               | ❌          | ❌        | ✅      | ❓                     | ❌         | ❌    | Agent Library written in Rust with tools support                                                |
@@ -72,6 +72,12 @@ This page provides an overview of applications that support the Model Context Pr
 
 {/* prettier-ignore-end */}
 
+[Resources]: /docs/concepts/resources
+[Prompts]: /docs/concepts/prompts
+[Tools]: /docs/concepts/tools
+[Discovery]: /docs/concepts/tools#tool-discovery-and-updates
+[Sampling]: /docs/concepts/sampling
+[Roots]: /docs/concepts/roots
 [5ire]: https://github.com/nanbingxyz/5ire
 [AgentAI]: https://github.com/AdamStrojek/rust-agentai
 [AgenticFlow]: https://agenticflow.ai/mcp
@@ -127,12 +133,7 @@ This page provides an overview of applications that support the Model Context Pr
 [Witsy]: https://github.com/nbonamy/witsy
 [Zed]: https://zed.dev
 [Zencoder]: https://zencoder.ai
-[Resources]: https://modelcontextprotocol.io/docs/concepts/resources
-[Prompts]: https://modelcontextprotocol.io/docs/concepts/prompts
-[Tools]: https://modelcontextprotocol.io/docs/concepts/tools
-[Sampling]: https://modelcontextprotocol.io/docs/concepts/sampling
 [HyperAgent]: https://github.com/hyperbrowserai/HyperAgent
-[Discovery]: /docs/concepts/tools#tool-discovery-and-updates
 
 </div>
 


### PR DESCRIPTION
This replaces absolute URLs with paths, links the "Roots" column header, and moves anchor definitions for the table header links to the top for organizational purposes.

Closes #525
