### PR TITLE
Fix windows 'touch' command client quick-start docs

### DIFF
--- a/docs/quickstart/client.mdx
+++ b/docs/quickstart/client.mdx
@@ -45,7 +45,10 @@ del main.py
 # On Unix or MacOS:
 rm main.py
 
-# Create our main file
+# Create our main fileMore actions
+# On Windows:
+New-Item client.py
+# On Unix or MacOS:
 touch client.py
 ```
 

--- a/docs/quickstart/client.mdx
+++ b/docs/quickstart/client.mdx
@@ -45,7 +45,7 @@ del main.py
 # On Unix or MacOS:
 rm main.py
 
-# Create our main fileMore actions
+# Create our main file
 # On Windows:
 New-Item client.py
 # On Unix or MacOS:


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Add Windows file creation command to client setup guide

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
While following the "Getting Started with Creating a Client" guide on Windows, I encountered an issue where the documentation only provided the Unix/macOS `touch` command for creating the `client.py` file. Windows users would be stuck at this step since `touch` is not available in Windows Command Prompt or PowerShell by default. This change adds the Windows equivalent (`New-Item`) to ensure Windows developers can successfully follow the tutorial.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
- Tested the `New-Item client.py` command in PowerShell on Windows 11
- Verified that the command successfully creates an empty `client.py` file
- Confirmed the rest of the tutorial continues to work as expected on Windows

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes. This is purely additive documentation that doesn't affect existing functionality.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
This change follows the existing pattern in the documentation where platform-specific commands are provided for both Windows and Unix/macOS (as seen with the virtual environment activation commands). The `New-Item` command is the standard PowerShell equivalent to the Unix `touch` command for creating empty files.