### PR TITLE
docs: add section about software_statement to Authorization page

### DIFF
--- a/docs/specification/draft/basic/authorization.mdx
+++ b/docs/specification/draft/basic/authorization.mdx
@@ -373,3 +373,49 @@ MCP clients **MUST** implement and use the `resource` parameter as defined in [R
 to explicitly specify the target resource for which the token is being requested. This requirement aligns with the recommendation in
 [RFC 9728 Section 7.4](https://datatracker.ietf.org/doc/html/rfc9728#section-7.4). This ensures that access tokens are bound to their intended resources and
 cannot be misused across different services.
+
+### Software Statement and JWKS
+
+MCP clients and authorization servers **SHOULD** support the use of `software_statement` and `jwks_uri` fields during Dynamic Client Registration (DCR), as defined in [RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591#section-3.1.1). 
+
+The `software_statement` is a signed JWT ([RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519)) containing metadata about the client software, and the `jwks_uri` points to a JSON Web Key Set ([RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517)) containing the public keys needed to verify these signatures.
+
+These fields enable authorization servers to validate and identify the software requesting registration, providing several benefits:
+
+- **Consistent client identification**: Software statements provide a consistent and trustworthy way to identify MCP clients, making it easier for authorization servers to track, audit, and manage them.
+- **Accountability**: Software statements establish a chain of trust back to the software vendor, supporting effective auditing and incident response.
+- **Vendor-level controls**: Authorization servers can restrict registration to trusted software vendors, reducing the risk of unauthorized or malicious clients. It can also be used to enable vendor-specific controls, such as rate limiting or blocking.
+
+MCP clients connecting to MCP servers that require software statements **MUST**:
+- Provide a `jwks_uri` that is accessible over HTTPS on a domain that the software vendor controls.
+- Include a valid `software_statement` JWT signed by a trusted authority (typically the software vendor's server) in their dynamic client registration request.
+   - Include `kid` in the `software_statement` JWT header that matches a key in the JWKS.
+
+Authorization servers that support software statements **MUST**:
+- Require the `jwks_uri` to use HTTPS.
+- Fetch the JWKS from the provided `jwks_uri`.
+- Validate the `software_statement` JWT signature using the `kid` in the JWT header to find the corresponding public key in the JWKS.
+- Validate the `exp` and `iat` claims to ensure timeliness.
+- Validate the `aud` claim matches their expected value.
+- Verify the `iss` value matches a trusted software publisher (typically the software vendor's server).
+
+The following sequence shows the Dynamic Client Registration flow when using software statements:
+
+```mermaid
+sequenceDiagram
+    participant C as MCP Client
+    participant CB as Software Vendor Server
+    participant A as Authorization Server
+
+    Note over C,CB: Software Statement Preparation
+    C->>CB: Request software_statement JWT
+    Note over CB: Generate JWT with claims:<br/>- client metadata<br/>- software ID<br/>- software version<br/>- expiration
+    CB-->>C: Signed software_statement JWT
+
+    Note over C,A: Dynamic Registration
+    C->>A: POST /register<br/>software_statement + jwks_uri
+    A->>CB: GET /mcp/jwks.json
+    CB-->>A: JWKS document
+    Note over A: 1. Validate software_statement<br/>2. Verify JWT signature using JWKS<br/>3. Check issuer trust<br/>4. Validate claims & expiry
+    A-->>C: Client credentials
+```


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

### Problem

The current MCP Dynamic Client Registration (DCR) flow lacks a way to verify the authenticity of client software attempting to register. This creates several challenges for authorization servers:

1. Cannot distinguish between legitimate MCP clients and potentially malicious implementations
2. No cryptographic way to verify that a client was created by a trusted vendor
3. Limited ability to audit which vendors' clients are using the system
4. Difficult to implement vendor-specific policies (rate limits, feature flags, allowlisting, blocking, etc.)

### Proposal

Recommend that MCP clients send `software_statement` and `jwks_uri` fields in DCR requests, as defined in [RFC 7591](https://datatracker.ietf.org/doc/html/rfc7591#section-3.1.1). This enables:

- Clients to provide cryptographically signed statements about their identity (they are who they say they are)
- Authorization servers to verify client authenticity using vendor public keys
  - Authorization servers can maintain their own list of trusted `jwks_uris` or have some self-server mechanism for clients (outside the scope of the MCP spec)
- Consistent client identification across registrations so that authorization servers can collate/group client registration to a certain vendors or software. This makes it easier to manage vendor-specific policies.

```mermaid
sequenceDiagram
    participant C as MCP Client
    participant CB as Software Vendor Server
    participant A as Authorization Server

    Note over C,CB: Software Statement Preparation
    C->>CB: Request software_statement JWT
    Note over CB: Generate JWT with claims:<br/>- client metadata<br/>- software ID<br/>- software version<br/>- expiration
    CB-->>C: Signed software_statement JWT

    Note over C,A: Dynamic Registration
    C->>A: POST /register<br/>software_statement + jwks_uri
    A->>CB: GET /mcp/jwks.json
    CB-->>A: JWKS document
    Note over A: 1. Validate software_statement<br/>2. Verify JWT signature using JWKS<br/>3. Check issuer trust<br/>4. Validate claims & expiry
    A-->>C: Client credentials
```

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

No breaking changes. While the change is recommending that MCP clients send `software_statement` and `jwks_uri` during DCR, it is not required.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
