### PR TITLE
Update codeowners of docs to @modelcontextprotocol/docs-maintaners group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CODEOWNERS file for MCP Specification repository
 
-# General documentation ownership - @steering-committee owns all of /docs
-/docs/ @modelcontextprotocol/steering-committee
+# General documentation ownership - @modelcontextprotocol/docs-maintaners owns all of /docs
+/docs/ @modelcontextprotocol/docs-maintaners
 
 # Specific ownership - @core-maintainer team owns docs/specification and schema/ directories
 /docs/specification/ @modelcontextprotocol/core-maintainers


### PR DESCRIPTION
Right now the review is assigned to @steering-committee, which is **very noisy**. For general docs, we can have a small group who will act on those PRs.

https://github.com/orgs/modelcontextprotocol/teams/docs-maintaners - we can edit members, just initial set up with round robin review assignment