### PR TITLE
docs: Fix h5, h6 style

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1,11 +1,10 @@
 #feature-support-matrix-wrapper {
-    overflow-x: auto;
+  overflow-x: auto;
 }
 
 #feature-support-matrix-wrapper table {
-    min-width: 800px;
+  min-width: 800px;
 }
-
 
 /*** Add automatic section numbers to headings and table of contents items ***/
 
@@ -18,7 +17,6 @@ body:has(#enable-section-numbers) {
   #table-of-contents {
     counter-reset: h2-counter h3-counter h4-counter h5-counter h6-counter;
   }
-
 
   #content-area h2[id],
   #table-of-contents li[data-depth="0"] {
@@ -36,10 +34,10 @@ body:has(#enable-section-numbers) {
   }
 
   #content-area h5[id],
+  #content-area h5,
   #table-of-contents li[data-depth="3"] {
     counter-set: h6-counter;
   }
-
 
   #content-area h2[id]::before,
   #table-of-contents li[data-depth="0"] a::before {
@@ -56,18 +54,31 @@ body:has(#enable-section-numbers) {
   #content-area h4[id]::before,
   #table-of-contents li[data-depth="2"] a::before {
     counter-increment: h4-counter;
-    content: counter(h2-counter) "." counter(h3-counter) "." counter(h4-counter) " ";
+    content: counter(h2-counter) "." counter(h3-counter) "." counter(h4-counter)
+      " ";
   }
 
   #content-area h5[id]::before,
+  #content-area h5::before,
   #table-of-contents li[data-depth="3"] a::before {
     counter-increment: h5-counter;
-    content: counter(h2-counter) "." counter(h3-counter) "." counter(h4-counter)  "." counter(h5-counter) " ";
+    content: counter(h2-counter) "." counter(h3-counter) "." counter(h4-counter)
+      "." counter(h5-counter) " ";
   }
 
   #content-area h6[id]::before,
+  #content-area h6::before,
   #table-of-contents li[data-depth="4"] a::before {
     counter-increment: h6-counter;
-    content: counter(h2-counter) "." counter(h3-counter) "." counter(h4-counter)  "." counter(h5-counter) "." counter(h6-counter) " ";
+    content: counter(h2-counter) "." counter(h3-counter) "." counter(h4-counter)
+      "." counter(h5-counter) "." counter(h6-counter) " ";
+  }
+
+  #content-area h5 {
+    font-weight: 500;
+  }
+
+  #content-area h6 {
+    font-weight: 400;
   }
 }


### PR DESCRIPTION

I noticed that mintlify does not correctly create id="" tags for h5 and
h6 headers. This means that we do not correctly trigger our styles on these
as they depend on the presence of id. For now we fix this by including h5 for
non-id, while we follow up with mintlify to fix this.

Before

![image](https://github.com/user-attachments/assets/87aafb77-e8f8-4133-9a74-96d79693aa22)

After
![image](https://github.com/user-attachments/assets/d99ef9d7-7134-4b79-a3d8-e624c1f84281)
