### PR TITLE
Client Advertisement for Supported Server Capabilities

### DIFF
--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -51,6 +51,7 @@ The client **MUST** initiate this phase by sending an `initialize` request conta
 - Protocol version supported
 - Client capabilities
 - Client implementation information
+- Client supported server capabilities [optional]
 
 ```json
 {
@@ -70,6 +71,10 @@ The client **MUST** initiate this phase by sending an `initialize` request conta
       "name": "ExampleClient",
       "title": "Example Client Display Name",
       "version": "1.0.0"
+    },
+    "supportedServerCapabilities": {
+      "tools": {},
+      "resources": { listChanged: false }
     }
   }
 }

--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -74,7 +74,9 @@ The client **MUST** initiate this phase by sending an `initialize` request conta
     },
     "supportedServerCapabilities": {
       "tools": {},
-      "resources": { listChanged: false }
+      "resources": {
+        "listChanged": false
+      }
     }
   }
 }

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -836,6 +836,9 @@
                         "protocolVersion": {
                             "description": "The latest version of the Model Context Protocol that the client supports. The client MAY decide to support older versions as well.",
                             "type": "string"
+                        },
+                        "supportedServerCapabilities": {
+                            "$ref": "#/definitions/ServerCapabilities"
                         }
                     },
                     "required": [

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -177,6 +177,7 @@ export interface InitializeRequest extends Request {
     protocolVersion: string;
     capabilities: ClientCapabilities;
     clientInfo: Implementation;
+    supportedServerCapabilties?: ServerCapabilities;
   };
 }
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

This change adds a new, optional field `supportedServerCapabilities` to the `InitializeRequest` so the client has a way to let the server know which types of server capabilities it supports.

```json
interface InitializeRequest {
  method: “initialize”;
  params: {
    capabilities: ClientCapabilities;
    clientInfo: Implementation;
    protocolVersion: string;
    supportedServerCapabilities?: ServerCapabilities;
  };
}
```

## Motivation and Context

Currently, MCP clients vary in their support for features such as tools, resources, and prompts. Without a standard way to signal this support, server implementations must take a lowest-common-denominator approach or redundantly define tools and resources in parallel. For example, a server may create both a tool and a resource to ensure compatibility with clients that only support one or the other, leading to unnecessary duplication and complexity.

This proposal addresses the gap by enabling clients to advertise their supported server capabilities, allowing servers to make informed decisions about how to expose functionality.

## How Has This Been Tested?

n/a

## Breaking Changes

None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed
