### PR TITLE
feat: add support for partial results and streaming responses

### DIFF
--- a/docs/specification/draft/basic/index.mdx
+++ b/docs/specification/draft/basic/index.mdx
@@ -41,6 +41,10 @@ Requests are sent from the client to the server or vice versa, to initiate an op
   method: string;
   params?: {
     [key: string]: unknown;
+    _meta?: {
+      [key: string]: unknown;
+      allowPartial?: boolean;
+    }
   };
 }
 ```
@@ -49,6 +53,7 @@ Requests are sent from the client to the server or vice versa, to initiate an op
 - Unlike base JSON-RPC, the ID **MUST NOT** be `null`.
 - The request ID **MUST NOT** have been previously used by the requestor within the same
   session.
+- Requests **MAY** allow partial results by setting the `allowPartial` flag.
 
 ### Responses
 
@@ -60,6 +65,10 @@ Responses are sent in reply to requests, containing the result or error of the o
   id: string | number;
   result?: {
     [key: string]: unknown;
+    _meta?: {
+      [key: string]: unknown;
+      hasMore?: boolean;
+    }
   }
   error?: {
     code: number;
@@ -73,6 +82,8 @@ Responses are sent in reply to requests, containing the result or error of the o
 - **Responses** are further sub-categorized as either **successful results** or
   **errors**. Either a `result` or an `error` **MUST** be set. A response **MUST NOT**
   set both.
+- Results **MAY** set `hasMore` flag only if the corresponding request set the `allowPartial` flag.
+  The flag indicates that more responses with the same ID will follow.
 - Results **MAY** follow any JSON object structure, while errors **MUST** include an
   error code and message at minimum.
 - Error codes **MUST** be integers.

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -101,15 +101,15 @@ MCP endpoint.
    `Content-Type: application/json`, to return one JSON object. The client **MUST**
    support both these cases.
 6. If the server initiates an SSE stream:
-   - The SSE stream **SHOULD** eventually include JSON-RPC _response_ for the
+   - The SSE stream **SHOULD** eventually include JSON-RPC _response(s)_ for the
      JSON-RPC _request_ sent in the POST body.
    - The server **MAY** send JSON-RPC _requests_ and _notifications_ before sending the
-     JSON-RPC _response_. These messages **SHOULD** relate to the originating client
+     final JSON-RPC _response_. These messages **SHOULD** relate to the originating client
      _request_.
-   - The server **SHOULD NOT** close the SSE stream before sending the JSON-RPC _response_
+   - The server **SHOULD NOT** close the SSE stream before sending the JSON-RPC _response(s)_
      for the received JSON-RPC _request_, unless the [session](#session-management)
      expires.
-   - After the JSON-RPC _response_ has been sent, the server **SHOULD** close the SSE
+   - After the final JSON-RPC _response_ has been sent, the server **SHOULD** close the SSE
      stream.
    - Disconnection **MAY** occur at any time (e.g., due to network conditions).
      Therefore:

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -351,6 +351,29 @@ Providing an output schema helps clients and LLMs understand and properly handle
 - Guiding clients and LLMs to properly parse and utilize the returned data
 - Supporting better documentation and developer experience
 
+## Content streaming
+
+Tools might provide result as a stream of partial results:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Client
+    participant Server
+
+    Note over Client,Server: Streaming
+    Client->>Server: tools/call
+    Server-->>Client: Tool partial result
+    Client-->>User: Content
+    Server-->>Client: Tool partial result
+    Client-->>User: Content
+    Server-->>Client: Tool partial result
+    Client-->>User: Content
+```
+
+_Unstructured_ content is incremental and the complete result can be acquired by concatenation.
+_Structured_ content is not incremental unless the tool's output schema states otherwise.
+
 ## Error Handling
 
 Tools use two error reporting mechanisms:

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -158,6 +158,12 @@
                 "_meta": {
                     "additionalProperties": {},
                     "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+                    "properties": {
+                        "hasMore": {
+                            "description": "If true, more results will follow.",
+                            "type": "boolean"
+                        }
+                    },
                     "type": "object"
                 },
                 "content": {
@@ -394,6 +400,12 @@
                 "_meta": {
                     "additionalProperties": {},
                     "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+                    "properties": {
+                        "hasMore": {
+                            "description": "If true, more results will follow.",
+                            "type": "boolean"
+                        }
+                    },
                     "type": "object"
                 },
                 "completion": {
@@ -515,6 +527,12 @@
                 "_meta": {
                     "additionalProperties": {},
                     "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+                    "properties": {
+                        "hasMore": {
+                            "description": "If true, more results will follow.",
+                            "type": "boolean"
+                        }
+                    },
                     "type": "object"
                 },
                 "content": {
@@ -612,6 +630,12 @@
                 "_meta": {
                     "additionalProperties": {},
                     "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+                    "properties": {
+                        "hasMore": {
+                            "description": "If true, more results will follow.",
+                            "type": "boolean"
+                        }
+                    },
                     "type": "object"
                 },
                 "action": {
@@ -746,6 +770,12 @@
                 "_meta": {
                     "additionalProperties": {},
                     "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+                    "properties": {
+                        "hasMore": {
+                            "description": "If true, more results will follow.",
+                            "type": "boolean"
+                        }
+                    },
                     "type": "object"
                 },
                 "description": {
@@ -858,6 +888,12 @@
                 "_meta": {
                     "additionalProperties": {},
                     "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+                    "properties": {
+                        "hasMore": {
+                            "description": "If true, more results will follow.",
+                            "type": "boolean"
+                        }
+                    },
                     "type": "object"
                 },
                 "capabilities": {
@@ -1009,6 +1045,10 @@
                             "additionalProperties": {},
                             "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
                             "properties": {
+                                "allowPartial": {
+                                    "description": "If specified, the caller is requesting partial results for this request. The receiver is not obligated to return partial results.",
+                                    "type": "boolean"
+                                },
                                 "progressToken": {
                                     "$ref": "#/definitions/ProgressToken",
                                     "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
@@ -1076,6 +1116,12 @@
                 "_meta": {
                     "additionalProperties": {},
                     "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+                    "properties": {
+                        "hasMore": {
+                            "description": "If true, more results will follow.",
+                            "type": "boolean"
+                        }
+                    },
                     "type": "object"
                 },
                 "nextCursor": {
@@ -1122,6 +1168,12 @@
                 "_meta": {
                     "additionalProperties": {},
                     "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+                    "properties": {
+                        "hasMore": {
+                            "description": "If true, more results will follow.",
+                            "type": "boolean"
+                        }
+                    },
                     "type": "object"
                 },
                 "nextCursor": {
@@ -1168,6 +1220,12 @@
                 "_meta": {
                     "additionalProperties": {},
                     "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+                    "properties": {
+                        "hasMore": {
+                            "description": "If true, more results will follow.",
+                            "type": "boolean"
+                        }
+                    },
                     "type": "object"
                 },
                 "nextCursor": {
@@ -1200,6 +1258,10 @@
                             "additionalProperties": {},
                             "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
                             "properties": {
+                                "allowPartial": {
+                                    "description": "If specified, the caller is requesting partial results for this request. The receiver is not obligated to return partial results.",
+                                    "type": "boolean"
+                                },
                                 "progressToken": {
                                     "$ref": "#/definitions/ProgressToken",
                                     "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
@@ -1222,6 +1284,12 @@
                 "_meta": {
                     "additionalProperties": {},
                     "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+                    "properties": {
+                        "hasMore": {
+                            "description": "If true, more results will follow.",
+                            "type": "boolean"
+                        }
+                    },
                     "type": "object"
                 },
                 "roots": {
@@ -1264,6 +1332,12 @@
                 "_meta": {
                     "additionalProperties": {},
                     "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+                    "properties": {
+                        "hasMore": {
+                            "description": "If true, more results will follow.",
+                            "type": "boolean"
+                        }
+                    },
                     "type": "object"
                 },
                 "nextCursor": {
@@ -1445,6 +1519,12 @@
                 "_meta": {
                     "additionalProperties": {},
                     "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+                    "properties": {
+                        "hasMore": {
+                            "description": "If true, more results will follow.",
+                            "type": "boolean"
+                        }
+                    },
                     "type": "object"
                 },
                 "nextCursor": {
@@ -1468,6 +1548,10 @@
                             "additionalProperties": {},
                             "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
                             "properties": {
+                                "allowPartial": {
+                                    "description": "If specified, the caller is requesting partial results for this request. The receiver is not obligated to return partial results.",
+                                    "type": "boolean"
+                                },
                                 "progressToken": {
                                     "$ref": "#/definitions/ProgressToken",
                                     "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
@@ -1700,6 +1784,12 @@
                 "_meta": {
                     "additionalProperties": {},
                     "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+                    "properties": {
+                        "hasMore": {
+                            "description": "If true, more results will follow.",
+                            "type": "boolean"
+                        }
+                    },
                     "type": "object"
                 },
                 "contents": {
@@ -1733,6 +1823,10 @@
                             "additionalProperties": {},
                             "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
                             "properties": {
+                                "allowPartial": {
+                                    "description": "If specified, the caller is requesting partial results for this request. The receiver is not obligated to return partial results.",
+                                    "type": "boolean"
+                                },
                                 "progressToken": {
                                     "$ref": "#/definitions/ProgressToken",
                                     "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
@@ -1988,6 +2082,12 @@
                 "_meta": {
                     "additionalProperties": {},
                     "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+                    "properties": {
+                        "hasMore": {
+                            "description": "If true, more results will follow.",
+                            "type": "boolean"
+                        }
+                    },
                     "type": "object"
                 }
             },

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -33,6 +33,10 @@ export interface Request {
        * If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications.
        */
       progressToken?: ProgressToken;
+      /**
+       * If specified, the caller is requesting partial results for this request. The receiver is not obligated to return partial results.
+       */
+      allowPartial?: boolean;
       [key: string]: unknown;
     };
     [key: string]: unknown;
@@ -54,7 +58,13 @@ export interface Result {
   /**
    * See [specification/draft/basic/index#general-fields] for notes on _meta usage.
    */
-  _meta?: { [key: string]: unknown };
+  _meta?: {
+    /**
+     * If true, more results will follow.
+     */
+    hasMore?: boolean;
+    [key: string]: unknown;
+  };
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

This PR introduces **support for partial results**, primarily intended to enable streaming responses from long-running tools and agent interactions. Returning partial output improves responsiveness, interactivity, and user experience. The feature was identified as a key improvement in #111, #117, and #484.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Partial result streaming improves responsiveness and flexibility for both **long-running tools** and **MCP-based agents**, enabling:

- **Better UX** – Clients can start processing or displaying output immediately (e.g. chatbots, code tools).
- **Concurrent processing** – Downstream agents/tools can act on partial results as they arrive.
- **Interruptibility** – Partial delivery allows early cancellation, saving compute on long responses.
- **Support for real-time applications** – Such as live summarization, transcription, or chat.

We are proposing this change because our own use case involves using MCP for agent communication, where partial results are essential for enabling responsive, real-time, multi-agent workflows.

### Related Work

- [[feat] Introduce partial results as part of progress notifications #383](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/383)  
  Proposes streaming via progress notifications, which is a promising direction. One limitation discussed in [this comment](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/383#issuecomment-2911300705) (which we independently arrived at as well) is that notifications may be ignored by clients, requiring a full result to be sent at the end regardless.

- [[Proposal] Task semantics and multi-turn interactions with tools #314](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/314)  
  Explores related concepts for streaming and multi-turn interactions. Since elicitation was introduced in the latest draft, both `progressToken` and `state` appear unnecessary under the updated semantics. This PR builds on those ideas and reflects recent protocol evolution.

### Related Issues

- [First-class streaming tool output #484](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/484)
- [Streaming interaction support #117](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/117)

## How Has This Been Tested?

**Yes**. Tool output streaming tested in real applications using the modified Python SDK.

## Breaking Changes

**None**. Clients must explicitly opt in via `allowPartial`. Servers are free to ignore this flag.

## Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed


## Additional Context

This feature is designed to be **minimal**, **backward-compatible**, and **avoid unnecessary data duplication**.

This implementation raises two open design questions:

1. **Structured data merging**  
   While unstructured content (e.g. `content` in `CallToolResult`) can be concatenated incrementally, merging partial **structured data** (objects, arrays, etc.) is not currently defined. This PR deliberately avoids specifying a merging or delta application algorithm, leaving it open for future discussion if the protocol chooses to express an opinion on it.

2. **Use of `id` for multiple responses**  
   This implementation leverages a flexibility in JSON-RPC to send **multiple responses with the same `id`**. While practical and effective, it stretches the spec's intent, which assumes a one-to-one mapping between request and response. Using `id` in this way introduces a form of implicit multiplexing, which may conflict with traditional request–response matching logic in some JSON-RPC clients.

## Example

Below is an example of a request with `allowPartial` set to true, followed by multiple partial responses:

```json
// Request
{
  "jsonrpc": "2.0",
  "id": 2,
  "method": "tools/call",
  "params": {
    "name": "generate_story",
    "arguments": {
      "topic": "fox"
    },
    "_meta": {
      "allowPartial": true  // Client allows partial (incremental) results
    }
  }
}

// First partial response (intermediate chunk)
{
  "jsonrpc": "2.0",
  "id": 2,
  "result": {
    "content": [
      {
        "type": "text",
        "text": "Once upon a time, in a land far away,"
      }
    ],
    "_meta": {
      "hasMore": true  // Indicates more chunks are coming
    }
  }
}

// Final response (completes the result)
{
  "jsonrpc": "2.0",
  "id": 2,
  "result": {
    "content": [
      {
        "type": "text",
        "text": " there lived a small and curious fox."
      }
    ],
    // _meta.hasMore omitted — this is the final chunk (alternatively, set hasMore: false explicitly)
  }
}
```

## Notes for Reviewers

- `allowPartial` is a client hint — servers are not required to support or act on it.
- `hasMore: true` appears only in intermediate responses; the final response omits it.
- Final responses are structurally identical to standard JSON-RPC responses, ensuring full backward compatibility.
- Clients that do not support streaming will simply treat the last message as the complete result.