### PR TITLE
docs: add comment about batch messages

### DIFF
--- a/docs/specification/2025-06-18/basic/index.mdx
+++ b/docs/specification/2025-06-18/basic/index.mdx
@@ -27,8 +27,9 @@ support exactly the features they need.
 ## Messages
 
 All messages between MCP clients and servers **MUST** follow the
-[JSON-RPC 2.0](https://www.jsonrpc.org/specification) specification. The protocol defines
-these types of messages:
+[JSON-RPC 2.0](https://www.jsonrpc.org/specification) specification, with the exception
+that MCP does not support batch messages, and clients MUST NOT send batch requests.
+The protocol defines these types of messages:
 
 ### Requests
 

--- a/docs/specification/draft/basic/index.mdx
+++ b/docs/specification/draft/basic/index.mdx
@@ -27,8 +27,9 @@ support exactly the features they need.
 ## Messages
 
 All messages between MCP clients and servers **MUST** follow the
-[JSON-RPC 2.0](https://www.jsonrpc.org/specification) specification. The protocol defines
-these types of messages:
+[JSON-RPC 2.0](https://www.jsonrpc.org/specification) specification, with the exception
+that MCP does not support batch messages, and clients MUST NOT send batch requests.
+The protocol defines these types of messages:
 
 ### Requests
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
MCP dropped support for batch messages in the latest version. This is noted [here](https://modelcontextprotocol.io/specification/2025-06-18/changelog#major-changes). This is **only** noted there.

MCP is emphatic that JSON-RPC is the base protocol for messages. JSON-RPC 2.0 spec states [clearly](https://www.jsonrpc.org/specification#batch):

> To send several Request objects at the same time, the Client MAY send an Array filled with Request objects.

MCP deviates from JSON-RPC in this regard. However, there is _no mention_ of this in the specification/protocol - batches have just been "disappeared" and the changelog is the only place that this is documented. In the next version, I would imagine even this will disappear (seeing as it's no longer a "change"). In this PR, I add a very short comment which clarifies that MCP does _not_ support all of the message types of JSON-RPC. My justification for the stronger language that clients "MUST NOT" send batch requests is that "MUST" is designed specifically for interoperability, and a client that thinks it can send batches and receive a response has lost interoperability.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Interoperability is at the core of a protocol like MCP. Without mentioning this deviation from JSON-RPC, the Protocol impairs interoperability by repeatedly stating that JSON-RPC message protocol is the base message format, which is misleading if it fails to declare exceptions to that very simple protocol. This omission could likely impair tooling that is built around JSON-RPC. A person should not have to study the changelog from previous versions to learn something that is a non-trivial part of the Protocol (changelogs are to notify people of _changes_ - they should not be considered a proper part of the Protocol itself).

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
N/A

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Client applications or client SDK's that support batch requests must remove this option, or accept that these requests will fail. But this PR is not a breaking change, it is merely a clarification of a breaking change. Server implementations needn't be bothered really, because they just don't need to handle batch requests. Either way, that has little to do with this PR, which does not propose any changes to the Protocol at all.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
This is admittedly bad form, since I already submitted a PR for this in #828 (which I closed), but I think it's gone stale and forgotten, and I'll stand my ground that this is worthy of inclusion, so I've shrunk the diff down to the smallest I could. I see no justification for not making this feature of MCP explicit, so I'm reopening this PR because I think adding 12 words that could possibly avoid confusion justifies this bad etiquette. I do apologize though and I won't re-open it again.