### PR TITLE
Updating the Authorization spec to fallback to WWW-Authenticate when Protected Resource Metadata is not found

### DIFF
--- a/docs/specification/draft/basic/authorization.mdx
+++ b/docs/specification/draft/basic/authorization.mdx
@@ -86,7 +86,7 @@ guidance on implementation details.
 Implementors should note that Protected Resource Metadata documents can define multiple authorization servers. The responsibility for selecting which authorization server to use lies with the MCP client, following the guidelines specified in
 [RFC9728 Section 7.6 "Authorization Servers"](https://datatracker.ietf.org/doc/html/rfc9728#name-authorization-servers).
 
-MCP servers **MUST** use the HTTP header `WWW-Authenticate` when returning a _401 Unauthorized_ to indicate the location of the resource server metadata URL
+MCP servers **MAY** use the HTTP header `WWW-Authenticate` when returning a _401 Unauthorized_ to indicate the location of the resource server metadata URL
 as described in [RFC9728 Section 5.1 "WWW-Authenticate Response"](https://datatracker.ietf.org/doc/html/rfc9728#name-www-authenticate-response).
 
 MCP clients **MUST** be able to parse `WWW-Authenticate` headers and respond appropriately to `HTTP 401 Unauthorized` responses from the MCP server.
@@ -106,12 +106,23 @@ sequenceDiagram
     participant M as MCP Server (Resource Server)
     participant A as Authorization Server
 
-    C->>M: MCP request without token
-    M-->>C: HTTP 401 Unauthorized with WWW-Authenticate header
-    Note over C: Extract resource_metadata<br />from WWW-Authenticate
-
+    Note over C: Try well-known metadata URL first
     C->>M: GET /.well-known/oauth-protected-resource
-    M-->>C: Resource metadata with authorization server URL
+    alt Metadata found
+        M-->>C: Resource metadata with authorization server URL
+    else Metadata not found (e.g. 404)
+        Note over C: Fallback to probing with unauthenticated request
+        C->>M: MCP request without token
+        M-->>C: HTTP 401 Unauthorized with optional WWW-Authenticate header
+        alt Header includes resource_metadata
+            Note over C: Extract resource_metadata from header
+            C->>M: GET resource_metadata URI
+            M-->>C: Resource metadata with authorization server URL
+        else No metadata found
+            Note over C: Abort or use pre-configured values
+        end
+    end
+
     Note over C: Validate RS metadata,<br />build AS metadata URL
 
     C->>A: GET /.well-known/oauth-authorization-server


### PR DESCRIPTION
Updating the Authorization spec to fallback to WWW-Authenticate when Protected Resource Metadata is not found

## Motivation and Context
According to the current spec, it is a MUST to implement the OAuth 2.0 Protected Resource Metadata which aligns with the [RFC](https://datatracker.ietf.org/doc/html/rfc9728#name-obtaining-protected-resourc). 

Also according to the current spec, 
`it is a MUST to use the HTTP header `WWW-Authenticate` when returning a _401 Unauthorized_ to indicate the location of the resource server metadata URL`. 
This might not aligned with the [RFC](https://datatracker.ietf.org/doc/html/rfc9728#section-5) which states that: `A protected resource MAY use the WWW-Authenticate HTTP response header field, as discussed in RFC9110, to return a URL to its protected resource metadata to the client`.

Not aligning with the RFC causes some challenges, it requires every URL to return back a header for other non-oauth mechanisms like PAT token cases. 

Proposal is the fallback to the header in cases where the using the `/.well-known/oauth-protected-resource` returns back a 404.

## How Has This Been Tested?
Have you tested this in a real application? Which scenarios were tested?

Updating the spec according to the [RFC](https://datatracker.ietf.org/doc/html/rfc9728#name-obtaining-protected-resourc)

## Breaking Changes
Will users need to update their code or configurations?

Yes some clients would need to update if they solely rely on WWW-Authenticate header and rather use this as a fallback instead. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
