### PR TITLE
Add go-sdk link

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -136,6 +136,7 @@
             "group": "SDKs",
             "pages": [
               "links/sdks/csharp",
+              "links/sdks/go",
               "links/sdks/java",
               "links/sdks/kotlin",
               "links/sdks/python",
@@ -257,6 +258,7 @@
             "group": "SDKs",
             "pages": [
               "links/sdks/csharp",
+              "links/sdks/go",
               "links/sdks/java",
               "links/sdks/kotlin",
               "links/sdks/python",
@@ -377,6 +379,7 @@
             "group": "SDKs",
             "pages": [
               "links/sdks/csharp",
+              "links/sdks/go",
               "links/sdks/java",
               "links/sdks/kotlin",
               "links/sdks/python",
@@ -501,6 +504,7 @@
             "group": "SDKs",
             "pages": [
               "links/sdks/csharp",
+              "links/sdks/go",
               "links/sdks/java",
               "links/sdks/kotlin",
               "links/sdks/python",

--- a/docs/links/sdks/go.mdx
+++ b/docs/links/sdks/go.mdx
@@ -1,0 +1,7 @@
+---
+title: go SDK
+url: https://github.com/modelcontextprotocol/go-sdk
+icon: golang
+---
+
+<Card title="go SDK" href="https://github.com/modelcontextprotocol/go-sdk" />


### PR DESCRIPTION
Adding link of go-sdk.

It will help go developers to find it on the introduction page easily.

- [x] Documentation update

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines

Used [PR](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/954) as reference 