### PR TITLE
Docs: Add Memex to clients.mdx

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -45,6 +45,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [mcp-use][mcp-use]                               | ✅          | ✅        | ✅      | ❓                     | ❌         | ❌    | Support tools, resources, stdio & http connection, local llms-agents.                           |
 | [MCPHub][MCPHub]                                 | ✅          | ✅        | ✅      | ❓                     | ❌         | ❌    | Supports tools, resources, and prompts in Neovim                                                |
 | [MCPOmni-Connect][MCPOmni-Connect]               | ✅          | ✅        | ✅      | ❓                     | ✅         | ❌    | Supports tools with agentic mode, ReAct, and orchestrator capabilities.                         |
+| [Memex][Memex]                                   | ✅          | ✅        | ✅      | ❓                     | ❌         | ❌    | Support tools. Also support *building and testing* MCP server, all-in-one desktop app.          |
 | [Microsoft Copilot Studio]                       | ❌          | ❌        | ✅      | ❓                     | ❌         | ❌    | Supports tools                                                                                  |
 | [MindPal][MindPal]                               | ❌          | ❌        | ✅      | ❓                     | ❌         | ❌    | Supports tools for no-code AI agents and multi-agent workflows.                                 |
 | [MooPoint][MooPoint]                             | ❌          | ❌        | ✅      | ❓                     | ✅         | ❌    | Web-Hosted client with tool calling support                                 |
@@ -109,6 +110,7 @@ This page provides an overview of applications that support the Model Context Pr
 [mcp-use]: https://github.com/pietrozullo/mcp-use
 [MCPHub]: https://github.com/ravitemer/mcphub.nvim
 [MCPOmni-Connect]: https://github.com/Abiorh001/mcp_omni_connect
+[Memex]: https://memex.tech/
 [Microsoft Copilot Studio]: https://learn.microsoft.com/en-us/microsoft-copilot-studio/agent-extend-action-mcp
 [MindPal]: https://mindpal.io
 [MooPoint]: https://moopoint.io
@@ -516,6 +518,22 @@ Programmatically assemble prompts for LLMs using [GenAIScript](https://microsoft
 - Dynamic tool and resource management across multiple servers
 - Support for both stdio and SSE transport protocols
 - Comprehensive tool orchestration and resource analysis capabilities
+
+### Memex
+
+[Memex](https://memex.tech/) is the first MCP client and MCP server builder - all-in-one desktop app. Unlike traditional MCP clients that only consume existing servers, Memex can create custom MCP servers from natural language prompts, immediately integrate them into its toolkit, and use them to solve problems—all within a single conversation.
+
+**Key features:**
+
+- **Prompt-to-MCP Server**: Generate fully functional MCP servers from natural language descriptions
+- **Self-Testing & Debugging**: Autonomously test, debug, and improve created MCP servers  
+- **Universal MCP Client**: Works with any MCP server through intuitive, natural language integration
+- **Curated MCP Directory**: Access to tested, one-click installable MCP servers (Neon, Netlify, GitHub, Context7, and more)
+- **Multi-Server Orchestration**: Leverage multiple MCP servers simultaneously for complex workflows
+
+**Learn more:**
+
+- [Memex Launch 2: MCP Teams and Agent API](https://memex.tech/blog/memex-launch-2-mcp-teams-and-agent-api-private-preview-125f)
 
 ### Microsoft Copilot Studio
 


### PR DESCRIPTION
Add Memex to the MCP clients documentation

## Motivation and Context

Memex is an MCP client that supports resources, prompts, and tools. Additionally supports building and testing MCP servers within the same application. https://memex.tech/blog/memex-launch-2-mcp-teams-and-agent-api-private-preview-125f

## How Has This Been Tested?

n/a

## Breaking Changes

No

## Types of changes

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to change)
- [x]  Documentation update

## Checklist

- [x]  I have read the [MCP Documentation](https://modelcontextprotocol.io/)
- [ ]  My code follows the repository's style guidelines
- [ ]  New and existing tests pass locally
- [ ]  I have added appropriate error handling
- [x]  I have added or updated documentation as needed

## Additional context

n/a