### PR TITLE
[spec] make user appear on the left side of the elicitation diagram

### DIFF
--- a/docs/specification/draft/client/elicitation.mdx
+++ b/docs/specification/draft/client/elicitation.mdx
@@ -179,9 +179,9 @@ To request information from a user, servers send an `elicitation/create` request
 
 ```mermaid
 sequenceDiagram
-    participant Server
-    participant Client
     participant User
+    participant Client
+    participant Server
 
     Note over Server,Client: Server initiates elicitation
     Server->>Client: elicitation/create


### PR DESCRIPTION
Diagrams flow left to right in the MCP specification, with the
user being leftmost.
