### PR TITLE
Add missing id fields to next page requests

### DIFF
--- a/docs/specification/2025-06-18/server/utilities/pagination.mdx
+++ b/docs/specification/2025-06-18/server/utilities/pagination.mdx
@@ -48,6 +48,7 @@ including that cursor:
 ```json
 {
   "jsonrpc": "2.0",
+  "id": "124",
   "method": "resources/list",
   "params": {
     "cursor": "eyJwYWdlIjogMn0="

--- a/docs/specification/draft/server/utilities/pagination.mdx
+++ b/docs/specification/draft/server/utilities/pagination.mdx
@@ -48,6 +48,7 @@ including that cursor:
 ```json
 {
   "jsonrpc": "2.0",
+  "id": "124",
   "method": "resources/list",
   "params": {
     "cursor": "eyJwYWdlIjogMn0="


### PR DESCRIPTION
This PR fixes a minor issue with the pagination request examples -- they were missing an `id` field, which is a required field in JSON RPC requests.

## Motivation and Context

Fix the examples to be valid requests.

## How Has This Been Tested?

Doc only change.

## Breaking Changes

Not breaking.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

I have only made this fix in the 2025-06-18 and draft spec directories. I think the problem also exists in earlier versions -- I can push fixes for those as well if that's desired.
