### PR TITLE
fix: escape space in desktop config path

### DIFF
--- a/docs/quickstart/user.mdx
+++ b/docs/quickstart/user.mdx
@@ -39,7 +39,7 @@ Click on "Developer" in the left-hand bar of the Settings pane, and then click o
 
 This will create a configuration file at:
 
-- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- macOS: `~/Library/Application\ Support/Claude/claude_desktop_config.json`
 - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
 
 if you don't already have one, and will display the file in your file system.


### PR DESCRIPTION
Motivated by this tweet: https://x.com/mishig25/status/1940338177295741352

before:

```
❯ ls "~/Library/Application Support/Claude/claude_desktop_config.json"
ls: ~/Library/Application Support/Claude/claude_desktop_config.json: No such file or directory
```

after:

```
❯ ls ~/Library/Application\ Support/Claude/claude_desktop_config.json
/Users/mamps/Library/Application Support/Claude/claude_desktop_config.json
```