### PR TITLE
Update CODEOWNERS: Add steering committee ownership for /docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,9 @@
 # CODEOWNERS file for MCP Specification repository
 
-# Global ownership - @core-maintainer team owns docs/specification and schema/ directories
+# General documentation ownership - @steering-committee owns all of /docs
+/docs/ @modelcontextprotocol/steering-committee
+
+# Specific ownership - @core-maintainer team owns docs/specification and schema/ directories
 /docs/specification/ @modelcontextprotocol/core-maintainers
 /schema/ @modelcontextprotocol/core-maintainers
 


### PR DESCRIPTION
## Summary
- Added `@modelcontextprotocol/steering-committee` as owners of the `/docs` directory
- Maintained `@modelcontextprotocol/core-maintainers` ownership for `/docs/specification` (more specific path takes precedence)
- This allows the steering committee to review and approve changes to general documentation while keeping specification changes restricted to core maintainers

## Test plan
- [ ] Verify that changes to files in `/docs` (but not `/docs/specification`) request review from steering committee
- [ ] Verify that changes to files in `/docs/specification` still request review from core maintainers
- [ ] Confirm GitHub recognizes the CODEOWNERS file syntax is valid

🤖 Generated with [Claude Code](https://claude.ai/code)