### PR TITLE
fix: deduplicate title definition in tools

### DIFF
--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -2453,10 +2453,6 @@
                 "readOnlyHint": {
                     "description": "If true, the tool does not modify its environment.\n\nDefault: false",
                     "type": "boolean"
-                },
-                "title": {
-                    "description": "A human-readable title for the tool.",
-                    "type": "string"
                 }
             },
             "type": "object"

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -770,11 +770,6 @@ export interface ToolListChangedNotification extends Notification {
  */
 export interface ToolAnnotations {
   /**
-   * A human-readable title for the tool.
-   */
-  title?: string;
-
-  /**
    * If true, the tool does not modify its environment.
    *
    * Default: false


### PR DESCRIPTION
## Motivation and Context

Following https://github.com/modelcontextprotocol/modelcontextprotocol/pull/663, there are now two ways for a Tool to define a title, as `Tool.title` which is now receives though `BaseMetdata`, and also in `Tool.anotations.title`. I believe this change was made in error as it's not clear to clients which they should use.

## How Has This Been Tested?
Not tested

## Breaking Changes
Yes, this is a breaking change by removal of the old property.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
