### PR TITLE
Backport changes to `lifecycle.mdx` from `2025-06-18` to `draft`.

### DIFF
--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -174,7 +174,7 @@ Capability objects can describe sub-capabilities like:
 During the operation phase, the client and server exchange messages according to the
 negotiated capabilities.
 
-Both parties **SHOULD**:
+Both parties **MUST**:
 
 - Respect the negotiated protocol version
 - Only use capabilities that were successfully negotiated

--- a/docs/specification/draft/changelog.mdx
+++ b/docs/specification/draft/changelog.mdx
@@ -10,7 +10,6 @@ the previous revision, [2025-06-18](/specification/2025-06-18).
 ## Major changes
 
 1. Enhance authorization server discovery with support for [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html). (PR [#797](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/797))
-2. Backport change _SHOULD_ to _MUST_ in [Lifecycle Operation](/specification/draft/basic/lifecycle#operation) from commit [e547813](https://github.com/modelcontextprotocol/modelcontextprotocol/commit/e54781342c25d97c9ca4ba3fede237a2f3f37b32).
 
 ## Other schema changes
 

--- a/docs/specification/draft/changelog.mdx
+++ b/docs/specification/draft/changelog.mdx
@@ -10,6 +10,7 @@ the previous revision, [2025-06-18](/specification/2025-06-18).
 ## Major changes
 
 1. Enhance authorization server discovery with support for [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html). (PR [#797](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/797))
+2. Backport change _SHOULD_ to _MUST_ in [Lifecycle Operation](/specification/draft/basic/lifecycle#operation) from commit [e547813](https://github.com/modelcontextprotocol/modelcontextprotocol/commit/e54781342c25d97c9ca4ba3fede237a2f3f37b32).
 
 ## Other schema changes
 


### PR DESCRIPTION
## Motivation and Context
In the PR releasing a new revision of the spec (#783), commit e547813 changed a `SHOULD` to `MUST` in Lifecycle Operation section, but the change was not backported to the draft file.

This PR backports the change avoiding potential regressions.

## How Has This Been Tested?
Ran instructions specified in `CONTRIBUTING.md`

## Breaking Changes
None

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
None