### PR TITLE
Progress notifications should not be a loop

### DIFF
--- a/docs/specification/2025-06-18/basic/utilities/progress.mdx
+++ b/docs/specification/2025-06-18/basic/utilities/progress.mdx
@@ -78,7 +78,7 @@ sequenceDiagram
     Sender->>Receiver: Method request with progressToken
 
     Note over Sender,Receiver: Progress updates
-    loop Progress Updates
+    Progress Updates
         Receiver-->>Sender: Progress notification (0.2/1.0)
         Receiver-->>Sender: Progress notification (0.6/1.0)
         Receiver-->>Sender: Progress notification (1.0/1.0)

--- a/docs/specification/2025-06-18/basic/utilities/progress.mdx
+++ b/docs/specification/2025-06-18/basic/utilities/progress.mdx
@@ -78,11 +78,9 @@ sequenceDiagram
     Sender->>Receiver: Method request with progressToken
 
     Note over Sender,Receiver: Progress updates
-    Progress Updates
-        Receiver-->>Sender: Progress notification (0.2/1.0)
-        Receiver-->>Sender: Progress notification (0.6/1.0)
-        Receiver-->>Sender: Progress notification (1.0/1.0)
-    end
+    Receiver-->>Sender: Progress notification (0.2/1.0)
+    Receiver-->>Sender: Progress notification (0.6/1.0)
+    Receiver-->>Sender: Progress notification (1.0/1.0)
 
     Note over Sender,Receiver: Operation complete
     Receiver->>Sender: Method response

--- a/docs/specification/draft/basic/utilities/progress.mdx
+++ b/docs/specification/draft/basic/utilities/progress.mdx
@@ -78,11 +78,9 @@ sequenceDiagram
     Sender->>Receiver: Method request with progressToken
 
     Note over Sender,Receiver: Progress updates
-    loop Progress Updates
-        Receiver-->>Sender: Progress notification (0.2/1.0)
-        Receiver-->>Sender: Progress notification (0.6/1.0)
-        Receiver-->>Sender: Progress notification (1.0/1.0)
-    end
+    Receiver-->>Sender: Progress notification (0.2/1.0)
+    Receiver-->>Sender: Progress notification (0.6/1.0)
+    Receiver-->>Sender: Progress notification (1.0/1.0)
 
     Note over Sender,Receiver: Operation complete
     Receiver->>Sender: Method response


### PR DESCRIPTION
I don't think these progress notifications should be a "loop" -- it is required that progress is monotonically increasing so the second iteration of this "loop" would be invalid.

## Motivation and Context

Minor clarification / fix.

## How Has This Been Tested?

Documentation fix -- no testing.

## Breaking Changes

Not breaking.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
