### PR TITLE
Simplify backward compatibility wording for Structured Outputs

### DIFF
--- a/docs/specification/2025-06-18/server/tools.mdx
+++ b/docs/specification/2025-06-18/server/tools.mdx
@@ -273,8 +273,7 @@ or data using a suitable [URI scheme](./resources#common-uri-schemes). Servers t
 
 **Structured** content is returned as a JSON object in the `structuredContent` field of a result.
 
-For backwards compatibility, a tool that returns structured content SHOULD also return functionally equivalent unstructured content.
-(For example, serialized JSON can be returned in a `TextContent` block.)
+For backwards compatibility, a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block.
 
 #### Output Schema
 

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -273,8 +273,7 @@ or data using a suitable [URI scheme](./resources#common-uri-schemes). Servers t
 
 **Structured** content is returned as a JSON object in the `structuredContent` field of a result.
 
-For backwards compatibility, a tool that returns structured content SHOULD also return functionally equivalent unstructured content.
-(For example, serialized JSON can be returned in a `TextContent` block.)
+For backwards compatibility, a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block.
 
 #### Output Schema
 


### PR DESCRIPTION
Make wording for backward compatibility with structured outputs more direct.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
MCP Server Developers reading the guidance interpret it to mean the opposite of what's intended (because "unstructured" refers to the TextContent field rather than the content itself).

## How Has This Been Tested?

Local serving.
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
