### PR TITLE
Replace reference to incorrect pypi.com with pypi.org

### DIFF
--- a/docs/docs/tools/inspector.mdx
+++ b/docs/docs/tools/inspector.mdx
@@ -21,7 +21,7 @@ npx @modelcontextprotocol/inspector <command> <arg1> <arg2>
 
 #### Inspecting servers from NPM or PyPi
 
-A common way to start server packages from [NPM](https://npmjs.com) or [PyPi](https://pypi.com).
+A common way to start server packages from [NPM](https://npmjs.com) or [PyPi](https://pypi.org).
 
 <Tabs>
 


### PR DESCRIPTION
## Motivation and Context
pypi.com is the wrong domain. 

## How Has This Been Tested?
N/A

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
