### PR TITLE
Allow servers to require `MCP-Protocol-Version`

### DIFF
--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -252,7 +252,7 @@ initialization](/specification/draft/basic/lifecycle#version-negotiation).
 
 For backwards compatibility, if the server does _not_ receive an `MCP-Protocol-Version`
 header, and has no other way to identify the version - for example, by relying on the
-protocol version negotiated during initialization - the server **SHOULD** assume protocol
+protocol version negotiated during initialization - the server **MAY** assume protocol
 version `2025-03-26`.
 
 If the server receives a request with an invalid or unsupported


### PR DESCRIPTION
(This is based on top of https://github.com/modelcontextprotocol/modelcontextprotocol/pull/830.)

This changes "server **SHOULD** assume protocol version" to "server **MAY** assume protocol version", in order to allow servers to reject requests that are missing the `MCP-Protocol-Version` header.

/cc @kurtisvg per https://github.com/modelcontextprotocol/modelcontextprotocol/pull/855#issuecomment-3014153193.