### PR TITLE
[Doc] Fix GitHub capitalization in SEP guidelines

### DIFF
--- a/docs/community/sep-guidelines.mdx
+++ b/docs/community/sep-guidelines.mdx
@@ -44,7 +44,7 @@ Each SEP must have an **SEP author** -- someone who writes the SEP using the sty
 
 SEPs should be submitted as a GitHub Issue in the [specification repository](https://github.com/modelcontextprotocol/modelcontextprotocol). The standard SEP workflow is:
 
-1. You, the SEP author, create a [well-formatted](#sep-format) GitHub Issue with the `SEP` and `proposal` tags. The SEP number is the same as the Github Issue number, the two can be used interchangably.
+1. You, the SEP author, create a [well-formatted](#sep-format) GitHub Issue with the `SEP` and `proposal` tags. The SEP number is the same as the GitHub Issue number, the two can be used interchangably.
 2. Find a Core Maintainer or Maintainer to sponsor your proposal. Core Maintainers and Maintainers will regularly go over the list of open proposals to determine which proposals to sponsor.
 3. Once a sponsor is found, the GitHub Issue is assigned to the sponsor. The sponsor will add the `draft` tag, ensure the SEP number is in the title, and assign a milestone.
 4. The sponsor will informally review the proposal and may request changes based on community feedback. When ready for formal review, the sponsor will add the `in-review` tag.


### PR DESCRIPTION
Follow-up to https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1045#pullrequestreview-3048343535.
