### PR TITLE
Mention fetching `https://` resources

### DIFF
--- a/docs/legacy/concepts/resources.mdx
+++ b/docs/legacy/concepts/resources.mdx
@@ -134,6 +134,8 @@ Servers may return multiple resources in response to one `resources/read` reques
 
 </Tip>
 
+Alternatively, if the scheme of the resource's URI is `https://`, clients may fetch the resource directly from the web — they do not need to read the resource via the MCP server. Fetching the resource directly can reduce MCP server load and avoid the overhead of Base64-encoding binary content.
+
 ## Resource updates
 
 MCP supports real-time updates for resources through two mechanisms:

--- a/docs/specification/draft/server/resources.mdx
+++ b/docs/specification/draft/server/resources.mdx
@@ -165,6 +165,8 @@ To retrieve resource contents, clients send a `resources/read` request:
 }
 ```
 
+Alternatively, if the scheme of `uri` is `https://`, clients may fetch the resource directly from the web. See the [Common URI Schemes section](#https%3A%2F%2F) for more information.
+
 ### Resource Templates
 
 Resource templates allow servers to expose parameterized resources using


### PR DESCRIPTION
The "Reading Resources" sections of both `concepts/resources.mdx` (in the User Guide) and `server/resources.mdx` (in the Specification) only mention reading resources via `resources/read`.  However, the "Common URI Schemes" section of `server/resources.mdx` [mentions](http://localhost:3000/specification/2025-06-18/server/resources#https%3A%2F%2F) that a client may fetch a resource directly from web if the resource URI has an `https://` scheme.  Fetching the resource directly can have performance benefits, so it's worth calling more attention to this provision.

This commit adds mention of the provision to both "Reading Resources" sections.
