### PR TITLE
Add optional name and title to ResourceContents

### DIFF
--- a/schema/2025-06-18/schema.json
+++ b/schema/2025-06-18/schema.json
@@ -90,6 +90,14 @@
                     "description": "The MIME type of this resource, if known.",
                     "type": "string"
                 },
+                "name": {
+                    "description": "The name of the resource.",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "A human-readable title for the resource.",
+                    "type": "string"
+                },
                 "uri": {
                     "description": "The URI of this resource.",
                     "format": "uri",
@@ -1812,6 +1820,14 @@
                     "description": "The MIME type of this resource, if known.",
                     "type": "string"
                 },
+                "name": {
+                    "description": "The name of the resource.",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "A human-readable title for the resource.",
+                    "type": "string"
+                },
                 "uri": {
                     "description": "The URI of this resource.",
                     "format": "uri",
@@ -2334,8 +2350,16 @@
                     "description": "The MIME type of this resource, if known.",
                     "type": "string"
                 },
+                "name": {
+                    "description": "The name of the resource.",
+                    "type": "string"
+                },
                 "text": {
                     "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "A human-readable title for the resource.",
                     "type": "string"
                 },
                 "uri": {

--- a/schema/2025-06-18/schema.ts
+++ b/schema/2025-06-18/schema.ts
@@ -539,6 +539,17 @@ export interface ResourceContents {
    * @format uri
    */
   uri: string;
+
+  /**
+   * The name of the resource.
+   */
+  name?: string;
+
+  /**
+   * A human-readable title for the resource.
+   */
+  title?: string;
+
   /**
    * The MIME type of this resource, if known.
    */

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -90,6 +90,14 @@
                     "description": "The MIME type of this resource, if known.",
                     "type": "string"
                 },
+                "name": {
+                    "description": "The name of the resource.",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "A human-readable title for the resource.",
+                    "type": "string"
+                },
                 "uri": {
                     "description": "The URI of this resource.",
                     "format": "uri",
@@ -1812,6 +1820,14 @@
                     "description": "The MIME type of this resource, if known.",
                     "type": "string"
                 },
+                "name": {
+                    "description": "The name of the resource.",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "A human-readable title for the resource.",
+                    "type": "string"
+                },
                 "uri": {
                     "description": "The URI of this resource.",
                     "format": "uri",
@@ -2334,8 +2350,16 @@
                     "description": "The MIME type of this resource, if known.",
                     "type": "string"
                 },
+                "name": {
+                    "description": "The name of the resource.",
+                    "type": "string"
+                },
                 "text": {
                     "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "A human-readable title for the resource.",
                     "type": "string"
                 },
                 "uri": {

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -539,6 +539,17 @@ export interface ResourceContents {
    * @format uri
    */
   uri: string;
+
+  /**
+   * The name of the resource.
+   */
+  name?: string;
+
+  /**
+   * A human-readable title for the resource.
+   */
+  title?: string;
+
   /**
    * The MIME type of this resource, if known.
    */


### PR DESCRIPTION
## Motivation and Context
The resource definition has `name` and `title`, but those fields aren't included in `ResourceContents` in `schema.ts`

https://github.com/modelcontextprotocol/modelcontextprotocol/blob/169021c2e1332eb9197a6f47fb6ec30e0a70b1d0/docs/specification/draft/server/resources.mdx?plain=1#L271-L278

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
