### PR TITLE
Adds server icons for UI affordances

### DIFF
--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -774,6 +774,15 @@
                     "description": "The MIME type of the icon.",
                     "type": "string"
                 },
+                "mode": {
+                    "description": "The UI mode for which this icon is intended.",
+                    "enum": [
+                        "all",
+                        "dark",
+                        "light"
+                    ],
+                    "type": "string"
+                },
                 "uri": {
                     "description": "The URI for retrieving the icon.",
                     "type": "string"
@@ -781,6 +790,7 @@
             },
             "required": [
                 "mimeType",
+                "mode",
                 "uri"
             ],
             "type": "object"

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -60,6 +60,10 @@
         "BaseMetadata": {
             "description": "Base interface for metadata with name (identifier) and title (display name) properties.",
             "properties": {
+                "icon": {
+                    "$ref": "#/definitions/Icon",
+                    "description": "Intended for UI and end-user contexts"
+                },
                 "name": {
                     "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
                     "type": "string"
@@ -764,6 +768,23 @@
             ],
             "type": "object"
         },
+        "Icon": {
+            "properties": {
+                "mimeType": {
+                    "description": "The MIME type of the icon.",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI for retrieving the icon.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "mimeType",
+                "uri"
+            ],
+            "type": "object"
+        },
         "ImageContent": {
             "description": "An image provided to or from an LLM.",
             "properties": {
@@ -800,6 +821,10 @@
         "Implementation": {
             "description": "Describes the name and version of an MCP implementation, with an optional title for UI representation.",
             "properties": {
+                "icon": {
+                    "$ref": "#/definitions/Icon",
+                    "description": "Intended for UI and end-user contexts"
+                },
                 "name": {
                     "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
                     "type": "string"
@@ -1566,6 +1591,10 @@
                     "description": "An optional description of what this prompt provides",
                     "type": "string"
                 },
+                "icon": {
+                    "$ref": "#/definitions/Icon",
+                    "description": "Intended for UI and end-user contexts"
+                },
                 "name": {
                     "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
                     "type": "string"
@@ -1586,6 +1615,10 @@
                 "description": {
                     "description": "A human-readable description of the argument.",
                     "type": "string"
+                },
+                "icon": {
+                    "$ref": "#/definitions/Icon",
+                    "description": "Intended for UI and end-user contexts"
                 },
                 "name": {
                     "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
@@ -1648,6 +1681,10 @@
         "PromptReference": {
             "description": "Identifies a prompt.",
             "properties": {
+                "icon": {
+                    "$ref": "#/definitions/Icon",
+                    "description": "Intended for UI and end-user contexts"
+                },
                 "name": {
                     "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
                     "type": "string"
@@ -1772,6 +1809,10 @@
                     "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
                     "type": "string"
                 },
+                "icon": {
+                    "$ref": "#/definitions/Icon",
+                    "description": "Intended for UI and end-user contexts"
+                },
                 "mimeType": {
                     "description": "The MIME type of this resource, if known.",
                     "type": "string"
@@ -1838,6 +1879,10 @@
                 "description": {
                     "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
                     "type": "string"
+                },
+                "icon": {
+                    "$ref": "#/definitions/Icon",
+                    "description": "Intended for UI and end-user contexts"
                 },
                 "mimeType": {
                     "description": "The MIME type of this resource, if known.",
@@ -1911,6 +1956,10 @@
                 "description": {
                     "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
                     "type": "string"
+                },
+                "icon": {
+                    "$ref": "#/definitions/Icon",
+                    "description": "Intended for UI and end-user contexts"
                 },
                 "mimeType": {
                     "description": "The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.",
@@ -2365,6 +2414,10 @@
                 "description": {
                     "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
                     "type": "string"
+                },
+                "icon": {
+                    "$ref": "#/definitions/Icon",
+                    "description": "Intended for UI and end-user contexts"
                 },
                 "inputSchema": {
                     "description": "A JSON Schema object defining the expected parameters for the tool.",

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -278,6 +278,12 @@ interface Icon {
    * The URI for retrieving the icon.
    */
   uri: string;
+
+  /**
+   * The UI mode for which this icon is intended.
+   *
+   */
+   mode: "light" | "dark" | "all";
 }
 
 

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -267,6 +267,20 @@ export interface ServerCapabilities {
   };
 }
 
+
+interface Icon {
+  /**
+   * The MIME type of the icon.
+   */
+  mimeType: string;
+
+  /**
+   * The URI for retrieving the icon.
+   */
+  uri: string;
+}
+
+
 /**
  * Base interface for metadata with name (identifier) and title (display name) properties.
  */
@@ -285,6 +299,11 @@ export interface BaseMetadata {
    * if present).
    */
   title?: string;
+
+  /**
+   * Intended for UI and end-user contexts
+   */
+  icon?: Icon;
 }
 
 /**


### PR DESCRIPTION
Currently, prompts and tool descriptions are often concatenated within a namespace to assure there are no collisions e.g. 
![image](https://github.com/user-attachments/assets/13a4afe5-0314-4fc4-a7f3-bddac18a9a2c)

This change adds an optional argument so that implementations can identify themselves visually.

## Motivation and Context
While we can encourage MCP clients to only show the tool/prompt name, it makes it difficult to succinctly show in the UI that it's coming from a specified 3rd party source. Adding an icon would 

## How Has This Been Tested?
n/a

## Breaking Changes
n/a

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Would love feedback and additional thoughts and shape and options!
