### PR TITLE
Use `<CodeGroup>` instead of `<Tabs>`

### DIFF
--- a/docs/docs/concepts/architecture.mdx
+++ b/docs/docs/concepts/architecture.mdx
@@ -36,62 +36,63 @@ flowchart LR
 
 The protocol layer handles message framing, request/response linking, and high-level communication patterns.
 
-<Tabs>
-  <Tab title="TypeScript">
+<CodeGroup>
 
-    ```typescript
-    class Protocol<Request, Notification, Result> {
-        // Handle incoming requests
-        setRequestHandler<T>(schema: T, handler: (request: T, extra: RequestHandlerExtra) => Promise<Result>): void
+```typescript TypeScript
+class Protocol<Request, Notification, Result> {
+  // Handle incoming requests
+  setRequestHandler<T>(
+    schema: T,
+    handler: (request: T, extra: RequestHandlerExtra) => Promise<Result>,
+  ): void;
 
-        // Handle incoming notifications
-        setNotificationHandler<T>(schema: T, handler: (notification: T) => Promise<void>): void
+  // Handle incoming notifications
+  setNotificationHandler<T>(
+    schema: T,
+    handler: (notification: T) => Promise<void>,
+  ): void;
 
-        // Send requests and await responses
-        request<T>(request: Request, schema: T, options?: RequestOptions): Promise<T>
+  // Send requests and await responses
+  request<T>(request: Request, schema: T, options?: RequestOptions): Promise<T>;
 
-        // Send one-way notifications
-        notification(notification: Notification): Promise<void>
-    }
-    ```
+  // Send one-way notifications
+  notification(notification: Notification): Promise<void>;
+}
+```
 
-  </Tab>
-  <Tab title="Python">
+```python Python
+class Session(BaseSession[RequestT, NotificationT, ResultT]):
+    async def send_request(
+        self,
+        request: RequestT,
+        result_type: type[Result]
+    ) -> Result:
+        """Send request and wait for response. Raises McpError if response contains error."""
+        # Request handling implementation
 
-    ```python
-    class Session(BaseSession[RequestT, NotificationT, ResultT]):
-        async def send_request(
-            self,
-            request: RequestT,
-            result_type: type[Result]
-        ) -> Result:
-            """Send request and wait for response. Raises McpError if response contains error."""
-            # Request handling implementation
+    async def send_notification(
+        self,
+        notification: NotificationT
+    ) -> None:
+        """Send one-way notification that doesn't expect response."""
+        # Notification handling implementation
 
-        async def send_notification(
-            self,
-            notification: NotificationT
-        ) -> None:
-            """Send one-way notification that doesn't expect response."""
-            # Notification handling implementation
+    async def _received_request(
+        self,
+        responder: RequestResponder[ReceiveRequestT, ResultT]
+    ) -> None:
+        """Handle incoming request from other side."""
+        # Request handling implementation
 
-        async def _received_request(
-            self,
-            responder: RequestResponder[ReceiveRequestT, ResultT]
-        ) -> None:
-            """Handle incoming request from other side."""
-            # Request handling implementation
+    async def _received_notification(
+        self,
+        notification: ReceiveNotificationT
+    ) -> None:
+        """Handle incoming notification from other side."""
+        # Notification handling implementation
+```
 
-        async def _received_notification(
-            self,
-            notification: ReceiveNotificationT
-        ) -> None:
-            """Handle incoming notification from other side."""
-            # Notification handling implementation
-    ```
-
-  </Tab>
-</Tabs>
+</CodeGroup>
 
 Key classes include:
 
@@ -216,73 +217,71 @@ Errors are propagated through:
 
 Here's a basic example of implementing an MCP server:
 
-<Tabs>
-  <Tab title="TypeScript">
+<CodeGroup>
 
-    ```typescript
-    import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-    import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+```typescript TypeScript
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 
-    const server = new Server({
-      name: "example-server",
-      version: "1.0.0"
-    }, {
-      capabilities: {
-        resources: {}
-      }
-    });
+const server = new Server(
+  {
+    name: "example-server",
+    version: "1.0.0",
+  },
+  {
+    capabilities: {
+      resources: {},
+    },
+  },
+);
 
-    // Handle requests
-    server.setRequestHandler(ListResourcesRequestSchema, async () => {
-      return {
-        resources: [
-          {
-            uri: "example://resource",
-            name: "Example Resource"
-          }
-        ]
-      };
-    });
+// Handle requests
+server.setRequestHandler(ListResourcesRequestSchema, async () => {
+  return {
+    resources: [
+      {
+        uri: "example://resource",
+        name: "Example Resource",
+      },
+    ],
+  };
+});
 
-    // Connect transport
-    const transport = new StdioServerTransport();
-    await server.connect(transport);
-    ```
+// Connect transport
+const transport = new StdioServerTransport();
+await server.connect(transport);
+```
 
-  </Tab>
-  <Tab title="Python">
+```python Python
+import asyncio
+import mcp.types as types
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
 
-    ```python
-    import asyncio
-    import mcp.types as types
-    from mcp.server import Server
-    from mcp.server.stdio import stdio_server
+app = Server("example-server")
 
-    app = Server("example-server")
+@app.list_resources()
+async def list_resources() -> list[types.Resource]:
+    return [
+        types.Resource(
+            uri="example://resource",
+            name="Example Resource"
+        )
+    ]
 
-    @app.list_resources()
-    async def list_resources() -> list[types.Resource]:
-        return [
-            types.Resource(
-                uri="example://resource",
-                name="Example Resource"
-            )
-        ]
+async def main():
+    async with stdio_server() as streams:
+        await app.run(
+            streams[0],
+            streams[1],
+            app.create_initialization_options()
+        )
 
-    async def main():
-        async with stdio_server() as streams:
-            await app.run(
-                streams[0],
-                streams[1],
-                app.create_initialization_options()
-            )
+if __name__ == "__main__":
+    asyncio.run(main())
+```
 
-    if __name__ == "__main__":
-        asyncio.run(main())
-    ```
-
-  </Tab>
-</Tabs>
+</CodeGroup>
 
 ## Best practices
 

--- a/docs/docs/concepts/prompts.mdx
+++ b/docs/docs/concepts/prompts.mdx
@@ -198,189 +198,187 @@ const debugWorkflow = {
 
 Here's a complete example of implementing prompts in an MCP server:
 
-<Tabs>
-  <Tab title="TypeScript">
+<CodeGroup>
 
-    ```typescript
-    import { Server } from "@modelcontextprotocol/sdk/server";
-    import {
-      ListPromptsRequestSchema,
-      GetPromptRequestSchema
-    } from "@modelcontextprotocol/sdk/types";
+```typescript TypeScript
+import { Server } from "@modelcontextprotocol/sdk/server";
+import {
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
+} from "@modelcontextprotocol/sdk/types";
 
-    const PROMPTS = {
-      "git-commit": {
-        name: "git-commit",
-        description: "Generate a Git commit message",
-        arguments: [
-          {
-            name: "changes",
-            description: "Git diff or description of changes",
-            required: true
-          }
-        ]
+const PROMPTS = {
+  "git-commit": {
+    name: "git-commit",
+    description: "Generate a Git commit message",
+    arguments: [
+      {
+        name: "changes",
+        description: "Git diff or description of changes",
+        required: true,
       },
-      "explain-code": {
-        name: "explain-code",
-        description: "Explain how code works",
-        arguments: [
-          {
-            name: "code",
-            description: "Code to explain",
-            required: true
+    ],
+  },
+  "explain-code": {
+    name: "explain-code",
+    description: "Explain how code works",
+    arguments: [
+      {
+        name: "code",
+        description: "Code to explain",
+        required: true,
+      },
+      {
+        name: "language",
+        description: "Programming language",
+        required: false,
+      },
+    ],
+  },
+};
+
+const server = new Server(
+  {
+    name: "example-prompts-server",
+    version: "1.0.0",
+  },
+  {
+    capabilities: {
+      prompts: {},
+    },
+  },
+);
+
+// List available prompts
+server.setRequestHandler(ListPromptsRequestSchema, async () => {
+  return {
+    prompts: Object.values(PROMPTS),
+  };
+});
+
+// Get specific prompt
+server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+  const prompt = PROMPTS[request.params.name];
+  if (!prompt) {
+    throw new Error(`Prompt not found: ${request.params.name}`);
+  }
+
+  if (request.params.name === "git-commit") {
+    return {
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: `Generate a concise but descriptive commit message for these changes:\n\n${request.params.arguments?.changes}`,
           },
-          {
-            name: "language",
-            description: "Programming language",
-            required: false
-          }
-        ]
-      }
+        },
+      ],
     };
+  }
 
-    const server = new Server({
-      name: "example-prompts-server",
-      version: "1.0.0"
-    }, {
-      capabilities: {
-        prompts: {}
-      }
-    });
+  if (request.params.name === "explain-code") {
+    const language = request.params.arguments?.language || "Unknown";
+    return {
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: `Explain how this ${language} code works:\n\n${request.params.arguments?.code}`,
+          },
+        },
+      ],
+    };
+  }
 
-    // List available prompts
-    server.setRequestHandler(ListPromptsRequestSchema, async () => {
-      return {
-        prompts: Object.values(PROMPTS)
-      };
-    });
+  throw new Error("Prompt implementation not found");
+});
+```
 
-    // Get specific prompt
-    server.setRequestHandler(GetPromptRequestSchema, async (request) => {
-      const prompt = PROMPTS[request.params.name];
-      if (!prompt) {
-        throw new Error(`Prompt not found: ${request.params.name}`);
-      }
+```python Python
+from mcp.server import Server
+import mcp.types as types
 
-      if (request.params.name === "git-commit") {
-        return {
-          messages: [
-            {
-              role: "user",
-              content: {
-                type: "text",
-                text: `Generate a concise but descriptive commit message for these changes:\n\n${request.params.arguments?.changes}`
-              }
-            }
-          ]
-        };
-      }
+# Define available prompts
+PROMPTS = {
+    "git-commit": types.Prompt(
+        name="git-commit",
+        description="Generate a Git commit message",
+        arguments=[
+            types.PromptArgument(
+                name="changes",
+                description="Git diff or description of changes",
+                required=True
+            )
+        ],
+    ),
+    "explain-code": types.Prompt(
+        name="explain-code",
+        description="Explain how code works",
+        arguments=[
+            types.PromptArgument(
+                name="code",
+                description="Code to explain",
+                required=True
+            ),
+            types.PromptArgument(
+                name="language",
+                description="Programming language",
+                required=False
+            )
+        ],
+    )
+}
 
-      if (request.params.name === "explain-code") {
-        const language = request.params.arguments?.language || "Unknown";
-        return {
-          messages: [
-            {
-              role: "user",
-              content: {
-                type: "text",
-                text: `Explain how this ${language} code works:\n\n${request.params.arguments?.code}`
-              }
-            }
-          ]
-        };
-      }
+# Initialize server
+app = Server("example-prompts-server")
 
-      throw new Error("Prompt implementation not found");
-    });
-    ```
+@app.list_prompts()
+async def list_prompts() -> list[types.Prompt]:
+    return list(PROMPTS.values())
 
-  </Tab>
-  <Tab title="Python">
+@app.get_prompt()
+async def get_prompt(
+    name: str, arguments: dict[str, str] | None = None
+) -> types.GetPromptResult:
+    if name not in PROMPTS:
+        raise ValueError(f"Prompt not found: {name}")
 
-    ```python
-    from mcp.server import Server
-    import mcp.types as types
-
-    # Define available prompts
-    PROMPTS = {
-        "git-commit": types.Prompt(
-            name="git-commit",
-            description="Generate a Git commit message",
-            arguments=[
-                types.PromptArgument(
-                    name="changes",
-                    description="Git diff or description of changes",
-                    required=True
+    if name == "git-commit":
+        changes = arguments.get("changes") if arguments else ""
+        return types.GetPromptResult(
+            messages=[
+                types.PromptMessage(
+                    role="user",
+                    content=types.TextContent(
+                        type="text",
+                        text=f"Generate a concise but descriptive commit message "
+                        f"for these changes:\n\n{changes}"
+                    )
                 )
-            ],
-        ),
-        "explain-code": types.Prompt(
-            name="explain-code",
-            description="Explain how code works",
-            arguments=[
-                types.PromptArgument(
-                    name="code",
-                    description="Code to explain",
-                    required=True
-                ),
-                types.PromptArgument(
-                    name="language",
-                    description="Programming language",
-                    required=False
-                )
-            ],
+            ]
         )
-    }
 
-    # Initialize server
-    app = Server("example-prompts-server")
-
-    @app.list_prompts()
-    async def list_prompts() -> list[types.Prompt]:
-        return list(PROMPTS.values())
-
-    @app.get_prompt()
-    async def get_prompt(
-        name: str, arguments: dict[str, str] | None = None
-    ) -> types.GetPromptResult:
-        if name not in PROMPTS:
-            raise ValueError(f"Prompt not found: {name}")
-
-        if name == "git-commit":
-            changes = arguments.get("changes") if arguments else ""
-            return types.GetPromptResult(
-                messages=[
-                    types.PromptMessage(
-                        role="user",
-                        content=types.TextContent(
-                            type="text",
-                            text=f"Generate a concise but descriptive commit message "
-                            f"for these changes:\n\n{changes}"
-                        )
+    if name == "explain-code":
+        code = arguments.get("code") if arguments else ""
+        language = arguments.get("language", "Unknown") if arguments else "Unknown"
+        return types.GetPromptResult(
+            messages=[
+                types.PromptMessage(
+                    role="user",
+                    content=types.TextContent(
+                        type="text",
+                        text=f"Explain how this {language} code works:\n\n{code}"
                     )
-                ]
-            )
+                )
+            ]
+        )
 
-        if name == "explain-code":
-            code = arguments.get("code") if arguments else ""
-            language = arguments.get("language", "Unknown") if arguments else "Unknown"
-            return types.GetPromptResult(
-                messages=[
-                    types.PromptMessage(
-                        role="user",
-                        content=types.TextContent(
-                            type="text",
-                            text=f"Explain how this {language} code works:\n\n{code}"
-                        )
-                    )
-                ]
-            )
+    raise ValueError("Prompt implementation not found")
+```
 
-        raise ValueError("Prompt implementation not found")
-    ```
-
-  </Tab>
-</Tabs>
+</CodeGroup>
 
 ## Best practices
 

--- a/docs/docs/concepts/resources.mdx
+++ b/docs/docs/concepts/resources.mdx
@@ -151,88 +151,86 @@ Clients can subscribe to updates for specific resources:
 
 Here's a simple example of implementing resource support in an MCP server:
 
-<Tabs>
-  <Tab title="TypeScript">
+<CodeGroup>
 
-    ```typescript
-    const server = new Server({
-      name: "example-server",
-      version: "1.0.0"
-    }, {
-      capabilities: {
-        resources: {}
-      }
-    });
+```typescript TypeScript
+const server = new Server(
+  {
+    name: "example-server",
+    version: "1.0.0",
+  },
+  {
+    capabilities: {
+      resources: {},
+    },
+  },
+);
 
-    // List available resources
-    server.setRequestHandler(ListResourcesRequestSchema, async () => {
-      return {
-        resources: [
-          {
-            uri: "file:///logs/app.log",
-            name: "Application Logs",
-            mimeType: "text/plain"
-          }
-        ]
-      };
-    });
+// List available resources
+server.setRequestHandler(ListResourcesRequestSchema, async () => {
+  return {
+    resources: [
+      {
+        uri: "file:///logs/app.log",
+        name: "Application Logs",
+        mimeType: "text/plain",
+      },
+    ],
+  };
+});
 
-    // Read resource contents
-    server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
-      const uri = request.params.uri;
+// Read resource contents
+server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+  const uri = request.params.uri;
 
-      if (uri === "file:///logs/app.log") {
-        const logContents = await readLogFile();
-        return {
-          contents: [
-            {
-              uri,
-              mimeType: "text/plain",
-              text: logContents
-            }
-          ]
-        };
-      }
+  if (uri === "file:///logs/app.log") {
+    const logContents = await readLogFile();
+    return {
+      contents: [
+        {
+          uri,
+          mimeType: "text/plain",
+          text: logContents,
+        },
+      ],
+    };
+  }
 
-      throw new Error("Resource not found");
-    });
-    ```
+  throw new Error("Resource not found");
+});
+```
 
-  </Tab>
-  <Tab title="Python">
+```python Python
+app = Server("example-server")
 
-    ```python
-    app = Server("example-server")
-
-    @app.list_resources()
-    async def list_resources() -> list[types.Resource]:
-        return [
-            types.Resource(
-                uri="file:///logs/app.log",
-                name="Application Logs",
-                mimeType="text/plain"
-            )
-        ]
-
-    @app.read_resource()
-    async def read_resource(uri: AnyUrl) -> str:
-        if str(uri) == "file:///logs/app.log":
-            log_contents = await read_log_file()
-            return log_contents
-
-        raise ValueError("Resource not found")
-
-    # Start server
-    async with stdio_server() as streams:
-        await app.run(
-            streams[0],
-            streams[1],
-            app.create_initialization_options()
+@app.list_resources()
+async def list_resources() -> list[types.Resource]:
+    return [
+        types.Resource(
+            uri="file:///logs/app.log",
+            name="Application Logs",
+            mimeType="text/plain"
         )
-    ```
+    ]
 
-  </Tab>
-</Tabs>
+@app.read_resource()
+async def read_resource(uri: AnyUrl) -> str:
+    if str(uri) == "file:///logs/app.log":
+        log_contents = await read_log_file()
+        return log_contents
+
+    raise ValueError("Resource not found")
+
+# Start server
+async with stdio_server() as streams:
+    await app.run(
+        streams[0],
+        streams[1],
+        app.create_initialization_options()
+    )
+```
+
+</CodeGroup>
 
 ## Best practices
 

--- a/docs/docs/concepts/tools.mdx
+++ b/docs/docs/concepts/tools.mdx
@@ -47,92 +47,92 @@ Each tool is defined with the following structure:
 
 Here's an example of implementing a basic tool in an MCP server:
 
-<Tabs>
-  <Tab title="TypeScript">
+<CodeGroup>
 
-    ```typescript
-    const server = new Server({
-      name: "example-server",
-      version: "1.0.0"
-    }, {
-      capabilities: {
-        tools: {}
-      }
-    });
+```typescript TypeScript
+const server = new Server(
+  {
+    name: "example-server",
+    version: "1.0.0",
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  },
+);
 
-    // Define available tools
-    server.setRequestHandler(ListToolsRequestSchema, async () => {
-      return {
-        tools: [{
-          name: "calculate_sum",
-          description: "Add two numbers together",
-          inputSchema: {
-            type: "object",
-            properties: {
-              a: { type: "number" },
-              b: { type: "number" }
-            },
-            required: ["a", "b"]
-          }
-        }]
-      };
-    });
+// Define available tools
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: [
+      {
+        name: "calculate_sum",
+        description: "Add two numbers together",
+        inputSchema: {
+          type: "object",
+          properties: {
+            a: { type: "number" },
+            b: { type: "number" },
+          },
+          required: ["a", "b"],
+        },
+      },
+    ],
+  };
+});
 
-    // Handle tool execution
-    server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      if (request.params.name === "calculate_sum") {
-        const { a, b } = request.params.arguments;
-        return {
-          content: [
-            {
-              type: "text",
-              text: String(a + b)
+// Handle tool execution
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  if (request.params.name === "calculate_sum") {
+    const { a, b } = request.params.arguments;
+    return {
+      content: [
+        {
+          type: "text",
+          text: String(a + b),
+        },
+      ],
+    };
+  }
+  throw new Error("Tool not found");
+});
+```
+
+```python Python
+app = Server("example-server")
+
+@app.list_tools()
+async def list_tools() -> list[types.Tool]:
+    return [
+        types.Tool(
+            name="calculate_sum",
+            description="Add two numbers together",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "a": {"type": "number"},
+                    "b": {"type": "number"}
+                },
+                "required": ["a", "b"]
             }
-          ]
-        };
-      }
-      throw new Error("Tool not found");
-    });
-    ```
+        )
+    ]
 
-  </Tab>
-  <Tab title="Python">
+@app.call_tool()
+async def call_tool(
+    name: str,
+    arguments: dict
+) -> list[types.TextContent | types.ImageContent | types.EmbeddedResource]:
+    if name == "calculate_sum":
+        a = arguments["a"]
+        b = arguments["b"]
+        result = a + b
+        return [types.TextContent(type="text", text=str(result))]
+    raise ValueError(f"Tool not found: {name}")
+```
 
-    ```python
-    app = Server("example-server")
-
-    @app.list_tools()
-    async def list_tools() -> list[types.Tool]:
-        return [
-            types.Tool(
-                name="calculate_sum",
-                description="Add two numbers together",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "a": {"type": "number"},
-                        "b": {"type": "number"}
-                    },
-                    "required": ["a", "b"]
-                }
-            )
-        ]
-
-    @app.call_tool()
-    async def call_tool(
-        name: str,
-        arguments: dict
-    ) -> list[types.TextContent | types.ImageContent | types.EmbeddedResource]:
-        if name == "calculate_sum":
-            a = arguments["a"]
-            b = arguments["b"]
-            result = a + b
-            return [types.TextContent(type="text", text=str(result))]
-        raise ValueError(f"Tool not found: {name}")
-    ```
-
-  </Tab>
-</Tabs>
+</CodeGroup>
 
 ## Example tool patterns
 
@@ -271,63 +271,58 @@ Tool errors should be reported within the result object, not as MCP protocol-lev
 
 Here's an example of proper error handling for tools:
 
-<Tabs>
-  <Tab title="TypeScript">
+<CodeGroup>
 
-    ```typescript
-    try {
-      // Tool operation
-      const result = performOperation();
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Operation successful: ${result}`
-          }
+```typescript TypeScript
+try {
+  // Tool operation
+  const result = performOperation();
+  return {
+    content: [
+      {
+        type: "text",
+        text: `Operation successful: ${result}`,
+      },
+    ],
+  };
+} catch (error) {
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text",
+        text: `Error: ${error.message}`,
+      },
+    ],
+  };
+}
+```
+
+```python Python
+try:
+    # Tool operation
+    result = perform_operation()
+    return types.CallToolResult(
+        content=[
+            types.TextContent(
+                type="text",
+                text=f"Operation successful: {result}"
+            )
         ]
-      };
-    } catch (error) {
-      return {
-        isError: true,
-        content: [
-          {
-            type: "text",
-            text: `Error: ${error.message}`
-          }
+    )
+except Exception as error:
+    return types.CallToolResult(
+        isError=True,
+        content=[
+            types.TextContent(
+                type="text",
+                text=f"Error: {str(error)}"
+            )
         ]
-      };
-    }
-    ```
+    )
+```
 
-  </Tab>
-  <Tab title="Python">
-
-    ```python
-    try:
-        # Tool operation
-        result = perform_operation()
-        return types.CallToolResult(
-            content=[
-                types.TextContent(
-                    type="text",
-                    text=f"Operation successful: {result}"
-                )
-            ]
-        )
-    except Exception as error:
-        return types.CallToolResult(
-            isError=True,
-            content=[
-                types.TextContent(
-                    type="text",
-                    text=f"Error: {str(error)}"
-                )
-            ]
-        )
-    ```
-
-  </Tab>
-</Tabs>
+</CodeGroup>
 
 This approach allows the LLM to see that an error occurred and potentially take corrective action or request human intervention.
 
@@ -423,61 +418,58 @@ Here's how to define tools with annotations for different scenarios:
 
 ### Integrating annotations in server implementation
 
-<Tabs>
-  <Tab title="TypeScript">
+<CodeGroup>
 
-    ```typescript
-    server.setRequestHandler(ListToolsRequestSchema, async () => {
-      return {
-        tools: [{
-          name: "calculate_sum",
-          description: "Add two numbers together",
-          inputSchema: {
-            type: "object",
-            properties: {
-              a: { type: "number" },
-              b: { type: "number" }
-            },
-            required: ["a", "b"]
+```typescript TypeScript
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: [
+      {
+        name: "calculate_sum",
+        description: "Add two numbers together",
+        inputSchema: {
+          type: "object",
+          properties: {
+            a: { type: "number" },
+            b: { type: "number" },
           },
-          annotations: {
-            title: "Calculate Sum",
-            readOnlyHint: true,
-            openWorldHint: false
-          }
-        }]
-      };
-    });
-    ```
+          required: ["a", "b"],
+        },
+        annotations: {
+          title: "Calculate Sum",
+          readOnlyHint: true,
+          openWorldHint: false,
+        },
+      },
+    ],
+  };
+});
+```
 
-  </Tab>
-  <Tab title="Python">
+```python Python
+from mcp.server.fastmcp import FastMCP
 
-    ```python
-    from mcp.server.fastmcp import FastMCP
+mcp = FastMCP("example-server")
 
-    mcp = FastMCP("example-server")
+@mcp.tool(
+    annotations={
+        "title": "Calculate Sum",
+        "readOnlyHint": True,
+        "openWorldHint": False
+    }
+)
+async def calculate_sum(a: float, b: float) -> str:
+    """Add two numbers together.
 
-    @mcp.tool(
-        annotations={
-            "title": "Calculate Sum",
-            "readOnlyHint": True,
-            "openWorldHint": False
-        }
-    )
-    async def calculate_sum(a: float, b: float) -> str:
-        """Add two numbers together.
+    Args:
+        a: First number to add
+        b: Second number to add
+    """
+    result = a + b
+    return str(result)
+```
 
-        Args:
-            a: First number to add
-            b: Second number to add
-        """
-        result = a + b
-        return str(result)
-    ```
-
-  </Tab>
-</Tabs>
+</CodeGroup>
 
 ### Best practices for tool annotations
 

--- a/docs/docs/concepts/transports.mdx
+++ b/docs/docs/concepts/transports.mdx
@@ -62,8 +62,10 @@ Use stdio when:
 - Needing simple process communication
 - Working with shell scripts
 
+#### Server
+
 <Tabs>
-  <Tab title="TypeScript (Server)">
+  <Tab title="TypeScript">
 
     ```typescript
     const server = new Server({
@@ -78,7 +80,26 @@ Use stdio when:
     ```
 
   </Tab>
-  <Tab title="TypeScript (Client)">
+  <Tab title="Python">
+
+    ```python
+    app = Server("example-server")
+
+    async with stdio_server() as streams:
+        await app.run(
+            streams[0],
+            streams[1],
+            app.create_initialization_options()
+        )
+    ```
+
+  </Tab>
+</Tabs>
+
+#### Client
+
+<Tabs>
+  <Tab title="TypeScript">
 
     ```typescript
     const client = new Client({
@@ -96,21 +117,7 @@ Use stdio when:
     ```
 
   </Tab>
-  <Tab title="Python (Server)">
-
-    ```python
-    app = Server("example-server")
-
-    async with stdio_server() as streams:
-        await app.run(
-            streams[0],
-            streams[1],
-            app.create_initialization_options()
-        )
-    ```
-
-  </Tab>
-  <Tab title="Python (Client)">
+  <Tab title="Python">
 
     ```python
     params = StdioServerParameters(
@@ -124,7 +131,6 @@ Use stdio when:
     ```
 
   </Tab>
-
 </Tabs>
 
 ### Streamable HTTP
@@ -149,8 +155,10 @@ Use Streamable HTTP when:
    - SSE streams initiated by client requests
    - SSE streams from HTTP GET requests to the MCP endpoint
 
+#### Server
+
 <Tabs>
-  <Tab title="TypeScript (Server)">
+  <Tab title="TypeScript">
 
     ```typescript
     import express from "express";
@@ -188,24 +196,7 @@ Use Streamable HTTP when:
     ```
 
   </Tab>
-  <Tab title="TypeScript (Client)">
-
-    ```typescript
-    const client = new Client({
-      name: "example-client",
-      version: "1.0.0"
-    }, {
-      capabilities: {}
-    });
-
-    const transport = new HttpClientTransport(
-      new URL("http://localhost:3000/mcp")
-    );
-    await client.connect(transport);
-    ```
-
-  </Tab>
-  <Tab title="Python (Server)">
+  <Tab title="Python">
 
     ```python
     from mcp.server.http import HttpServerTransport
@@ -238,7 +229,29 @@ Use Streamable HTTP when:
     ```
 
   </Tab>
-  <Tab title="Python (Client)">
+</Tabs>
+
+#### Client
+
+<Tabs>
+  <Tab title="TypeScript">
+
+    ```typescript
+    const client = new Client({
+      name: "example-client",
+      version: "1.0.0"
+    }, {
+      capabilities: {}
+    });
+
+    const transport = new HttpClientTransport(
+      new URL("http://localhost:3000/mcp")
+    );
+    await client.connect(transport);
+    ```
+
+  </Tab>
+  <Tab title="Python">
 
     ```python
     async with http_client("http://localhost:8000/mcp") as transport:
@@ -247,7 +260,6 @@ Use Streamable HTTP when:
     ```
 
   </Tab>
-
 </Tabs>
 
 #### Session Management
@@ -325,8 +337,10 @@ Previously used when:
 
 The deprecated SSE transport had similar security considerations to Streamable HTTP, particularly regarding DNS rebinding attacks. These same protections should be applied when using SSE streams within the Streamable HTTP transport.
 
+#### Server
+
 <Tabs>
-  <Tab title="TypeScript (Server)">
+  <Tab title="TypeScript">
 
     ```typescript
     import express from "express";
@@ -357,24 +371,7 @@ The deprecated SSE transport had similar security considerations to Streamable H
     ```
 
   </Tab>
-  <Tab title="TypeScript (Client)">
-
-    ```typescript
-    const client = new Client({
-      name: "example-client",
-      version: "1.0.0"
-    }, {
-      capabilities: {}
-    });
-
-    const transport = new SSEClientTransport(
-      new URL("http://localhost:3000/sse")
-    );
-    await client.connect(transport);
-    ```
-
-  </Tab>
-  <Tab title="Python (Server)">
+  <Tab title="Python">
 
     ```python
     from mcp.server.sse import SseServerTransport
@@ -400,7 +397,29 @@ The deprecated SSE transport had similar security considerations to Streamable H
     ```
 
   </Tab>
-  <Tab title="Python (Client)">
+</Tabs>
+
+#### Client
+
+<Tabs>
+  <Tab title="TypeScript">
+
+    ```typescript
+    const client = new Client({
+      name: "example-client",
+      version: "1.0.0"
+    }, {
+      capabilities: {}
+    });
+
+    const transport = new SSEClientTransport(
+      new URL("http://localhost:3000/sse")
+    );
+    await client.connect(transport);
+    ```
+
+  </Tab>
+  <Tab title="Python">
 
     ```python
     async with sse_client("http://localhost:8000/sse") as streams:
@@ -409,7 +428,6 @@ The deprecated SSE transport had similar security considerations to Streamable H
     ```
 
   </Tab>
-
 </Tabs>
 
 ## Custom Transports

--- a/docs/docs/concepts/transports.mdx
+++ b/docs/docs/concepts/transports.mdx
@@ -64,74 +64,70 @@ Use stdio when:
 
 #### Server
 
-<Tabs>
-  <Tab title="TypeScript">
+<CodeGroup>
 
-    ```typescript
-    const server = new Server({
-      name: "example-server",
-      version: "1.0.0"
-    }, {
-      capabilities: {}
-    });
+```typescript TypeScript
+const server = new Server(
+  {
+    name: "example-server",
+    version: "1.0.0",
+  },
+  {
+    capabilities: {},
+  },
+);
 
-    const transport = new StdioServerTransport();
-    await server.connect(transport);
-    ```
+const transport = new StdioServerTransport();
+await server.connect(transport);
+```
 
-  </Tab>
-  <Tab title="Python">
+```python Python
+app = Server("example-server")
 
-    ```python
-    app = Server("example-server")
+async with stdio_server() as streams:
+    await app.run(
+        streams[0],
+        streams[1],
+        app.create_initialization_options()
+    )
+```
 
-    async with stdio_server() as streams:
-        await app.run(
-            streams[0],
-            streams[1],
-            app.create_initialization_options()
-        )
-    ```
-
-  </Tab>
-</Tabs>
+</CodeGroup>
 
 #### Client
 
-<Tabs>
-  <Tab title="TypeScript">
+<CodeGroup>
 
-    ```typescript
-    const client = new Client({
-      name: "example-client",
-      version: "1.0.0"
-    }, {
-      capabilities: {}
-    });
+```typescript TypeScript
+const client = new Client(
+  {
+    name: "example-client",
+    version: "1.0.0",
+  },
+  {
+    capabilities: {},
+  },
+);
 
-    const transport = new StdioClientTransport({
-      command: "./server",
-      args: ["--option", "value"]
-    });
-    await client.connect(transport);
-    ```
+const transport = new StdioClientTransport({
+  command: "./server",
+  args: ["--option", "value"],
+});
+await client.connect(transport);
+```
 
-  </Tab>
-  <Tab title="Python">
+```python Python
+params = StdioServerParameters(
+    command="./server",
+    args=["--option", "value"]
+)
 
-    ```python
-    params = StdioServerParameters(
-        command="./server",
-        args=["--option", "value"]
-    )
+async with stdio_client(params) as streams:
+    async with ClientSession(streams[0], streams[1]) as session:
+        await session.initialize()
+```
 
-    async with stdio_client(params) as streams:
-        async with ClientSession(streams[0], streams[1]) as session:
-            await session.initialize()
-    ```
-
-  </Tab>
-</Tabs>
+</CodeGroup>
 
 ### Streamable HTTP
 
@@ -157,110 +153,104 @@ Use Streamable HTTP when:
 
 #### Server
 
-<Tabs>
-  <Tab title="TypeScript">
+<CodeGroup>
 
-    ```typescript
-    import express from "express";
+```typescript TypeScript
+import express from "express";
 
-    const app = express();
+const app = express();
 
-    const server = new Server({
-      name: "example-server",
-      version: "1.0.0"
-    }, {
-      capabilities: {}
-    });
+const server = new Server(
+  {
+    name: "example-server",
+    version: "1.0.0",
+  },
+  {
+    capabilities: {},
+  },
+);
 
-    // MCP endpoint handles both POST and GET
-    app.post("/mcp", async (req, res) => {
-      // Handle JSON-RPC request
-      const response = await server.handleRequest(req.body);
+// MCP endpoint handles both POST and GET
+app.post("/mcp", async (req, res) => {
+  // Handle JSON-RPC request
+  const response = await server.handleRequest(req.body);
 
-      // Return single response or SSE stream
-      if (needsStreaming) {
-        res.setHeader("Content-Type", "text/event-stream");
-        // Send SSE events...
-      } else {
-        res.json(response);
-      }
-    });
+  // Return single response or SSE stream
+  if (needsStreaming) {
+    res.setHeader("Content-Type", "text/event-stream");
+    // Send SSE events...
+  } else {
+    res.json(response);
+  }
+});
 
-    app.get("/mcp", (req, res) => {
-      // Optional: Support server-initiated SSE streams
-      res.setHeader("Content-Type", "text/event-stream");
-      // Send server notifications/requests...
-    });
+app.get("/mcp", (req, res) => {
+  // Optional: Support server-initiated SSE streams
+  res.setHeader("Content-Type", "text/event-stream");
+  // Send server notifications/requests...
+});
 
-    app.listen(3000);
-    ```
+app.listen(3000);
+```
 
-  </Tab>
-  <Tab title="Python">
+```python Python
+from mcp.server.http import HttpServerTransport
+from starlette.applications import Starlette
+from starlette.routing import Route
 
-    ```python
-    from mcp.server.http import HttpServerTransport
-    from starlette.applications import Starlette
-    from starlette.routing import Route
+app = Server("example-server")
 
-    app = Server("example-server")
+async def handle_mcp(scope, receive, send):
+    if scope["method"] == "POST":
+        # Handle JSON-RPC request
+        response = await app.handle_request(request_body)
 
-    async def handle_mcp(scope, receive, send):
-        if scope["method"] == "POST":
-            # Handle JSON-RPC request
-            response = await app.handle_request(request_body)
+        if needs_streaming:
+            # Return SSE stream
+            await send_sse_response(send, response)
+        else:
+            # Return JSON response
+            await send_json_response(send, response)
 
-            if needs_streaming:
-                # Return SSE stream
-                await send_sse_response(send, response)
-            else:
-                # Return JSON response
-                await send_json_response(send, response)
+    elif scope["method"] == "GET":
+        # Optional: Support server-initiated SSE streams
+        await send_sse_stream(send)
 
-        elif scope["method"] == "GET":
-            # Optional: Support server-initiated SSE streams
-            await send_sse_stream(send)
+starlette_app = Starlette(
+    routes=[
+        Route("/mcp", endpoint=handle_mcp, methods=["POST", "GET"]),
+    ]
+)
+```
 
-    starlette_app = Starlette(
-        routes=[
-            Route("/mcp", endpoint=handle_mcp, methods=["POST", "GET"]),
-        ]
-    )
-    ```
-
-  </Tab>
-</Tabs>
+</CodeGroup>
 
 #### Client
 
-<Tabs>
-  <Tab title="TypeScript">
+<CodeGroup>
 
-    ```typescript
-    const client = new Client({
-      name: "example-client",
-      version: "1.0.0"
-    }, {
-      capabilities: {}
-    });
+```typescript TypeScript
+const client = new Client(
+  {
+    name: "example-client",
+    version: "1.0.0",
+  },
+  {
+    capabilities: {},
+  },
+);
 
-    const transport = new HttpClientTransport(
-      new URL("http://localhost:3000/mcp")
-    );
-    await client.connect(transport);
-    ```
+const transport = new HttpClientTransport(new URL("http://localhost:3000/mcp"));
+await client.connect(transport);
+```
 
-  </Tab>
-  <Tab title="Python">
+```python Python
+async with http_client("http://localhost:8000/mcp") as transport:
+    async with ClientSession(transport[0], transport[1]) as session:
+        await session.initialize()
+```
 
-    ```python
-    async with http_client("http://localhost:8000/mcp") as transport:
-        async with ClientSession(transport[0], transport[1]) as session:
-            await session.initialize()
-    ```
-
-  </Tab>
-</Tabs>
+</CodeGroup>
 
 #### Session Management
 
@@ -339,96 +329,90 @@ The deprecated SSE transport had similar security considerations to Streamable H
 
 #### Server
 
-<Tabs>
-  <Tab title="TypeScript">
+<CodeGroup>
 
-    ```typescript
-    import express from "express";
+```typescript TypeScript
+import express from "express";
 
-    const app = express();
+const app = express();
 
-    const server = new Server({
-      name: "example-server",
-      version: "1.0.0"
-    }, {
-      capabilities: {}
-    });
+const server = new Server(
+  {
+    name: "example-server",
+    version: "1.0.0",
+  },
+  {
+    capabilities: {},
+  },
+);
 
-    let transport: SSEServerTransport | null = null;
+let transport: SSEServerTransport | null = null;
 
-    app.get("/sse", (req, res) => {
-      transport = new SSEServerTransport("/messages", res);
-      server.connect(transport);
-    });
+app.get("/sse", (req, res) => {
+  transport = new SSEServerTransport("/messages", res);
+  server.connect(transport);
+});
 
-    app.post("/messages", (req, res) => {
-      if (transport) {
-        transport.handlePostMessage(req, res);
-      }
-    });
+app.post("/messages", (req, res) => {
+  if (transport) {
+    transport.handlePostMessage(req, res);
+  }
+});
 
-    app.listen(3000);
-    ```
+app.listen(3000);
+```
 
-  </Tab>
-  <Tab title="Python">
+```python Python
+from mcp.server.sse import SseServerTransport
+from starlette.applications import Starlette
+from starlette.routing import Route
 
-    ```python
-    from mcp.server.sse import SseServerTransport
-    from starlette.applications import Starlette
-    from starlette.routing import Route
+app = Server("example-server")
+sse = SseServerTransport("/messages")
 
-    app = Server("example-server")
-    sse = SseServerTransport("/messages")
+async def handle_sse(scope, receive, send):
+    async with sse.connect_sse(scope, receive, send) as streams:
+        await app.run(streams[0], streams[1], app.create_initialization_options())
 
-    async def handle_sse(scope, receive, send):
-        async with sse.connect_sse(scope, receive, send) as streams:
-            await app.run(streams[0], streams[1], app.create_initialization_options())
+async def handle_messages(scope, receive, send):
+    await sse.handle_post_message(scope, receive, send)
 
-    async def handle_messages(scope, receive, send):
-        await sse.handle_post_message(scope, receive, send)
+starlette_app = Starlette(
+    routes=[
+        Route("/sse", endpoint=handle_sse),
+        Route("/messages", endpoint=handle_messages, methods=["POST"]),
+    ]
+)
+```
 
-    starlette_app = Starlette(
-        routes=[
-            Route("/sse", endpoint=handle_sse),
-            Route("/messages", endpoint=handle_messages, methods=["POST"]),
-        ]
-    )
-    ```
-
-  </Tab>
-</Tabs>
+</CodeGroup>
 
 #### Client
 
-<Tabs>
-  <Tab title="TypeScript">
+<CodeGroup>
 
-    ```typescript
-    const client = new Client({
-      name: "example-client",
-      version: "1.0.0"
-    }, {
-      capabilities: {}
-    });
+```typescript TypeScript
+const client = new Client(
+  {
+    name: "example-client",
+    version: "1.0.0",
+  },
+  {
+    capabilities: {},
+  },
+);
 
-    const transport = new SSEClientTransport(
-      new URL("http://localhost:3000/sse")
-    );
-    await client.connect(transport);
-    ```
+const transport = new SSEClientTransport(new URL("http://localhost:3000/sse"));
+await client.connect(transport);
+```
 
-  </Tab>
-  <Tab title="Python">
+```python Python
+async with sse_client("http://localhost:8000/sse") as streams:
+    async with ClientSession(streams[0], streams[1]) as session:
+        await session.initialize()
+```
 
-    ```python
-    async with sse_client("http://localhost:8000/sse") as streams:
-        async with ClientSession(streams[0], streams[1]) as session:
-            await session.initialize()
-    ```
-
-  </Tab>
-</Tabs>
+</CodeGroup>
 
 ## Custom Transports
 
@@ -441,67 +425,62 @@ You can implement custom transports for:
 - Integration with existing systems
 - Performance optimization
 
-<Tabs>
-  <Tab title="TypeScript">
+<CodeGroup>
 
-    ```typescript
-    interface Transport {
-      // Start processing messages
-      start(): Promise<void>;
+```typescript TypeScript
+interface Transport {
+  // Start processing messages
+  start(): Promise<void>;
 
-      // Send a JSON-RPC message
-      send(message: JSONRPCMessage): Promise<void>;
+  // Send a JSON-RPC message
+  send(message: JSONRPCMessage): Promise<void>;
 
-      // Close the connection
-      close(): Promise<void>;
+  // Close the connection
+  close(): Promise<void>;
 
-      // Callbacks
-      onclose?: () => void;
-      onerror?: (error: Error) => void;
-      onmessage?: (message: JSONRPCMessage) => void;
-    }
-    ```
+  // Callbacks
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage) => void;
+}
+```
 
-  </Tab>
-  <Tab title="Python">
+```python Python
+# Note that while MCP Servers are often implemented with asyncio, we recommend
+# implementing low-level interfaces like transports with `anyio` for wider compatibility.
 
-    Note that while MCP Servers are often implemented with asyncio, we recommend
-    implementing low-level interfaces like transports with `anyio` for wider compatibility.
-    ```python
-    @contextmanager
-    async def create_transport(
-        read_stream: MemoryObjectReceiveStream[JSONRPCMessage | Exception],
-        write_stream: MemoryObjectSendStream[JSONRPCMessage]
-    ):
-        """
-        Transport interface for MCP.
+@contextmanager
+async def create_transport(
+    read_stream: MemoryObjectReceiveStream[JSONRPCMessage | Exception],
+    write_stream: MemoryObjectSendStream[JSONRPCMessage]
+):
+    """
+    Transport interface for MCP.
 
-        Args:
-            read_stream: Stream to read incoming messages from
-            write_stream: Stream to write outgoing messages to
-        """
-        async with anyio.create_task_group() as tg:
-            try:
-                # Start processing messages
-                tg.start_soon(lambda: process_messages(read_stream))
+    Args:
+        read_stream: Stream to read incoming messages from
+        write_stream: Stream to write outgoing messages to
+    """
+    async with anyio.create_task_group() as tg:
+        try:
+            # Start processing messages
+            tg.start_soon(lambda: process_messages(read_stream))
 
-                # Send messages
-                async with write_stream:
-                    yield write_stream
+            # Send messages
+            async with write_stream:
+                yield write_stream
 
-            except Exception as exc:
-                # Handle errors
-                raise exc
-            finally:
-                # Clean up
-                tg.cancel_scope.cancel()
-                await write_stream.aclose()
-                await read_stream.aclose()
-    ```
+        except Exception as exc:
+            # Handle errors
+            raise exc
+        finally:
+            # Clean up
+            tg.cancel_scope.cancel()
+            await write_stream.aclose()
+            await read_stream.aclose()
+```
 
-  </Tab>
-
-</Tabs>
+</CodeGroup>
 
 ## Error Handling
 
@@ -515,74 +494,68 @@ Transport implementations should handle various error scenarios:
 
 Example error handling:
 
-<Tabs>
-  <Tab title="TypeScript">
+<CodeGroup>
 
-    ```typescript
-    class ExampleTransport implements Transport {
-      async start() {
-        try {
-          // Connection logic
-        } catch (error) {
-          this.onerror?.(new Error(`Failed to connect: ${error}`));
-          throw error;
-        }
-      }
-
-      async send(message: JSONRPCMessage) {
-        try {
-          // Sending logic
-        } catch (error) {
-          this.onerror?.(new Error(`Failed to send message: ${error}`));
-          throw error;
-        }
-      }
+```typescript TypeScript
+class ExampleTransport implements Transport {
+  async start() {
+    try {
+      // Connection logic
+    } catch (error) {
+      this.onerror?.(new Error(`Failed to connect: ${error}`));
+      throw error;
     }
-    ```
+  }
 
-  </Tab>
-  <Tab title="Python">
+  async send(message: JSONRPCMessage) {
+    try {
+      // Sending logic
+    } catch (error) {
+      this.onerror?.(new Error(`Failed to send message: ${error}`));
+      throw error;
+    }
+  }
+}
+```
 
-Note that while MCP Servers are often implemented with asyncio, we recommend
-implementing low-level interfaces like transports with `anyio` for wider compatibility.
+```python Python
+# Note that while MCP Servers are often implemented with asyncio, we recommend
+# implementing low-level interfaces like transports with `anyio` for wider compatibility.
 
-    ```python
-    @contextmanager
-    async def example_transport(scope: Scope, receive: Receive, send: Send):
-        try:
-            # Create streams for bidirectional communication
-            read_stream_writer, read_stream = anyio.create_memory_object_stream(0)
-            write_stream, write_stream_reader = anyio.create_memory_object_stream(0)
+@contextmanager
+async def example_transport(scope: Scope, receive: Receive, send: Send):
+    try:
+        # Create streams for bidirectional communication
+        read_stream_writer, read_stream = anyio.create_memory_object_stream(0)
+        write_stream, write_stream_reader = anyio.create_memory_object_stream(0)
 
-            async def message_handler():
-                try:
-                    async with read_stream_writer:
-                        # Message handling logic
-                        pass
-                except Exception as exc:
-                    logger.error(f"Failed to handle message: {exc}")
-                    raise exc
+        async def message_handler():
+            try:
+                async with read_stream_writer:
+                    # Message handling logic
+                    pass
+            except Exception as exc:
+                logger.error(f"Failed to handle message: {exc}")
+                raise exc
 
-            async with anyio.create_task_group() as tg:
-                tg.start_soon(message_handler)
-                try:
-                    # Yield streams for communication
-                    yield read_stream, write_stream
-                except Exception as exc:
-                    logger.error(f"Transport error: {exc}")
-                    raise exc
-                finally:
-                    tg.cancel_scope.cancel()
-                    await write_stream.aclose()
-                    await read_stream.aclose()
-        except Exception as exc:
-            logger.error(f"Failed to initialize transport: {exc}")
-            raise exc
-    ```
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(message_handler)
+            try:
+                # Yield streams for communication
+                yield read_stream, write_stream
+            except Exception as exc:
+                logger.error(f"Transport error: {exc}")
+                raise exc
+            finally:
+                tg.cancel_scope.cancel()
+                await write_stream.aclose()
+                await read_stream.aclose()
+    except Exception as exc:
+        logger.error(f"Failed to initialize transport: {exc}")
+        raise exc
+```
 
-  </Tab>
-
-</Tabs>
+</CodeGroup>
 
 ## Best Practices
 

--- a/docs/docs/tools/debugging.mdx
+++ b/docs/docs/tools/debugging.mdx
@@ -173,28 +173,23 @@ Local MCP servers should not log messages to stdout (standard out), as this will
 
 For all [transports](/docs/concepts/transports), you can also provide logging to the client by sending a log message notification:
 
-<Tabs>
-  <Tab title="Python">
+<CodeGroup>
 
-    ```python
-    server.request_context.session.send_log_message(
-      level="info",
-      data="Server started successfully",
-    )
-    ```
+```python Python
+server.request_context.session.send_log_message(
+  level="info",
+  data="Server started successfully",
+)
+```
 
-  </Tab>
-  <Tab title="TypeScript">
+```typescript TypeScript
+server.sendLoggingMessage({
+  level: "info",
+  data: "Server started successfully",
+});
+```
 
-    ```typescript
-    server.sendLoggingMessage({
-      level: "info",
-      data: "Server started successfully",
-    });
-    ```
-
-  </Tab>
-</Tabs>
+</CodeGroup>
 
 Important events to log:
 

--- a/docs/quickstart/server.mdx
+++ b/docs/quickstart/server.mdx
@@ -281,31 +281,25 @@ We'll need to configure Claude for Desktop for whichever MCP servers you want to
 
 For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
-<Tabs>
-<Tab title="MacOS/Linux">
+<CodeGroup>
 
-```bash
+```bash MacOS/Linux
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
-</Tab>
-<Tab title="Windows">
-
-```powershell
+```powershell Windows
 code $env:AppData\Claude\claude_desktop_config.json
 ```
 
-</Tab>
-</Tabs>
+</CodeGroup>
 
 You'll then add your servers in the `mcpServers` key. The MCP UI elements will only show up in Claude for Desktop if at least one server is properly configured.
 
 In this case, we'll add our single weather server like so:
 
-<Tabs>
-<Tab title="MacOS/Linux">
+<CodeGroup>
 
-```json Python
+```json MacOS/Linux
 {
   "mcpServers": {
     "weather": {
@@ -321,10 +315,7 @@ In this case, we'll add our single weather server like so:
 }
 ```
 
-</Tab>
-<Tab title="Windows">
-
-```json Python
+```json Windows
 {
   "mcpServers": {
     "weather": {
@@ -340,8 +331,7 @@ In this case, we'll add our single weather server like so:
 }
 ```
 
-</Tab>
-</Tabs>
+</CodeGroup>
 
 <Warning>
 
@@ -775,33 +765,25 @@ We'll need to configure Claude for Desktop for whichever MCP servers you want to
 
 For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
-<Tabs>
-<Tab title="MacOS/Linux">
+<CodeGroup>
 
-```bash
+```bash MacOS/Linux
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
-</Tab>
-<Tab title="Windows">
-
-```powershell
+```powershell Windows
 code $env:AppData\Claude\claude_desktop_config.json
 ```
 
-</Tab>
-</Tabs>
+</CodeGroup>
 
 You'll then add your servers in the `mcpServers` key. The MCP UI elements will only show up in Claude for Desktop if at least one server is properly configured.
 
 In this case, we'll add our single weather server like so:
 
-<Tabs>
-<Tab title="MacOS/Linux">
-
 <CodeGroup>
 
-```json Node
+```json MacOS/Linux
 {
   "mcpServers": {
     "weather": {
@@ -812,14 +794,7 @@ In this case, we'll add our single weather server like so:
 }
 ```
 
-</CodeGroup>
-
-</Tab>
-<Tab title="Windows">
-
-<CodeGroup>
-
-```json Node
+```json Windows
 {
   "mcpServers": {
     "weather": {
@@ -831,9 +806,6 @@ In this case, we'll add our single weather server like so:
 ```
 
 </CodeGroup>
-
-</Tab>
-</Tabs>
 
 This tells Claude for Desktop:
 
@@ -889,10 +861,9 @@ Use the [Spring Initializer](https://start.spring.io/) to bootstrap the project.
 
 You will need to add the following dependencies:
 
-<Tabs>
-  <Tab title="Maven">
+<CodeGroup>
 
-```xml
+```xml Maven
 <dependencies>
       <dependency>
           <groupId>org.springframework.ai</groupId>
@@ -906,18 +877,14 @@ You will need to add the following dependencies:
 </dependencies>
 ```
 
-  </Tab>
-  <Tab title="Gradle">
-
-```groovy
+```groovy Gradle
 dependencies {
   implementation platform("org.springframework.ai:spring-ai-starter-mcp-server")
   implementation platform("org.springframework:spring-web")
 }
 ```
 
-  </Tab>
-</Tabs>
+</CodeGroup>
 
 Then configure your application by setting the application properties:
 
@@ -1043,32 +1010,26 @@ Make sure to create the file if it doesn't exist.
 
 For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
-<Tabs>
-  <Tab title="MacOS/Linux">
+<CodeGroup>
 
-```bash
+```bash MacOS/Linux
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
-  </Tab>
-  <Tab title="Windows">
-
-```powershell
+```powershell Windows
 code $env:AppData\Claude\claude_desktop_config.json
 ```
 
-  </Tab>
-</Tabs>
+</CodeGroup>
 
 You'll then add your servers in the `mcpServers` key.
 The MCP UI elements will only show up in Claude for Desktop if at least one server is properly configured.
 
 In this case, we'll add our single weather server like so:
 
-<Tabs>
-  <Tab title="MacOS/Linux">
+<CodeGroup>
 
-```json java
+```json MacOS/Linux
 {
   "mcpServers": {
     "spring-ai-mcp-weather": {
@@ -1083,11 +1044,7 @@ In this case, we'll add our single weather server like so:
 }
 ```
 
-  </Tab>
-
-  <Tab title="Windows">
-
-```json java
+```json Windows
 {
   "mcpServers": {
     "spring-ai-mcp-weather": {
@@ -1102,8 +1059,7 @@ In this case, we'll add our single weather server like so:
 }
 ```
 
-  </Tab>
-</Tabs>
+</CodeGroup>
 
 <Note>
 
@@ -1777,30 +1733,24 @@ here.](https://claude.ai/download) If you already have Claude for Desktop, **mak
 We'll need to configure Claude for Desktop for whichever MCP servers you want to use. To do this, open your Claude for Desktop App configuration at `~/Library/Application Support/Claude/claude_desktop_config.json` in a text editor. Make sure to create the file if it doesn't exist.
 For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
-<Tabs>
-<Tab title="MacOS/Linux">
+<CodeGroup>
 
-```bash
+```bash MacOS/Linux
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
-</Tab>
-<Tab title="Windows">
-
-```powershell
+```powershell Windows
 code $env:AppData\Claude\claude_desktop_config.json
 ```
 
-</Tab>
-</Tabs>
+</CodeGroup>
 
 You'll then add your servers in the `mcpServers` key. The MCP UI elements will only show up in Claude for Desktop if at least one server is properly configured.
 In this case, we'll add our single weather server like so:
 
-<Tabs>
-<Tab title="MacOS/Linux">
+<CodeGroup>
 
-```json
+```json MacOS/Linux
 {
   "mcpServers": {
     "weather": {
@@ -1811,11 +1761,7 @@ In this case, we'll add our single weather server like so:
 }
 ```
 
-</Tab>
-
-<Tab title="Windows">
-
-```json
+```json Windows
 {
   "mcpServers": {
     "weather": {
@@ -1831,8 +1777,7 @@ In this case, we'll add our single weather server like so:
 }
 ```
 
-</Tab>
-</Tabs>
+</CodeGroup>
 
 This tells Claude for Desktop:
 

--- a/docs/quickstart/user.mdx
+++ b/docs/quickstart/user.mdx
@@ -46,10 +46,9 @@ if you don't already have one, and will display the file in your file system.
 
 Open up the configuration file in any text editor. Replace the file contents with this:
 
-<Tabs>
-<Tab title="MacOS/Linux">
+<CodeGroup>
 
-```json
+```json MacOS/Linux
 {
   "mcpServers": {
     "filesystem": {
@@ -65,10 +64,7 @@ Open up the configuration file in any text editor. Replace the file contents wit
 }
 ```
 
-</Tab>
-<Tab title="Windows">
-
-```json
+```json Windows
 {
   "mcpServers": {
     "filesystem": {
@@ -84,8 +80,7 @@ Open up the configuration file in any text editor. Replace the file contents wit
 }
 ```
 
-</Tab>
-</Tabs>
+</CodeGroup>
 
 Make sure to replace `username` with your computer's username. The paths should point to valid directories that you want Claude to be able to access and modify. It's set up to work for Desktop and Downloads, but you can add more paths as well.
 
@@ -163,22 +158,17 @@ As needed, Claude will call the relevant tools and seek your approval before tak
 4. Look at [logs](#getting-logs-from-claude-for-desktop) to see why the server is not connecting
 5. In your command line, try manually running the server (replacing `username` as you did in `claude_desktop_config.json`) to see if you get any errors:
 
-<Tabs>
-<Tab title="MacOS/Linux">
+<CodeGroup>
 
-```bash
+```bash MacOS/Linux
 npx -y @modelcontextprotocol/server-filesystem /Users/username/Desktop /Users/username/Downloads
 ```
 
-</Tab>
-<Tab title="Windows">
-
-```powershell
+```powershell Windows
 npx -y @modelcontextprotocol/server-filesystem C:\Users\username\Desktop C:\Users\username\Downloads
 ```
 
-</Tab>
-</Tabs>
+</CodeGroup>
 
 </Accordion>
 <Accordion title="Getting logs from Claude for Desktop">
@@ -193,23 +183,17 @@ Claude.app logging related to MCP is written to log files in:
 
 You can run the following command to list recent logs and follow along with any new ones (on Windows, it will only show recent logs):
 
-<Tabs>
-<Tab title="MacOS/Linux">
+<CodeGroup>
 
-```bash
-# Check Claude's logs for errors
+```bash MacOS/Linux
 tail -n 20 -f ~/Library/Logs/Claude/mcp*.log
 ```
 
-</Tab>
-<Tab title="Windows">
-
-```powershell
+```powershell Windows
 type "%APPDATA%\Claude\logs\mcp*.log"
 ```
 
-</Tab>
-</Tabs>
+</CodeGroup>
 
 </Accordion>
 <Accordion title="Tool calls failing silently">

--- a/docs/quickstart/user.mdx
+++ b/docs/quickstart/user.mdx
@@ -173,7 +173,7 @@ npx -y @modelcontextprotocol/server-filesystem /Users/username/Desktop /Users/us
 </Tab>
 <Tab title="Windows">
 
-```bash
+```powershell
 npx -y @modelcontextprotocol/server-filesystem C:\Users\username\Desktop C:\Users\username\Downloads
 ```
 
@@ -204,7 +204,7 @@ tail -n 20 -f ~/Library/Logs/Claude/mcp*.log
 </Tab>
 <Tab title="Windows">
 
-```bash
+```powershell
 type "%APPDATA%\Claude\logs\mcp*.log"
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "glob": "^11.0.0",
-        "mintlify": "^4.0.468",
+        "mintlify": "^4.0",
         "prettier": "^3.4.2",
         "tsx": "^4.19.1",
         "typedoc": "^0.28.7",
@@ -21,6 +21,46 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz",
+      "integrity": "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.13.1"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize/node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@asyncapi/parser": {
@@ -80,24 +120,24 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -118,9 +158,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.0.tgz",
-      "integrity": "sha512-64WYIf4UYcdLnbKn/umDlNjQDSS8AgZrI/R9+x5ilkUVFxXcA1Ebl+gQLc/6mERA4407Xof0R7wEyEuj091CVw==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
+      "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -956,15 +996,15 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.5.tgz",
-      "integrity": "sha512-swPczVU+at65xa5uPfNP9u3qx/alNwiaykiI/ExpsmMSQW55trmZcwhYWzw/7fj+n6Q8z1eENvR7vFfq9oPSAQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.2.0.tgz",
+      "integrity": "sha512-fdSw07FLJEU5vbpOPzXo5c6xmMGDzbZE2+niuDHX5N6mc6V0Ebso/q3xiHra4D73+PMsC8MJmcaZKuAAoaQsSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
-        "@inquirer/figures": "^1.0.11",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -980,15 +1020,44 @@
         }
       }
     },
-    "node_modules/@inquirer/confirm": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.9.tgz",
-      "integrity": "sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w==",
+    "node_modules/@inquirer/checkbox/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
-        "@inquirer/type": "^3.0.6"
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@inquirer/checkbox/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.14",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.14.tgz",
+      "integrity": "sha512-5yR4IBfe0kXe59r1YCTG8WXkUbl7Z35HK87Sw+WUyGD8wNUx7JvY7laahzeytyE1oLn74bQnL7hstctQxisQ8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -1003,14 +1072,14 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
-      "integrity": "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==",
+      "version": "10.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
+      "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.11",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
@@ -1030,6 +1099,35 @@
         }
       }
     },
+    "node_modules/@inquirer/core/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@inquirer/core/node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -1046,14 +1144,14 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.10.tgz",
-      "integrity": "sha512-5GVWJ+qeI6BzR6TIInLP9SXhWCEcvgFQYmcRG6d6RIlhFjM5TyG18paTGBgRYyEouvCmzeco47x9zX9tQEofkw==",
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.15.tgz",
+      "integrity": "sha512-wst31XT8DnGOSS4nNJDIklGKnf+8shuauVrWzgKegWUe28zfCftcWZ2vktGdzJgcylWSS2SrDnYUb6alZcwnCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8",
         "external-editor": "^3.1.0"
       },
       "engines": {
@@ -1069,14 +1167,14 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.12.tgz",
-      "integrity": "sha512-jV8QoZE1fC0vPe6TnsOfig+qwu7Iza1pkXoUJ3SroRagrt2hxiL+RbM432YAihNR7m7XnU0HWl/WQ35RIGmXHw==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.17.tgz",
+      "integrity": "sha512-PSqy9VmJx/VbE3CT453yOfNa+PykpKg/0SYP7odez1/NWBGuDXgPhp4AeGYYKjhLn5lUUavVS/JbeYMPdH50Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -1092,9 +1190,9 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
-      "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1102,14 +1200,14 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.9.tgz",
-      "integrity": "sha512-mshNG24Ij5KqsQtOZMgj5TwEjIf+F2HOESk6bjMwGWgcH5UBe8UoljwzNFHqdMbGYbgAf6v2wU/X9CAdKJzgOA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.1.tgz",
+      "integrity": "sha512-tVC+O1rBl0lJpoUZv4xY+WGWY8V5b0zxU1XDsMsIHYregdh7bN5X5QnIONNBAl0K765FYlAfNHS2Bhn7SSOVow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
-        "@inquirer/type": "^3.0.6"
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -1124,14 +1222,14 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.12.tgz",
-      "integrity": "sha512-7HRFHxbPCA4e4jMxTQglHJwP+v/kpFsCf2szzfBHy98Wlc3L08HL76UDiA87TOdX5fwj2HMOLWqRWv9Pnn+Z5Q==",
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.17.tgz",
+      "integrity": "sha512-GcvGHkyIgfZgVnnimURdOueMk0CztycfC8NZTiIY9arIAkeOgt6zG57G+7vC59Jns3UX27LMkPKnKWAOF5xEYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
-        "@inquirer/type": "^3.0.6"
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -1146,14 +1244,14 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.12.tgz",
-      "integrity": "sha512-FlOB0zvuELPEbnBYiPaOdJIaDzb2PmJ7ghi/SVwIHDDSQ2K4opGBkF+5kXOg6ucrtSUQdLhVVY5tycH0j0l+0g==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.17.tgz",
+      "integrity": "sha512-DJolTnNeZ00E1+1TW+8614F7rOJJCM4y4BAGQ3Gq6kQIG+OJ4zr3GLjIjVVJCbKsk2jmkmv6v2kQuN/vriHdZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2"
       },
       "engines": {
@@ -1168,23 +1266,52 @@
         }
       }
     },
-    "node_modules/@inquirer/prompts": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.4.1.tgz",
-      "integrity": "sha512-UlmM5FVOZF0gpoe1PT/jN4vk8JmpIWBlMvTL8M+hlvPmzN89K6z03+IFmyeu/oFCenwdwHDr2gky7nIGSEVvlA==",
+    "node_modules/@inquirer/password/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.1.5",
-        "@inquirer/confirm": "^5.1.9",
-        "@inquirer/editor": "^4.2.10",
-        "@inquirer/expand": "^4.0.12",
-        "@inquirer/input": "^4.1.9",
-        "@inquirer/number": "^3.0.12",
-        "@inquirer/password": "^4.0.12",
-        "@inquirer/rawlist": "^4.0.12",
-        "@inquirer/search": "^3.0.12",
-        "@inquirer/select": "^4.1.1"
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@inquirer/password/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.7.1.tgz",
+      "integrity": "sha512-XDxPrEWeWUBy8scAXzXuFY45r/q49R0g72bUzgQXZ1DY/xEFX+ESDMkTQolcb5jRBzaNJX2W8XQl6krMNDTjaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.2.0",
+        "@inquirer/confirm": "^5.1.14",
+        "@inquirer/editor": "^4.2.15",
+        "@inquirer/expand": "^4.0.17",
+        "@inquirer/input": "^4.2.1",
+        "@inquirer/number": "^3.0.17",
+        "@inquirer/password": "^4.0.17",
+        "@inquirer/rawlist": "^4.1.5",
+        "@inquirer/search": "^3.0.17",
+        "@inquirer/select": "^4.3.1"
       },
       "engines": {
         "node": ">=18"
@@ -1199,14 +1326,14 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.12.tgz",
-      "integrity": "sha512-wNPJZy8Oc7RyGISPxp9/MpTOqX8lr0r+lCCWm7hQra+MDtYRgINv1hxw7R+vKP71Bu/3LszabxOodfV/uTfsaA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.5.tgz",
+      "integrity": "sha512-R5qMyGJqtDdi4Ht521iAkNqyB6p2UPuZUbMifakg1sWtu24gc2Z8CJuw8rP081OckNDMgtDCuLe42Q2Kr3BolA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -1222,15 +1349,15 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.12.tgz",
-      "integrity": "sha512-H/kDJA3kNlnNIjB8YsaXoQI0Qccgf0Na14K1h8ExWhNmUg2E941dyFPrZeugihEa9AZNW5NdsD/NcvUME83OPQ==",
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.17.tgz",
+      "integrity": "sha512-CuBU4BAGFqRYors4TNCYzy9X3DpKtgIW4Boi0WNkm4Ei1hvY9acxKdBdyqzqBCEe4YxSdaQQsasJlFlUJNgojw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
-        "@inquirer/figures": "^1.0.11",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -1246,15 +1373,15 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.1.1.tgz",
-      "integrity": "sha512-IUXzzTKVdiVNMA+2yUvPxWsSgOG4kfX93jOM4Zb5FgujeInotv5SPIJVeXQ+fO4xu7tW8VowFhdG5JRmmCyQ1Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.3.1.tgz",
+      "integrity": "sha512-Gfl/5sqOF5vS/LIrSndFgOh7jgoe0UXEizDqahFRkq5aJBLegZ6WjuMh/hVEJwlFQjyLq1z9fRtvUMkb7jM1LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
-        "@inquirer/figures": "^1.0.11",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -1270,10 +1397,39 @@
         }
       }
     },
+    "node_modules/@inquirer/select/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@inquirer/select/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@inquirer/type": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.6.tgz",
-      "integrity": "sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1521,24 +1677,26 @@
       }
     },
     "node_modules/@mintlify/cli": {
-      "version": "4.0.467",
-      "resolved": "https://registry.npmjs.org/@mintlify/cli/-/cli-4.0.467.tgz",
-      "integrity": "sha512-s/t+2rGZaQWA/GPSIgS6uFfx33cmhtJu/hjsPkF9OD64hwsnvudugKTLMXJX0k70LKNrP55vMPg2yLBobypRJg==",
+      "version": "4.0.629",
+      "resolved": "https://registry.npmjs.org/@mintlify/cli/-/cli-4.0.629.tgz",
+      "integrity": "sha512-2m4Tk1JypS60gDD+EsyJQRHGtLMlrSRgrzH8RnsaCF3w+MAygGZKDchEKnpBUMXMPAn9wloB4DvQbM0evSslsg==",
       "dev": true,
       "license": "Elastic-2.0",
       "dependencies": {
-        "@mintlify/common": "1.0.331",
-        "@mintlify/link-rot": "3.0.437",
-        "@mintlify/models": "0.0.182",
-        "@mintlify/prebuild": "1.0.434",
-        "@mintlify/previewing": "4.0.458",
-        "@mintlify/validation": "0.1.335",
+        "@mintlify/common": "1.0.453",
+        "@mintlify/link-rot": "3.0.577",
+        "@mintlify/models": "0.0.207",
+        "@mintlify/prebuild": "1.0.571",
+        "@mintlify/previewing": "4.0.615",
+        "@mintlify/validation": "0.1.416",
         "chalk": "^5.2.0",
         "detect-port": "^1.5.1",
         "fs-extra": "^11.2.0",
+        "ink": "^5.2.1",
         "inquirer": "^12.3.0",
         "js-yaml": "^4.1.0",
-        "ora": "^6.1.2",
+        "react": "^18.3.1",
+        "semver": "^7.7.2",
         "yargs": "^17.6.0"
       },
       "bin": {
@@ -1550,28 +1708,29 @@
       }
     },
     "node_modules/@mintlify/common": {
-      "version": "1.0.331",
-      "resolved": "https://registry.npmjs.org/@mintlify/common/-/common-1.0.331.tgz",
-      "integrity": "sha512-upv9s5TEWD5LYjmr1JZXzNQ6I4QMYJ+z7T5Ao9vUFzewKruYfJxrWYxaPVlzlwBH+vfc4a9YmZCQYew/ftMHVw==",
+      "version": "1.0.453",
+      "resolved": "https://registry.npmjs.org/@mintlify/common/-/common-1.0.453.tgz",
+      "integrity": "sha512-IubMjUvXoWTLiU9tBV/u5qg4Ck7UKsQLylWyKtUyp9s5hhEXTefS/GJUNKfMwhEJHWCNf//JghADPznD/+VGmg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@asyncapi/parser": "^3.4.0",
-        "@mintlify/mdx": "^1.0.1",
-        "@mintlify/models": "0.0.182",
+        "@mintlify/mdx": "^2.0.3",
+        "@mintlify/models": "0.0.207",
         "@mintlify/openapi-parser": "^0.0.7",
-        "@mintlify/validation": "0.1.335",
+        "@mintlify/validation": "0.1.416",
         "@sindresorhus/slugify": "^2.1.1",
         "acorn": "^8.11.2",
+        "acorn-jsx": "^5.3.2",
         "estree-util-to-js": "^2.0.0",
         "estree-walker": "^3.0.3",
         "gray-matter": "^4.0.3",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-html": "^9.0.4",
         "hast-util-to-text": "^4.0.2",
-        "is-absolute-url": "^4.0.1",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
+        "mdast": "^3.0.0",
         "mdast-util-from-markdown": "^2.0.2",
         "mdast-util-mdx": "^3.0.0",
         "mdast-util-mdx-jsx": "^3.1.3",
@@ -1582,6 +1741,7 @@
         "remark-gfm": "^4.0.0",
         "remark-math": "^6.0.0",
         "remark-mdx": "^3.1.0",
+        "remark-stringify": "^11.0.0",
         "unified": "^11.0.5",
         "unist-builder": "^4.0.0",
         "unist-util-map": "^4.0.0",
@@ -1593,16 +1753,17 @@
       }
     },
     "node_modules/@mintlify/link-rot": {
-      "version": "3.0.437",
-      "resolved": "https://registry.npmjs.org/@mintlify/link-rot/-/link-rot-3.0.437.tgz",
-      "integrity": "sha512-y3HUO6wlFjUOfBBznOSaDf9nzgxtEIqs0C35hAqf6jCyHvBU032xmjUX/WW53/8LYWhc4Yv3aL59lG458SRSGg==",
+      "version": "3.0.577",
+      "resolved": "https://registry.npmjs.org/@mintlify/link-rot/-/link-rot-3.0.577.tgz",
+      "integrity": "sha512-bO5j9MuIJflKlSheVIxWXZ5kiz49SwW/T/9qLYylT54pg5qH/RQuVI1/HWM/YvgezKhxgZ41rUbiZsnRroPNWg==",
       "dev": true,
       "license": "Elastic-2.0",
       "dependencies": {
-        "@mintlify/common": "1.0.331",
-        "@mintlify/prebuild": "1.0.434",
+        "@mintlify/common": "1.0.453",
+        "@mintlify/prebuild": "1.0.571",
+        "@mintlify/previewing": "4.0.615",
+        "@mintlify/validation": "0.1.416",
         "fs-extra": "^11.1.0",
-        "is-absolute-url": "^4.0.1",
         "unist-util-visit": "^4.1.1"
       },
       "engines": {
@@ -1662,21 +1823,21 @@
       }
     },
     "node_modules/@mintlify/mdx": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@mintlify/mdx/-/mdx-1.0.1.tgz",
-      "integrity": "sha512-zrzt8nxoIgJeSUeuJaC8pbd5EHKjCq30qV2HMoqIHLjeE0l7hkMgjBPNWNde7CYDPig1ODS1kPuE5Bnt+/+PIg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mintlify/mdx/-/mdx-2.0.3.tgz",
+      "integrity": "sha512-UGlwavma8QooWAlhtXpTAG5MAUZTTUKI8Qu25Wqfp1HMOPrYGvo5YQPmlqqogbMsqDMcFPLP/ZYnaZsGUYBspQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/hast": "^3.0.4",
-        "@types/unist": "^3.0.3",
+        "@shikijs/transformers": "^3.6.0",
         "hast-util-to-string": "^3.0.1",
+        "mdast-util-mdx-jsx": "^3.2.0",
         "next-mdx-remote-client": "^1.0.3",
-        "refractor": "^4.8.1",
         "rehype-katex": "^7.0.1",
         "remark-gfm": "^4.0.0",
         "remark-math": "^6.0.0",
         "remark-smartypants": "^3.0.2",
+        "shiki": "^3.6.0",
         "unified": "^11.0.0",
         "unist-util-visit": "^5.0.0"
       },
@@ -1686,13 +1847,13 @@
       }
     },
     "node_modules/@mintlify/models": {
-      "version": "0.0.182",
-      "resolved": "https://registry.npmjs.org/@mintlify/models/-/models-0.0.182.tgz",
-      "integrity": "sha512-kJexQIZIA+NFFUeeYWx9gNt+2q/YDTszwT1xQaYIfLdx9GXibEYg8CkkJFisuGBVCOWXnm2XKDyDQpYPNFQafg==",
+      "version": "0.0.207",
+      "resolved": "https://registry.npmjs.org/@mintlify/models/-/models-0.0.207.tgz",
+      "integrity": "sha512-6KBzbnjJGC7O8bt4otbW4nJdh8w5Pcw/exs+AqzLzw6FjHJE8C4cylDqWePqJU+9wvEbiIr1d2atastSrxsVIQ==",
       "dev": true,
       "license": "Elastic-2.0",
       "dependencies": {
-        "axios": "^1.4.0",
+        "axios": "^1.8.3",
         "openapi-types": "^12.0.0"
       },
       "engines": {
@@ -1718,23 +1879,22 @@
       }
     },
     "node_modules/@mintlify/prebuild": {
-      "version": "1.0.434",
-      "resolved": "https://registry.npmjs.org/@mintlify/prebuild/-/prebuild-1.0.434.tgz",
-      "integrity": "sha512-zMLIdvoGA30tvX7RZ1A9RzWxoB+ms88+FEnELgACaUCt4SxS2kok+/u3BgAW9WkHrjikHfbR+MVxGcTrEdQoyw==",
+      "version": "1.0.571",
+      "resolved": "https://registry.npmjs.org/@mintlify/prebuild/-/prebuild-1.0.571.tgz",
+      "integrity": "sha512-+OrxOfSD9n3UrYo9BXR/sYmr9uTZBHggVT6W4C6FZco9g7LYvbEk2UDqk2JAXBshAGL2/SfU81X0xg1phSVDDw==",
       "dev": true,
       "license": "Elastic-2.0",
       "dependencies": {
-        "@mintlify/common": "1.0.331",
+        "@mintlify/common": "1.0.453",
         "@mintlify/openapi-parser": "^0.0.7",
-        "@mintlify/scraping": "4.0.183",
-        "@mintlify/validation": "0.1.335",
-        "axios": "^1.6.2",
+        "@mintlify/scraping": "4.0.309",
+        "@mintlify/validation": "0.1.416",
         "chalk": "^5.3.0",
-        "favicons": "^7.0.2",
+        "favicons": "^7.2.0",
         "fs-extra": "^11.1.0",
         "gray-matter": "^4.0.3",
-        "is-absolute-url": "^4.0.1",
         "js-yaml": "^4.1.0",
+        "mdast": "^3.0.0",
         "openapi-types": "^12.0.0",
         "unist-util-visit": "^4.1.1"
       }
@@ -1792,15 +1952,15 @@
       }
     },
     "node_modules/@mintlify/previewing": {
-      "version": "4.0.458",
-      "resolved": "https://registry.npmjs.org/@mintlify/previewing/-/previewing-4.0.458.tgz",
-      "integrity": "sha512-LUREX9LhlGC8+F+T68sBt1IwVHxKWnjvrknR6LVX1NPvXz0ZpQaXcl69/bwG4X6amv5yxot7fwVhue6plt/T3A==",
+      "version": "4.0.615",
+      "resolved": "https://registry.npmjs.org/@mintlify/previewing/-/previewing-4.0.615.tgz",
+      "integrity": "sha512-2WYM6Ze9QiBHQBulOreAJi5+eoiw3nxTVB7ByEpAt4kWi0UjB7yHv2D3qykxXmaQNxuD816fHEtXBsfQh89X0g==",
       "dev": true,
       "license": "Elastic-2.0",
       "dependencies": {
-        "@mintlify/common": "1.0.331",
-        "@mintlify/prebuild": "1.0.434",
-        "@mintlify/validation": "0.1.335",
+        "@mintlify/common": "1.0.453",
+        "@mintlify/prebuild": "1.0.571",
+        "@mintlify/validation": "0.1.416",
         "better-opn": "^3.0.2",
         "chalk": "^5.1.0",
         "chokidar": "^3.5.3",
@@ -1808,11 +1968,13 @@
         "fs-extra": "^11.1.0",
         "got": "^13.0.0",
         "gray-matter": "^4.0.3",
-        "is-absolute-url": "^4.0.1",
+        "ink": "^5.2.1",
+        "ink-spinner": "^5.0.0",
         "is-online": "^10.0.0",
         "js-yaml": "^4.1.0",
+        "mdast": "^3.0.0",
         "openapi-types": "^12.0.0",
-        "ora": "^6.1.2",
+        "react": "^18.3.1",
         "socket.io": "^4.7.2",
         "tar": "^6.1.15",
         "unist-util-visit": "^4.1.1",
@@ -1875,25 +2037,25 @@
       }
     },
     "node_modules/@mintlify/scraping": {
-      "version": "4.0.183",
-      "resolved": "https://registry.npmjs.org/@mintlify/scraping/-/scraping-4.0.183.tgz",
-      "integrity": "sha512-GVEqNxeRRmxyLmMwA6pvnBA8zxxcexVChusJde/RrPxT+sgBEgZ7ysGWmIXs06HGNsvrqy1bZ0HShdNOv2JANA==",
+      "version": "4.0.309",
+      "resolved": "https://registry.npmjs.org/@mintlify/scraping/-/scraping-4.0.309.tgz",
+      "integrity": "sha512-ScjSQNVdVG+3gQqvk79KbDWmCnFPGPW7tjcUHsle+d+kmPVbdsAV3zw8P5SbDfH+L7ivY3zQHhOL56sxFn2NSw==",
       "dev": true,
       "license": "Elastic-2.0",
       "dependencies": {
-        "@mintlify/common": "1.0.331",
+        "@mintlify/common": "1.0.453",
         "@mintlify/openapi-parser": "^0.0.7",
         "fs-extra": "^11.1.1",
         "hast-util-to-mdast": "^10.1.0",
         "js-yaml": "^4.1.0",
         "mdast-util-mdx-jsx": "^3.1.3",
+        "neotraverse": "^0.6.18",
         "puppeteer": "^22.14.0",
         "rehype-parse": "^9.0.0",
         "remark-gfm": "^4.0.0",
         "remark-mdx": "^3.0.1",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
-        "traverse": "^0.6.10",
         "unified": "^11.0.5",
         "unist-util-visit": "^5.0.0",
         "yargs": "^17.6.0",
@@ -1907,14 +2069,13 @@
       }
     },
     "node_modules/@mintlify/validation": {
-      "version": "0.1.335",
-      "resolved": "https://registry.npmjs.org/@mintlify/validation/-/validation-0.1.335.tgz",
-      "integrity": "sha512-TQ2CvYGki+2M75D4JMpQvD226zCWEoDqPyzq4aFKANFp9R/TvgS8q1/aV2NVNeE1yyNoKSwL3CbZJ6rbkKiYPw==",
+      "version": "0.1.416",
+      "resolved": "https://registry.npmjs.org/@mintlify/validation/-/validation-0.1.416.tgz",
+      "integrity": "sha512-YkjeegbRxTXgK5eE8cjvc1i4t3oabGyUZIOLJslnqJPi50zwpmkXM1HWhfhQO1Z5GWD3ZrNBITi1/d8SoAL6oQ==",
       "dev": true,
       "license": "Elastic-2.0",
       "dependencies": {
-        "@mintlify/models": "0.0.182",
-        "is-absolute-url": "^4.0.1",
+        "@mintlify/models": "0.0.207",
         "lcm": "^0.0.3",
         "lodash": "^4.17.21",
         "openapi-types": "^12.0.0",
@@ -1966,41 +2127,77 @@
         "node": ">=18"
       }
     },
-    "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.7.0.tgz",
-      "integrity": "sha512-5BxcD6LjVWsGu4xyaBC5bu8LdNgPCVBnAkWTtOCs/CZxcB22L8rcoWfv7Hh/3WooVjBZmFtyxhgvkQFedPGnFw==",
+    "node_modules/@shikijs/core": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.8.1.tgz",
+      "integrity": "sha512-uTSXzUBQ/IgFcUa6gmGShCHr4tMdR3pxUiiWKDm8pd42UKJdYhkAYsAmHX5mTwybQ5VyGDgTjW4qKSsRvGSang==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.7.0",
+        "@shikijs/types": "3.8.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.8.1.tgz",
+      "integrity": "sha512-rZRp3BM1llrHkuBPAdYAzjlF7OqlM0rm/7EWASeCcY7cRYZIrOnGIHE9qsLz5TCjGefxBFnwgIECzBs2vmOyKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.8.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.3"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.8.1.tgz",
+      "integrity": "sha512-KGQJZHlNY7c656qPFEQpIoqOuC4LrxjyNndRdzk5WKB/Ie87+NJCF1xo9KkOUxwxylk7rT6nhlZyTGTC4fCe1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.8.1",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.7.0.tgz",
-      "integrity": "sha512-1zYtdfXLr9xDKLTGy5kb7O0zDQsxXiIsw1iIBcNOO8Yi5/Y1qDbJ+0VsFoqTlzdmneO8Ij35g7QKF8kcLyznCQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.8.1.tgz",
+      "integrity": "sha512-TjOFg2Wp1w07oKnXjs0AUMb4kJvujML+fJ1C5cmEj45lhjbUXtziT1x2bPQb9Db6kmPhkG5NI2tgYW1/DzhUuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.7.0"
+        "@shikijs/types": "3.8.1"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.7.0.tgz",
-      "integrity": "sha512-VJx8497iZPy5zLiiCTSIaOChIcKQwR0FebwE9S3rcN0+J/GTWwQ1v/bqhTbpbY3zybPKeO8wdammqkpXc4NVjQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.8.1.tgz",
+      "integrity": "sha512-Vu3t3BBLifc0GB0UPg2Pox1naTemrrvyZv2lkiSw3QayVV60me1ujFQwPZGgUTmwXl1yhCPW8Lieesm0CYruLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.7.0"
+        "@shikijs/types": "3.8.1"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-3.8.1.tgz",
+      "integrity": "sha512-nmTyFfBrhJk6HJi118jes0wuWdfKXeVUq1Nq+hm8h6wbk1KUfvtg+LY/uDfxZD2VDItHO3QoINIs3NtoKBmgxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.8.1",
+        "@shikijs/types": "3.8.1"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.7.0.tgz",
-      "integrity": "sha512-MGaLeaRlSWpnP0XSAum3kP3a8vtcTsITqoEPYdt3lQG3YCdQH4DnEhodkYcNMcU0uW0RffhoD1O3e0vG5eSBBg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.8.1.tgz",
+      "integrity": "sha512-5C39Q8/8r1I26suLh+5TPk1DTrbY/kn3IdWA5HdizR0FhlhD05zx5nKCqhzSfDHH3p4S0ZefxWd77DLV+8FhGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2184,9 +2381,9 @@
       }
     },
     "node_modules/@stoplight/spectral-core": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.19.5.tgz",
-      "integrity": "sha512-i+njdliW7bAHGsHEgDvH0To/9IxiYiBELltkZ7ASVy4i+WXtZ40lQXpeRQRwePrBcSgQl0gcZFuKX10nmSHtbw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.20.0.tgz",
+      "integrity": "sha512-5hBP81nCC1zn1hJXL/uxPNRKNcB+/pEIHgCjPRpl/w/qy9yC9ver04tw1W0l/PMiv0UeB5dYgozXVQ4j5a6QQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2249,9 +2446,9 @@
       }
     },
     "node_modules/@stoplight/spectral-core/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2303,9 +2500,9 @@
       "license": "0BSD"
     },
     "node_modules/@stoplight/spectral-functions": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.9.4.tgz",
-      "integrity": "sha512-+dgu7QQ1JIZFsNLhNbQLPA9tniIT3KjOc9ORv0LYSCLvZjkWT2bN7vgmathbXsbmhnmhvl15H9sRqUIqzi+qoQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.10.1.tgz",
+      "integrity": "sha512-obu8ZfoHxELOapfGsCJixKZXZcffjg+lSoNuttpmUFuDzVLT3VmH8QkPXfOGOL5Pz80BR35ClNAToDkdnYIURg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2565,9 +2762,9 @@
       "license": "MIT"
     },
     "node_modules/@types/cors": {
-      "version": "2.8.17",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
-      "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2595,9 +2792,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2686,17 +2883,10 @@
         "undici-types": "~5.26.4"
       }
     },
-    "node_modules/@types/prismjs": {
-      "version": "1.26.5",
-      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
-      "integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2810,9 +3000,9 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2897,16 +3087,16 @@
       }
     },
     "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+      "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "type-fest": "^0.21.3"
+        "environment": "^1.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3070,6 +3260,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -3087,9 +3290,9 @@
       }
     },
     "node_modules/avsc": {
-      "version": "5.7.7",
-      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.7.tgz",
-      "integrity": "sha512-9cYNccliXZDByFsFliVwk5GvTq058Fj513CiR4E60ndDwmuXzTJEp/Bp8FyuRmGyYupLjHLs+JA9/CBoVS4/NQ==",
+      "version": "5.7.9",
+      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.9.tgz",
+      "integrity": "sha512-yOA4wFeI7ET3v32Di/sUybQ+ttP20JHSW3mxLuNGeO0uD6PPcvLrIQXSvy/rhJOWU5JrYh7U4OHplWMmtAtjMg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3097,9 +3300,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3134,17 +3337,17 @@
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
-      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.0.tgz",
+      "integrity": "sha512-EKZ5BTXYExaNqi3I3f9RtEsaI/xBSGjE0XZCZilPzFAV/goswFHuPd9jEZlPIZ/iNZJwDSao9qRiScySz7MbQg==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.2.tgz",
-      "integrity": "sha512-8wSeOia5B7LwD4+h465y73KOdj5QHsbbuoUfPBi+pXgFJIPuG7SsiOdJuijWMyfid49eD+WivpfY7KT8gbAzBA==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.6.tgz",
+      "integrity": "sha512-25RsLF33BqooOEFNdMcEhMpJy8EoR88zSMrnOQOaM3USnOK2VmaJ1uaQEwPA6AQjrv1lXChScosN6CzbwbO9OQ==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -3277,18 +3480,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/bl": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
-      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "node_modules/body-parser": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -3355,9 +3546,9 @@
       }
     },
     "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
       "funding": [
         {
@@ -3376,7 +3567,7 @@
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-crc32": {
@@ -3639,6 +3830,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
@@ -3668,6 +3872,120 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -3693,14 +4011,17 @@
         "node": ">=12"
       }
     },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
       "engines": {
-        "node": ">=0.8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/collapse-white-space": {
@@ -3821,6 +4142,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/cookie": {
@@ -3975,9 +4306,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3993,9 +4324,9 @@
       }
     },
     "node_modules/decode-named-character-reference": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.1.0.tgz",
-      "integrity": "sha512-Wy+JTSbFThEOXQIR2L6mxJvEs+veIzpmqD7ynWxMXGpnk3smkHQOp6forLdHsKpAMW9iJpaBBIxz285t1n1C3w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
+      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4030,19 +4361,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4171,9 +4489,9 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4302,9 +4620,9 @@
       }
     },
     "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4415,6 +4733,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -4426,9 +4757,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.23.9",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
-      "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
+      "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4436,18 +4767,18 @@
         "arraybuffer.prototype.slice": "^1.0.4",
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
+        "call-bound": "^1.0.4",
         "data-view-buffer": "^1.0.2",
         "data-view-byte-length": "^1.0.2",
         "data-view-byte-offset": "^1.0.1",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "es-set-tostringtag": "^2.1.0",
         "es-to-primitive": "^1.3.0",
         "function.prototype.name": "^1.1.8",
-        "get-intrinsic": "^1.2.7",
-        "get-proto": "^1.0.0",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
         "get-symbol-description": "^1.1.0",
         "globalthis": "^1.0.4",
         "gopd": "^1.2.0",
@@ -4459,21 +4790,24 @@
         "is-array-buffer": "^3.0.5",
         "is-callable": "^1.2.7",
         "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
         "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
         "is-shared-array-buffer": "^1.0.4",
         "is-string": "^1.1.1",
         "is-typed-array": "^1.1.15",
-        "is-weakref": "^1.1.0",
+        "is-weakref": "^1.1.1",
         "math-intrinsics": "^1.1.0",
-        "object-inspect": "^1.13.3",
+        "object-inspect": "^1.13.4",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.7",
         "own-keys": "^1.0.1",
-        "regexp.prototype.flags": "^1.5.3",
+        "regexp.prototype.flags": "^1.5.4",
         "safe-array-concat": "^1.1.3",
         "safe-push-apply": "^1.0.0",
         "safe-regex-test": "^1.1.0",
         "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
         "string.prototype.trim": "^1.2.10",
         "string.prototype.trimend": "^1.0.9",
         "string.prototype.trimstart": "^1.0.8",
@@ -4482,7 +4816,7 @@
         "typed-array-byte-offset": "^1.0.4",
         "typed-array-length": "^1.0.7",
         "unbox-primitive": "^1.1.0",
-        "which-typed-array": "^1.1.18"
+        "which-typed-array": "^1.1.19"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4492,18 +4826,18 @@
       }
     },
     "node_modules/es-aggregate-error": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.13.tgz",
-      "integrity": "sha512-KkzhUUuD2CUMqEc8JEqsXEMDHzDPE8RCjZeUBitsnB1eNcAJWQPiciKsMXe3Yytj4Flw1XLl46Qcf9OxvZha7A==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.14.tgz",
+      "integrity": "sha512-3YxX6rVb07B5TV11AV5wsL7nQCHXNwoHPsQC8S4AmBiqYhyNCJ5BRKXkXyDJvs8QzXN20NgRtxe3dEEQD9NLHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
+        "es-abstract": "^1.24.0",
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "globalthis": "^1.0.3",
+        "globalthis": "^1.0.4",
         "has-property-descriptors": "^1.0.2",
         "set-function-name": "^2.0.2"
       },
@@ -4580,6 +4914,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.39.7",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.7.tgz",
+      "integrity": "sha512-ek/wWryKouBrZIjkwW2BFf91CWOIMvoy2AE5YYgUrfWsJQM2Su1LoLtrw8uusEpN9RfqLlV/0FVNjT0WMv8Bxw==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esast-util-from-estree": {
       "version": "2.0.0",
@@ -5178,15 +5523,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -5352,6 +5698,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5436,9 +5795,9 @@
       }
     },
     "node_modules/get-uri": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
-      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6044,9 +6403,9 @@
       }
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
@@ -6202,6 +6561,164 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ink": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-5.2.1.tgz",
+      "integrity": "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.1.3",
+        "ansi-escapes": "^7.0.0",
+        "ansi-styles": "^6.2.1",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^4.0.0",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.22.0",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^1.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.29.0",
+        "scheduler": "^0.23.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^7.1.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.27.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.18.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0",
+        "react-devtools-core": "^4.19.1"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink-spinner": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ink-spinner/-/ink-spinner-5.0.0.tgz",
+      "integrity": "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-spinners": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "peerDependencies": {
+        "ink": ">=4.0.0",
+        "react": ">=18.0.0"
+      }
+    },
+    "node_modules/ink/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ink/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ink/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/wrap-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
@@ -6210,18 +6727,18 @@
       "license": "MIT"
     },
     "node_modules/inquirer": {
-      "version": "12.5.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.5.2.tgz",
-      "integrity": "sha512-qoDk/vdSTIaXNXAoNnlg7ubexpJfUo7t8GT2vylxvE49BrLhToFuPPdMViidG2boHV7+AcP1TCkJs/+PPoF2QQ==",
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.8.2.tgz",
+      "integrity": "sha512-oBDL9f4+cDambZVJdfJu2M5JQfvaug9lbo6fKDlFV40i8t3FGA1Db67ov5Hp5DInG4zmXhHWTSnlXBntnJ7GMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
-        "@inquirer/prompts": "^7.4.1",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/prompts": "^7.7.1",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2",
         "mute-stream": "^2.0.0",
-        "run-async": "^3.0.0",
+        "run-async": "^4.0.5",
         "rxjs": "^7.8.2"
       },
       "engines": {
@@ -6234,6 +6751,35 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/internal-slot": {
@@ -6283,19 +6829,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/is-absolute-url": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
-      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-alphabetical": {
@@ -6579,14 +7112,17 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/is-interactive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+    "node_modules/is-in-ci": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+      "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
       "dev": true,
       "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6609,6 +7145,19 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6800,19 +7349,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-weakmap": {
@@ -7015,9 +7551,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.21",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.21.tgz",
-      "integrity": "sha512-XvqR7FgOHtWupfMiigNzmh+MgUVmDGU2kXZm899ZkPfcuoPuFxyHmXsgATDpFZDAXCI8tvinaVcDo8PIIJSo4A==",
+      "version": "0.16.22",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.22.tgz",
+      "integrity": "sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==",
       "dev": true,
       "funding": [
         "https://opencollective.com/katex",
@@ -7105,23 +7641,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/log-symbols": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
-      "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.0.0",
-        "is-unicode-supported": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -7139,7 +7658,6 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -7235,6 +7753,14 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdast": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast/-/mdast-3.0.0.tgz",
+      "integrity": "sha512-xySmf8g4fPKMeC07jXGz971EkLbWAJ83s4US2Tj9lEdnZ142UP5grN73H1Xd3HzrdbU5o9GYYP/y8F9ZSwLE9g==",
+      "deprecated": "`mdast` was renamed to `remark`",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
@@ -8517,13 +9043,13 @@
       }
     },
     "node_modules/mintlify": {
-      "version": "4.0.468",
-      "resolved": "https://registry.npmjs.org/mintlify/-/mintlify-4.0.468.tgz",
-      "integrity": "sha512-LQhUKmVUAuf4B6vtIdWfAuJC22Jbsv5xgDZc1/qDxBky0JFwTn7PjP+06pBw4eEJOhcWlkfo0PtwyPHKKdl07w==",
+      "version": "4.2.25",
+      "resolved": "https://registry.npmjs.org/mintlify/-/mintlify-4.2.25.tgz",
+      "integrity": "sha512-RLbQ+X7NawPOtFjxhq4w2kFQAz+BVEz/a0RbLrWA5RKVW8FXpn/rZJowHqL6fr3Dq2U2WrT7jLTfeZ1yBya8nA==",
       "dev": true,
       "license": "Elastic-2.0",
       "dependencies": {
-        "@mintlify/cli": "4.0.467"
+        "@mintlify/cli": "4.0.629"
       },
       "bin": {
         "mint": "index.js",
@@ -8580,6 +9106,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/neotraverse": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+      "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/netmask": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
@@ -8591,19 +9127,19 @@
       }
     },
     "node_modules/next-mdx-remote-client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-mdx-remote-client/-/next-mdx-remote-client-1.1.0.tgz",
-      "integrity": "sha512-RuKP5Xe/cdgpeQOw1OqY6/t29DgjPQxvSUXpjr5OXB6gZpCnXrrruT6c+OwF2sskOA2jGjUbxVoavrB8CbGmQQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/next-mdx-remote-client/-/next-mdx-remote-client-1.1.1.tgz",
+      "integrity": "sha512-cJnJGaRiHc1gn4aCzDmY9zmcCjEw+zMCpCYIy45Kjs8HzeQpdGcaO5GrgIcX/DFkuCVrrzc69wi2gGnExXbv/A==",
       "dev": true,
       "license": "MPL 2.0",
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
+        "@babel/code-frame": "^7.27.1",
         "@mdx-js/mdx": "^3.1.0",
         "@mdx-js/react": "^3.1.0",
         "remark-mdx-remove-esm": "^1.1.0",
         "serialize-error": "^12.0.0",
         "vfile": "^6.0.3",
-        "vfile-matter": "^5.0.0"
+        "vfile-matter": "^5.0.1"
       },
       "engines": {
         "node": ">=18.18.0"
@@ -8679,9 +9215,9 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
-      "integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.2.tgz",
+      "integrity": "sha512-Ee/R3SyN4BuynXcnTaekmaVdbDAEiNrHqjQIA37mHU8G9pf7aaAD4ZX3XjBLo6rsdcxA/gtkcNYZLt30ACgynw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8784,6 +9320,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
+      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.3.tgz",
+      "integrity": "sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.1",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/open": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
@@ -8808,59 +9363,6 @@
       "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ora": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-6.3.1.tgz",
-      "integrity": "sha512-ERAyNnZOfqM+Ao3RAvIXkYh5joP220yf59gVe2X/cI6SiCxIdi4c9HZKZD8R6q/RDXEje1THBju6iExiSsgJaQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.0.0",
-        "cli-cursor": "^4.0.0",
-        "cli-spinners": "^2.6.1",
-        "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^1.1.0",
-        "log-symbols": "^5.1.0",
-        "stdin-discarder": "^0.1.0",
-        "strip-ansi": "^7.0.1",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ora/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
     },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
@@ -9067,16 +9569,29 @@
       }
     },
     "node_modules/parse5": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
-      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "entities": "^4.5.0"
+        "entities": "^6.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -9087,6 +9602,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/path-equal": {
@@ -9214,9 +9739,9 @@
       }
     },
     "node_modules/property-information": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.0.0.tgz",
-      "integrity": "sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -9320,9 +9845,9 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9438,7 +9963,6 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9461,19 +9985,21 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+    "node_modules/react-reconciler": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
+      "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
       }
     },
     "node_modules/readdirp": {
@@ -9580,82 +10106,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/refractor": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-4.9.0.tgz",
-      "integrity": "sha512-nEG1SPXFoGGx+dcjftjv8cAjEusIh6ED1xhf5DG3C0x/k+rmZ2duKnc3QLpt6qeHv5fPb8uwN3VWN2BT7fr3Og==",
+    "node_modules/regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.0.1.tgz",
+      "integrity": "sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/hast": "^2.0.0",
-        "@types/prismjs": "^1.0.0",
-        "hastscript": "^7.0.0",
-        "parse-entities": "^4.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
+        "regex-utilities": "^2.3.0"
       }
     },
-    "node_modules/refractor/node_modules/@types/hast": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
-      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/unist": "^2"
+        "regex-utilities": "^2.3.0"
       }
     },
-    "node_modules/refractor/node_modules/@types/unist": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/refractor/node_modules/hast-util-parse-selector": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
-      "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/refractor/node_modules/hastscript": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
-      "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^2.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-parse-selector": "^3.0.0",
-        "property-information": "^6.0.0",
-        "space-separated-tokens": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/refractor/node_modules/property-information": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
-      "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -9831,15 +10307,18 @@
       }
     },
     "node_modules/remark-mdx-remove-esm": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remark-mdx-remove-esm/-/remark-mdx-remove-esm-1.1.0.tgz",
-      "integrity": "sha512-oN3F9QRuPKSdzZi+wvEodBVjKwya63sl403pWzJvm0+c503iUjCDR+JAnP3Ho/4205IWbQ2NujPQi/B9kU6ZrA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/remark-mdx-remove-esm/-/remark-mdx-remove-esm-1.2.0.tgz",
+      "integrity": "sha512-BOZDeA9EuHDxQsvX7y4ovdlP8dk2/ToDGjOTrT5gs57OqTZuH4J1Tn8XjUFa221xvfXxiKaWrKT04waQ+tYydg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/mdast": "^4.0.3",
+        "@types/mdast": "^4.0.4",
         "mdast-util-mdxjs-esm": "^2.0.1",
         "unist-util-remove": "^4.0.0"
+      },
+      "peerDependencies": {
+        "unified": "^11"
       }
     },
     "node_modules/remark-parse": {
@@ -10062,9 +10541,9 @@
       }
     },
     "node_modules/run-async": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.5.tgz",
+      "integrity": "sha512-oN9GTgxUNDBumHTTDmQ8dep6VIJbgj9S3dPP+9XylVLIK4xB9XTXtKWROd5pnhdXR9k0EgO1JRcNh0T+Ny2FsA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10194,7 +10673,6 @@
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -10214,9 +10692,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -10289,19 +10767,6 @@
       },
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/serialize-error/node_modules/type-fest": {
-      "version": "4.39.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.39.1.tgz",
-      "integrity": "sha512-uW9qzd66uyHYxwyVBYiwS4Oi0qZyUqwjU+Oevr6ZogYiXt99EOYtwvzMSLw1c3lYo2HzJsep/NB23iEVEgjG/w==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10442,6 +10907,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.8.1.tgz",
+      "integrity": "sha512-+MYIyjwGPCaegbpBeFN9+oOifI8CKiKG3awI/6h3JeT85c//H2wDW/xCJEGuQ5jPqtbboKNqNy+JyX9PYpGwNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.8.1",
+        "@shikijs/engine-javascript": "3.8.1",
+        "@shikijs/engine-oniguruma": "3.8.1",
+        "@shikijs/langs": "3.8.1",
+        "@shikijs/themes": "3.8.1",
+        "@shikijs/types": "3.8.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -10560,6 +11042,52 @@
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/slice-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
+      "integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
+      "integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
@@ -10693,9 +11221,9 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
-      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.6.tgz",
+      "integrity": "sha512-pe4Y2yzru68lXCb38aAqRf5gvN8YdjP1lok5o0J7BOHljkyCGKVz7H3vpVIXKD27rj2giOJ7DwVyk/GWrPHDWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10750,6 +11278,29 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -10760,26 +11311,24 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/stdin-discarder": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
-      "integrity": "sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==",
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bl": "^5.0.0"
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">= 0.4"
       }
     },
     "node_modules/streamx": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
-      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
+      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10788,16 +11337,6 @@
       },
       "optionalDependencies": {
         "bare-events": "^2.2.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -10943,19 +11482,19 @@
       }
     },
     "node_modules/style-to-js": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.16.tgz",
-      "integrity": "sha512-/Q6ld50hKYPH3d/r6nr117TZkHR0w0kGGIVfpG9N6D8NymRPM9RqCUv4pRpJ62E5DqOYx2AFpbZMyCPnjQCnOw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.17.tgz",
+      "integrity": "sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "style-to-object": "1.0.8"
+        "style-to-object": "1.0.9"
       }
     },
     "node_modules/style-to-object": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.8.tgz",
-      "integrity": "sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.9.tgz",
+      "integrity": "sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10981,9 +11520,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
+      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11077,24 +11616,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/traverse": {
-      "version": "0.6.11",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.11.tgz",
-      "integrity": "sha512-vxXDZg8/+p3gblxB6BhhG5yWVn1kGRlaL8O78UDXc3wRnPizB5g83dcvWV1jpDMIPnjZjOFuxlMmE82XJ4407w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "gopd": "^1.2.0",
-        "typedarray.prototype.slice": "^1.0.5",
-        "which-typed-array": "^1.1.18"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -11156,13 +11677,13 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=10"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -11252,29 +11773,6 @@
         "is-typed-array": "^1.1.13",
         "possible-typed-array-names": "^1.0.0",
         "reflect.getprototypeof": "^1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typedarray.prototype.slice": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/typedarray.prototype.slice/-/typedarray.prototype.slice-1.0.5.tgz",
-      "integrity": "sha512-q7QNVDGTdl702bVFiI5eY4l/HkgCM6at9KhcFbgUAzezHFbOVy4+0O/lCjsABEQwbZPravVfBIiBVGo89yzHFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.9",
-        "es-errors": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "math-intrinsics": "^1.1.0",
-        "typed-array-buffer": "^1.0.3",
-        "typed-array-byte-offset": "^1.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11495,31 +11993,6 @@
       "dependencies": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
-      }
-    },
-    "node_modules/unbzip2-stream/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/undici-types": {
@@ -11773,13 +12246,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/utility-types": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
@@ -11875,16 +12341,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
       }
     },
     "node_modules/web-namespaces": {
@@ -12021,6 +12477,76 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/widest-line/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -12066,9 +12592,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12204,10 +12730,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -12215,9 +12748,9 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "glob": "^11.0.0",
-    "mintlify": "^4.0.468",
+    "mintlify": "^4.0",
     "prettier": "^3.4.2",
     "tsx": "^4.19.1",
     "typedoc": "^0.28.7",


### PR DESCRIPTION
Mintlify assigns `id`s to tabs based solely on tab name.  Thus, if there are multiple tabs with the same name on a page, clicking one of those tabs will jump to the tab group containing the first such tab.  For example, if there are two tab groups, each with a "TypeScript" tab and a "Python" tab, clicking the "Python" tab in the second group will jump to the first group where the "TypeScript" tab is still active:

https://github.com/user-attachments/assets/c2bdc03a-bc5b-47c7-9f3a-614d8b008db8

This PR replaces `<Tabs>` with `<CodeGroup>` where applicable, avoiding the problem and presenting a more appropriate UI.  The few remaining occurrences of `<Tabs>` do not exihibit such conflicts, except in the `docs/sdk/java/*.mdx` guides, which are currently not public.

Closes #1031.

| Before (local) | After (local) |
| --- | --- |
| <img width="1420" height="772" alt="before1" src="https://github.com/user-attachments/assets/5cbe69b6-f9f4-4862-ac49-56f56a1e1176" /> | <img width="1420" height="772" alt="after1" src="https://github.com/user-attachments/assets/68fd0264-0c7b-45ed-872d-9938704727fa" /> |
| <img width="1420" height="772" alt="before2" src="https://github.com/user-attachments/assets/1aab5bd3-f2d3-49c7-ab98-4369d44c41f8" /> | <img width="1420" height="772" alt="after2" src="https://github.com/user-attachments/assets/468db537-eb4b-4ef5-8429-ecc744691994" /> |
