### PR TITLE
docs: clarify documentation regarding dropping support for batching

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -539,7 +539,7 @@ Programmatically assemble prompts for LLMs using [GenAIScript](https://microsoft
 **Key features:**
 
 - **Prompt-to-MCP Server**: Generate fully functional MCP servers from natural language descriptions
-- **Self-Testing & Debugging**: Autonomously test, debug, and improve created MCP servers  
+- **Self-Testing & Debugging**: Autonomously test, debug, and improve created MCP servers
 - **Universal MCP Client**: Works with any MCP server through intuitive, natural language integration
 - **Curated MCP Directory**: Access to tested, one-click installable MCP servers (Neon, Netlify, GitHub, Context7, and more)
 - **Multi-Server Orchestration**: Leverage multiple MCP servers simultaneously for complex workflows

--- a/docs/docs/concepts/architecture.mdx
+++ b/docs/docs/concepts/architecture.mdx
@@ -181,6 +181,8 @@ After initialization, the following patterns are supported:
 - **Request-Response**: Client or server sends requests, the other responds
 - **Notifications**: Either party sends one-way messages
 
+Note that MCP does not support batched messages.
+
 ### 3. Termination
 
 Either party can terminate the connection:

--- a/docs/specification/2025-06-18/basic/index.mdx
+++ b/docs/specification/2025-06-18/basic/index.mdx
@@ -49,6 +49,7 @@ Requests are sent from the client to the server or vice versa, to initiate an op
 - Unlike base JSON-RPC, the ID **MUST NOT** be `null`.
 - The request ID **MUST NOT** have been previously used by the requestor within the same
   session.
+- Unlike base JSON-RPC, requests **MUST NOT** be batched.
 
 ### Responses
 

--- a/docs/specification/2025-06-18/basic/transports.mdx
+++ b/docs/specification/2025-06-18/basic/transports.mdx
@@ -26,7 +26,7 @@ In the **stdio** transport:
 - The client launches the MCP server as a subprocess.
 - The server reads JSON-RPC messages from its standard input (`stdin`) and sends messages
   to its standard output (`stdout`).
-- Messages are individual JSON-RPC requests, notifications, or responses.
+- Messages are individual JSON-RPC requests, notifications, or responses (batches are not supported).
 - Messages are delimited by newlines, and **MUST NOT** contain embedded newlines.
 - The server **MAY** write UTF-8 strings to its standard error (`stderr`) for logging
   purposes. Clients **MAY** capture, forward, or ignore this logging.
@@ -270,6 +270,7 @@ protocol version 2024-11-05) as follows:
   new "MCP endpoint" defined for the Streamable HTTP transport.
   - It is also possible to combine the old POST endpoint and the new MCP endpoint, but
     this may introduce unneeded complexity.
+- Continue to support batch requests from the client.
 
 **Clients** wanting to support older servers should:
 

--- a/docs/specification/2025-06-18/index.mdx
+++ b/docs/specification/2025-06-18/index.mdx
@@ -53,6 +53,10 @@ and tools into the ecosystem of AI applications.
 - Stateful connections
 - Server and client capability negotiation
 
+MCP deviates slightly from the JSON-RPC 2.0 specification in two respects:
+- Unlike base JSON-RPC, the `id` of a request/response (notifications excluded) **MUST NOT** be `null`.
+- Unlike base JSON-RPC, MCP does not support batching requests. Clients MUST NOT send batch requests, and servers MUST NOT respond to them.
+
 ### Features
 
 Servers offer any of the following features to clients:

--- a/docs/specification/2025-06-18/index.mdx
+++ b/docs/specification/2025-06-18/index.mdx
@@ -54,6 +54,7 @@ and tools into the ecosystem of AI applications.
 - Server and client capability negotiation
 
 MCP deviates slightly from the JSON-RPC 2.0 specification in two respects:
+
 - Unlike base JSON-RPC, the `id` of a request/response (notifications excluded) **MUST NOT** be `null`.
 - Unlike base JSON-RPC, MCP does not support batching requests. Clients MUST NOT send batch requests, and servers MUST NOT respond to them.
 

--- a/docs/specification/draft/basic/index.mdx
+++ b/docs/specification/draft/basic/index.mdx
@@ -49,6 +49,7 @@ Requests are sent from the client to the server or vice versa, to initiate an op
 - Unlike base JSON-RPC, the ID **MUST NOT** be `null`.
 - The request ID **MUST NOT** have been previously used by the requestor within the same
   session.
+- Unlike base JSON-RPC, requests **MUST NOT** be batched.
 
 ### Responses
 

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -26,7 +26,7 @@ In the **stdio** transport:
 - The client launches the MCP server as a subprocess.
 - The server reads JSON-RPC messages from its standard input (`stdin`) and sends messages
   to its standard output (`stdout`).
-- Messages are individual JSON-RPC requests, notifications, or responses.
+- Messages are individual JSON-RPC requests, notifications, or responses (batching is not supported).
 - Messages are delimited by newlines, and **MUST NOT** contain embedded newlines.
 - The server **MAY** write UTF-8 strings to its standard error (`stderr`) for logging
   purposes. Clients **MAY** capture, forward, or ignore this logging.

--- a/docs/specification/draft/index.mdx
+++ b/docs/specification/draft/index.mdx
@@ -53,6 +53,10 @@ and tools into the ecosystem of AI applications.
 - Stateful connections
 - Server and client capability negotiation
 
+MCP deviates slightly from the JSON-RPC 2.0 specification in two respects:
+- Unlike base JSON-RPC, the `id` of a request/response (notifications excluded) **MUST NOT** be `null`.
+- Unlike base JSON-RPC, MCP does not support batching requests. Clients MUST NOT send batch requests, and servers MUST NOT respond to them.
+
 ### Features
 
 Servers offer any of the following features to clients:

--- a/docs/specification/draft/index.mdx
+++ b/docs/specification/draft/index.mdx
@@ -54,6 +54,7 @@ and tools into the ecosystem of AI applications.
 - Server and client capability negotiation
 
 MCP deviates slightly from the JSON-RPC 2.0 specification in two respects:
+
 - Unlike base JSON-RPC, the `id` of a request/response (notifications excluded) **MUST NOT** be `null`.
 - Unlike base JSON-RPC, MCP does not support batching requests. Clients MUST NOT send batch requests, and servers MUST NOT respond to them.
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

I noticed in the latest Spec that batch requests are no longer supported. In my opinion, this is a deviation from JSON-RPC 2.0 spec. Regardless of whether that deviation is merited, I think it's important to be more explicit about this in the documentation. Currently, the Spec/documentation does not state anything about the lack of support for batch requests, except for in the "Key Changes" from the last version. Given that JSON-RPC (a) is part of the base messaging protocol, (b) is widely used and tooling exists for it, and (c) is clear [that](https://www.jsonrpc.org/specification#batch) "the Client MAY send an Array filled with Request objects", I think it's important to be explicit about this deviation.

For instance, the spec does explicitly state:

> Unlike base JSON-RPC, the `id` of a request/response (notifications excluded) **MUST NOT** be `null`.

So, there's precedent for some deviation from JSON-RPC, and this deviation is clearly documented in one of the first documents. I think a similar notice should be added regarding the lack of support for batching. In this PR, I've added such language where appropriate.

One point I am unclear is whether MCP currently _disallows_ batch requests or whether it simply no longer _requires_ support for them. I.e. which of the following is correct:

- A server MUST (or SHOULD) not respond to a batch request.
- A server MAY refuse to respond to a batch request.

The "Key Changes" section says "Remove support for JSON-RPC batching" - but I'm not sure which of the above is intended. The stronger, first reading seems implied; on the other hand, PR #416 discusses removing the _requirement_ - which is more suggestive of the weaker, second reading. After reading the relevant sections, I think the first reading is closer to what is intended, but I'm not sure.

Additionally I'm not sure if support for batching is allowed for backwards-compatibility purposes.

So, some of the content of the text proposed in this minor clarification may be incorrect - but I think the need for an explicit statement is still appropriate. 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
It improves the clarity of the schema by making any deviations from JSON-RPC 2.0 more explicit.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
N/A

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No - this is only meant to make more explicit what the Spec is already supposed to have declared.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
See the comment here
