### PR TITLE
Rework docs navigation (part 2)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -22,7 +22,7 @@
         "version": "Version 2025-03-26",
         "groups": [
           {
-            "group": "Get Started",
+            "group": "User Guide",
             "pages": [
               "introduction",
               {
@@ -138,7 +138,7 @@
         "version": "Version 2024-11-05",
         "groups": [
           {
-            "group": "Get Started",
+            "group": "User Guide",
             "pages": [
               "introduction",
               {
@@ -253,7 +253,7 @@
         "version": "Draft",
         "groups": [
           {
-            "group": "Get Started",
+            "group": "User Guide",
             "pages": [
               "introduction",
               {


### PR DESCRIPTION
This makes a few follow-up changes to #770, namely:

* Prefix version labels with "Version"
  * This makes the version select box stand out more.
* Move "SDKs" group to the bottom of the sidebar
  * This addresses a bug in the live production site wherein Mintlify will try to navigate to an SDK's external URL when the user clicks on the "SDKs" group in order to expand it.  This bug only occurs in the live production site, which is why it was not caught during local development.
* Nest "Concepts" group in "Get Started" group
  * This bumps up the "Protocol" group in the sidebar such that it appears above the fold.
* Rename "Get Started" group to "User Guide"
  * This mimics the previously existing division between the "User Guide" and "Specification" tabs.

| Before | After |
| --- | --- |
| ![before-1](https://github.com/user-attachments/assets/38957e2c-3b0b-4657-8acd-a579ba2145c4) | ![after-1](https://github.com/user-attachments/assets/886ede4a-1c14-4f58-bf14-3b68321d24a0) |
| ![before-2](https://github.com/user-attachments/assets/fccd6c9e-45a1-4e53-bb99-faf5e9195d8a) | ![after-2](https://github.com/user-attachments/assets/3baaaea4-6089-40c5-bc5a-d3028ca04049) |
