### PR TITLE
fix: if MCP-Protocol-Version header is not provided, assume 2025-03-26

### DIFF
--- a/docs/specification/2025-06-18/basic/transports.mdx
+++ b/docs/specification/2025-06-18/basic/transports.mdx
@@ -250,13 +250,13 @@ For example: `MCP-Protocol-Version: 2025-06-18`
 The protocol version sent by the client **SHOULD** be the one [negotiated during
 initialization](/specification/2025-06-18/basic/lifecycle#version-negotiation).
 
-For backwards compatibility, if the server does _not_ receive an `MCP-Protocol-Version`
-header, and has no other way to identify the version - for example, by relying on the
-protocol version negotiated during initialization - the server **SHOULD** assume protocol
-version `2025-06-18`.
-
 If the server receives a request with an invalid or unsupported
 `MCP-Protocol-Version`, it **MUST** respond with `400 Bad Request`.
+
+For backwards compatibility, if the server does _not_ receive an `MCP-Protocol-Version`
+header, and has no other way to identify the version - for example, by relying on the
+protocol version negotiated during initialization - the server **MAY** assume protocol
+version `2025-03-26`.
 
 ### Backwards Compatibility
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

The current language in the spec (2025-06-18) reads:

> For backwards compatibility, if the server does not receive an MCP-Protocol-Version header, and has no other way to identify the version - for example, by relying on the protocol version negotiated during initialization - the server SHOULD assume protocol version 2025-06-18.

This updates the language to use **MAY**, and to assume the version is 2025-03-18 (since in version 2025-06-18 onwards the header is required).

## Motivation and Context
Fixes #548

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
I believe this is a non-breaking change because `2025-06-18` already required the MCP-Protocol-Version header. While change in version assumption shouldn't actually break anyone on 2025-06-18, and will actually allow for better supporting backwards compatibility with 2025-03-18. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
