### PR TITLE
Fix `MCP-Protocol-Version` fallback value

### DIFF
--- a/docs/specification/2025-06-18/basic/transports.mdx
+++ b/docs/specification/2025-06-18/basic/transports.mdx
@@ -253,7 +253,7 @@ initialization](/specification/2025-06-18/basic/lifecycle#version-negotiation).
 For backwards compatibility, if the server does _not_ receive an `MCP-Protocol-Version`
 header, and has no other way to identify the version - for example, by relying on the
 protocol version negotiated during initialization - the server **SHOULD** assume protocol
-version `2025-06-18`.
+version `2025-03-26`.
 
 If the server receives a request with an invalid or unsupported
 `MCP-Protocol-Version`, it **MUST** respond with `400 Bad Request`.

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -253,7 +253,7 @@ initialization](/specification/draft/basic/lifecycle#version-negotiation).
 For backwards compatibility, if the server does _not_ receive an `MCP-Protocol-Version`
 header, and has no other way to identify the version - for example, by relying on the
 protocol version negotiated during initialization - the server **SHOULD** assume protocol
-version `2025-06-18`.
+version `2025-03-26`.
 
 If the server receives a request with an invalid or unsupported
 `MCP-Protocol-Version`, it **MUST** respond with `400 Bad Request`.


### PR DESCRIPTION
Per 3d0eeb97b55f44274628a8f635ac095137791c25, the intended fallback value for the `MCP-Protocol-Version` header is `2025-03-26`.  It was accidentally changed to `2025-06-18` in d2cac4fd1420d4119624a001813df54fedaaa0ee.

---

@dsp-ant @bhosmer-ant  This is erratum for the `2025-06-18` spec.  Is there a particular way we want to handle this?
