### PR TITLE
expand `_meta` name reservation

### DIFF
--- a/docs/specification/draft/basic/index.mdx
+++ b/docs/specification/draft/basic/index.mdx
@@ -139,7 +139,9 @@ may reserve particular names for purpose-specific metadata, as declared in those
 
 - If specified, MUST be a series of labels separated by dots (`.`), followed by a slash (`/`).
   - Labels MUST start with a letter and end with a letter or digit; interior characters can be letters, digits, or hyphens (`-`).
-- The `modelcontextprotocol.[*]/` and `mcp.[*]/` prefixes are reserved for MCP use (where `[*]` stands for any top-level domain).
+- Any prefix beginning with zero or more valid labels, followed by `modelcontextprotocol` or `mcp`, followed by any valid label,
+  is **reserved** for MCP use.
+  - For example: `modelcontextprotocol.io/`, `mcp.dev/`, `api.modelcontextprotocol.org/`, and `tools.mcp.com/` are all reserved.
 
 **Name:**
 


### PR DESCRIPTION
Expands the set of reserved `_meta` key names to include leading labels, e.g. `api.mcp.ai`