### PR TITLE
Add postMessage Transport for #1005

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -444,7 +444,13 @@
                 "pages": [
                   "specification/draft/basic/index",
                   "specification/draft/basic/lifecycle",
-                  "specification/draft/basic/transports",
+                  {
+                    "group": "Transports",
+                    "pages": [
+                      "specification/draft/basic/transports",
+                      "specification/draft/basic/transports/postmessage"
+                    ]
+                  },
                   "specification/draft/basic/authorization",
                   "specification/draft/basic/security_best_practices",
                   {

--- a/docs/docs/concepts/transports.mdx
+++ b/docs/docs/concepts/transports.mdx
@@ -49,7 +49,7 @@ There are three types of JSON-RPC messages used:
 
 ## Built-in Transport Types
 
-MCP currently defines two standard transport mechanisms:
+MCP currently defines three standard transport mechanisms:
 
 ### Standard Input/Output (stdio)
 
@@ -305,6 +305,49 @@ When implementing Streamable HTTP transport, follow these security best practice
 5. **Validate Session IDs**: Ensure session IDs are cryptographically secure and properly validated
 
 Without these protections, attackers could use DNS rebinding to interact with local MCP servers from remote websites.
+
+### postMessage
+
+The postMessage transport enables secure, zero-installation MCP connections between browser contexts (iframes and popup windows). This transport leverages the browser's native `window.postMessage` API to provide browser-sandboxed execution without requiring software installation.
+
+Use postMessage when:
+
+- Building browser-based integrations with embedded MCP servers
+- Requiring zero-installation server distribution (servers as URLs)
+- Processing sensitive data locally without remote server transmission
+- Needing rich interactive UIs with full graphical interfaces
+- Implementing privacy-preserving edge computing
+- Creating inverted architectures where applications provide tools to embedded AI clients
+
+#### Key Features
+
+**Two Architectural Patterns**:
+
+- **Standard Architecture**: Outer Frame (MCP Client) embeds Inner Frame (MCP Server)
+- **Inverted Architecture**: Outer Frame (MCP Server) provides tools to Inner Frame (MCP Client)
+
+**Two-Phase Protocol**:
+
+1. **Setup Phase** (`#setup` URL hash): One-time configuration for authentication, API keys, preferences
+2. **Transport Phase** (no hash): Ongoing MCP communication with configured servers
+
+**Security Model**: Uses browser's origin-based security with strict `event.origin` validation and origin pinning after handshake.
+
+#### Security Considerations
+
+The postMessage transport uses origin-based security validation. Servers should maintain an explicit allowlist of permitted origins and use restrictive iframe sandbox attributes.
+
+#### Use Cases
+
+**Privacy-First Processing**: Healthcare and financial applications can process sensitive data entirely in-browser without remote transmission.
+
+**Interactive Visualization Tools**: Servers provide rich UI tools like diagram editors, data visualization dashboards, and real-time collaboration interfaces.
+
+**Zero Installation**: Servers distributed as URLs eliminate installation barriers and security risks, enabling instant access to MCP capabilities.
+
+**Edge Computing**: Computation occurs in the user's browser context, reducing latency and server costs while improving data locality.
+
+For detailed implementation guidance including message flows, version negotiation, and session management, see the [postMessage transport specification](/specification/draft/basic/transports/postmessage).
 
 ### Server-Sent Events (SSE) - Deprecated
 

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -8,11 +8,12 @@ title: Transports
 
 MCP uses JSON-RPC to encode messages. JSON-RPC messages **MUST** be UTF-8 encoded.
 
-The protocol currently defines two standard transport mechanisms for client-server
+The protocol currently defines three standard transport mechanisms for client-server
 communication:
 
 1. [stdio](#stdio), communication over standard in and standard out
 2. [Streamable HTTP](#streamable-http)
+3. [postMessage](#postmessage), secure browser-based communication using window.postMessage
 
 Clients **SHOULD** support stdio whenever possible.
 
@@ -286,6 +287,48 @@ protocol version 2024-11-05) as follows:
      - When the `endpoint` event arrives, the client can assume this is a server running
        the old HTTP+SSE transport, and should use that transport for all subsequent
        communication.
+
+## postMessage
+
+The **postMessage transport** enables secure, zero-installation MCP connections between browser contexts (iframes and popup windows). This transport leverages the browser's native `window.postMessage` API to provide browser-sandboxed execution without requiring software installation.
+
+### Key Features
+
+- **Zero Installation**: Servers are distributed as URLs, eliminating installation barriers and security risks
+- **Privacy-First Processing**: Sensitive data can be processed locally in the browser without remote server transmission
+- **Rich Interactive UIs**: Servers can provide full graphical interfaces, not just text-based responses
+- **Two Architectural Patterns**: Supports both traditional client-server patterns and inverted architectures where applications provide tools to embedded AI clients
+
+### Security Warning
+
+<Warning>
+
+When implementing postMessage transport, servers **MUST** validate message origins using `event.origin` from the browser's MessageEvent API.
+
+</Warning>
+
+### Two-Phase Protocol
+
+The transport uses a two-phase connection model:
+
+1. **Setup Phase** (`#setup` URL hash): One-time configuration when adding a server (authentication, API keys, preferences)
+2. **Transport Phase** (no hash): Ongoing MCP communication with configured servers
+
+Both phases implement secure handshake protocols with origin validation and session management.
+
+### Supported Architectures
+
+The transport supports two powerful patterns:
+
+**Standard Architecture**: Outer Frame acts as MCP Client, Inner Frame acts as MCP Server
+
+- Use case: Chat application embeds third-party diagram tool
+
+**Inverted Architecture**: Outer Frame acts as MCP Server, Inner Frame acts as MCP Client
+
+- Use case: User dashboard provides contextual data as tools to embedded AI copilot
+
+For detailed specification including message flows, security protocols, version negotiation, and implementation guidance, see the [postMessage transport specification](./transports/postmessage).
 
 ## Custom Transports
 

--- a/docs/specification/draft/basic/transports/postmessage.mdx
+++ b/docs/specification/draft/basic/transports/postmessage.mdx
@@ -1,0 +1,414 @@
+---
+title: postMessage Transport
+---
+
+<div id="enable-section-numbers" />
+
+<Info>**Protocol Revision**: draft</Info>
+
+The **postMessage transport** enables secure, zero-installation MCP connections between browser contexts (iframes and popup windows). By leveraging the browser's native `window.postMessage` API, this transport eliminates installation barriers while maintaining strong security through origin-based isolation.
+
+## Overview
+
+The postMessage transport supports two powerful architectural patterns by separating the **Window Hierarchy** (physical layer) from **MCP Protocol Roles** (logical layer):
+
+### Supported Architectures
+
+#### Standard Architecture (Client-in-Control)
+
+- **Outer Frame**: MCP Client
+- **Inner Frame**: MCP Server
+- **Use Case**: A primary application (like a chat client) embeds and consumes tools from third-party services.
+
+#### Inverted Architecture (Server-in-Control)
+
+- **Outer Frame**: MCP Server
+- **Inner Frame**: MCP Client
+- **Use Case**: A primary application (like a user dashboard) provides contextual data as tools to an embedded, sandboxed AI copilot.
+
+| Transport Feature       | Standard Architecture | Inverted Architecture |
+| ----------------------- | --------------------- | --------------------- |
+| **Outer Frame Role**    | MCP Client            | MCP Server            |
+| **Inner Frame Role**    | MCP Server            | MCP Client            |
+| **Who provides tools?** | Inner Frame           | Outer Frame           |
+| **Who calls tools?**    | Outer Frame           | Inner Frame           |
+
+## Protocol Phases
+
+The transport uses a **two-phase connection model**:
+
+1. **Setup Phase** (`#setup` URL hash): One-time configuration when a server is first added. Used for authentication, API keys, user preferences, etc.
+2. **Transport Phase** (no `#setup` hash): Normal, ongoing MCP communication with configured servers.
+
+**Note**: The setup phase is always required in terms of protocol steps, but can be transparent to users. Servers can immediately respond with handshake completion, making setup instantaneous without user interaction.
+
+## Security Implementation
+
+### Origin Validation Requirements
+
+The transport's security model relies on browser origin enforcement:
+
+- MCP Servers must maintain an explicit allowlist of permitted client origins
+- Message validation uses `event.origin` from the browser's MessageEvent API
+- Origin information in message payloads should not be used for security decisions
+
+### Target Origin Protocol
+
+1. **Inner Frame's First Message**: Uses `targetOrigin: '*'` for initial handshake (doesn't know Outer Frame's origin yet)
+2. **Origin Pinning**: After receiving Outer Frame's first message, Inner Frame pins the `event.origin` value
+3. **Subsequent Messages**: Inner Frame uses only the pinned origin for all future communication
+4. **Outer Frame Behavior**: Always uses Inner Frame's origin (from iframe URL) as `targetOrigin`
+
+## Message Flows
+
+To avoid race conditions, the Outer Frame **must** always begin listening for messages _before_ navigating the Inner Frame to its URL.
+
+```mermaid
+sequenceDiagram
+    participant OuterFrame
+    participant InnerFrame
+
+    Note over OuterFrame,InnerFrame: Setup Phase
+    OuterFrame->>OuterFrame: Start listening for messages
+    OuterFrame->>InnerFrame: Load subordinate window with "setup" hash
+    InnerFrame->>OuterFrame: SetupHandshake (targetOrigin: '*')
+    OuterFrame->>InnerFrame: SetupHandshakeReply (sessionId: abc123)
+    Note over InnerFrame: Pins Outer Frame origin<br/>Optional user interaction
+    InnerFrame->>OuterFrame: SetupComplete (displayName, visibility)
+    Note over OuterFrame: Persists config, transport is ready for future connections
+
+    Note over OuterFrame,InnerFrame: Transport Phase (when a connection is needed)
+    OuterFrame->>OuterFrame: Start listening for messages
+    OuterFrame->>InnerFrame: Load subordinate window (no hash)
+    InnerFrame->>OuterFrame: TransportHandshake (targetOrigin: '*')
+    OuterFrame->>InnerFrame: TransportHandshakeReply (sessionId: abc123)
+    Note over InnerFrame: Pins Outer Frame origin
+    InnerFrame->>OuterFrame: TransportAccepted
+
+    Note over OuterFrame,InnerFrame: MCP Communication
+    OuterFrame->>InnerFrame: MCPMessage (e.g., initialize or tool_call)
+    InnerFrame->>OuterFrame: MCPMessage (e.g., result)
+    Note over OuterFrame,InnerFrame: Ongoing MCP exchange...
+```
+
+## Message Types
+
+The protocol defines eight message types across two phases, all prefixed with `MCP_`:
+
+### Setup Phase Messages
+
+#### 1. SetupHandshake (Inner Frame → Outer Frame)
+
+**Context**: The Outer Frame has created a subordinate window (Inner Frame) and navigated it to a URL with a `#setup` hash. The Inner Frame detects this and initiates setup.
+
+**Target Origin**: The Inner Frame **must** use `'*'` because it cannot know the origin of its parent/opener at this stage.
+
+```typescript
+export interface SetupHandshakeMessage {
+  type: "MCP_SETUP_HANDSHAKE";
+
+  /** Minimum protocol version required by the inner frame */
+  minProtocolVersion: string;
+
+  /** Maximum protocol version supported by the inner frame */
+  maxProtocolVersion: string;
+
+  /** Whether the server needs to show UI during setup */
+  requiresVisibleSetup: boolean;
+
+  /** Optional permissions needed during setup and/or transport phases */
+  requestedPermissions?: PermissionRequirement[];
+}
+```
+
+#### 2. SetupHandshakeReply (Outer Frame → Inner Frame)
+
+**Context**: The Outer Frame receives the setup handshake and replies to confirm willingness to proceed. If `requiresVisibleSetup` was true, the Outer Frame makes the Inner Frame visible.
+
+**Target Origin**: The Outer Frame uses the Inner Frame's origin (known from iframe URL).
+
+**Security**: Upon receiving this message, the Inner Frame must:
+
+1. Validate that `event.origin` matches the expected Outer Frame's origin
+2. Pin `event.origin` for all subsequent communication in this session
+
+```typescript
+export interface SetupHandshakeReplyMessage {
+  type: "MCP_SETUP_HANDSHAKE_REPLY";
+
+  /** The agreed-upon protocol version within the negotiated range */
+  protocolVersion: string;
+
+  /** Unique identifier for this connection instance */
+  sessionId: string;
+}
+```
+
+#### 3. SetupComplete (Inner Frame → Outer Frame)
+
+**Context**: Setup is complete within the Inner Frame. This final message allows the Outer Frame to persist configuration and close/hide the setup window.
+
+**Target Origin**: The Inner Frame uses the pinned origin of the Outer Frame.
+
+```typescript
+export interface SetupCompleteMessage {
+  type: "MCP_SETUP_COMPLETE";
+
+  /** Whether setup succeeded or failed */
+  status: "success" | "error";
+
+  /** User-facing name for the application */
+  displayName: string;
+
+  /** Optional brief message to show the user */
+  ephemeralMessage?: string;
+
+  /** Visibility behavior during transport phase */
+  transportVisibility: {
+    requirement: "required" | "optional" | "hidden";
+    description?: string; // If 'optional', describes benefit of visibility
+  };
+
+  /** If status is 'error', details about what went wrong */
+  error?: {
+    code:
+      | "USER_CANCELLED"
+      | "AUTH_FAILED"
+      | "TIMEOUT"
+      | "CONFIG_ERROR"
+      | "VERSION_MISMATCH"
+      | "INSUFFICIENT_PERMISSIONS";
+    message: string;
+  };
+}
+```
+
+### Transport Phase Messages
+
+#### 4. TransportHandshake (Inner Frame → Outer Frame)
+
+**Context**: The Outer Frame has created a subordinate window for an active transport session (no `#setup` hash). The Inner Frame initiates the connection.
+
+**Target Origin**: The Inner Frame uses `'*'` because, as a new window instance, it doesn't yet know its controller's origin.
+
+```typescript
+export interface TransportHandshakeMessage {
+  type: "MCP_TRANSPORT_HANDSHAKE";
+
+  /** Protocol version for compatibility checking */
+  protocolVersion: "1.0";
+}
+```
+
+#### 5. TransportHandshakeReply (Outer Frame → Inner Frame)
+
+**Context**: The Outer Frame receives the transport handshake and replies with the `sessionId`, authorizing the transport to begin.
+
+**Target Origin**: The Outer Frame uses the Inner Frame's origin.
+
+**Security**: Upon receiving this message, the Inner Frame must:
+
+1. Validate that `event.origin` is an allowed origin
+2. Pin `event.origin` for all subsequent communication in this session
+
+```typescript
+export interface TransportHandshakeReplyMessage {
+  type: "MCP_TRANSPORT_HANDSHAKE_REPLY";
+
+  /** Unique identifier for this connection instance */
+  sessionId: string;
+
+  /** Protocol version for compatibility checking */
+  protocolVersion: "1.0";
+}
+```
+
+#### 6. TransportAccepted (Inner Frame → Outer Frame)
+
+**Context**: The Inner Frame has received the handshake reply, validated the Outer Frame's origin, and is ready for MCP communication.
+
+**Target Origin**: The Inner Frame uses the pinned origin of the Outer Frame.
+
+```typescript
+export interface TransportAcceptedMessage {
+  type: "MCP_TRANSPORT_ACCEPTED";
+
+  /** Echo back the session ID to confirm */
+  sessionId: string;
+}
+```
+
+#### 7. MCPMessage (Bidirectional)
+
+**Context**: After `TransportAccepted`, all MCP protocol messages are wrapped in this message type to distinguish them from transport control messages.
+
+**Target Origin**: Both parties use their respective pinned origins.
+
+```typescript
+export interface MCPMessage {
+  type: "MCP_MESSAGE";
+
+  /** The complete MCP JSON-RPC 2.0 message */
+  payload: {
+    jsonrpc: "2.0";
+    id?: string | number;
+    method?: string;
+    params?: any;
+    result?: any;
+    error?: any;
+  };
+}
+```
+
+#### 8. SetupRequired (Inner Frame → Outer Frame) _Optional_
+
+**Context**: During an active session, the Inner Frame determines it needs to re-run the setup phase (e.g., expired OAuth token, invalid API key).
+
+**Target Origin**: The Inner Frame uses the pinned origin from the session.
+
+```typescript
+export interface SetupRequiredMessage {
+  type: "MCP_SETUP_REQUIRED";
+
+  /** Why setup is needed again */
+  reason: "AUTH_EXPIRED" | "CONFIG_CHANGED" | "PERMISSIONS_CHANGED" | "OTHER";
+
+  /** Human-readable explanation */
+  message: string;
+
+  /** Whether the current session can continue working */
+  canContinue: boolean;
+}
+```
+
+## Version Negotiation
+
+The protocol supports range-based version negotiation during setup handshake for backward and forward compatibility:
+
+1. **Inner Frame declares range**: Sends `minProtocolVersion` and `maxProtocolVersion`
+2. **Outer Frame selects version**: Chooses highest compatible version within range
+3. **Semantic version validation**: Both parties validate using [semantic versioning](https://semver.org/) rules
+4. **Compatibility check**: If no compatible version exists, outer frame rejects with `VERSION_MISMATCH` error
+
+**Example**:
+
+- Inner Frame supports: `minProtocolVersion: "1.0.0"`, `maxProtocolVersion: "1.2.0"`
+- Outer Frame supports: `["1.1.0", "1.3.0", "2.0.0"]`
+- Agreed version: `"1.1.0"` (highest version within Inner Frame's range)
+
+## Permission Declaration System
+
+Inner frames can declare browser permissions needed, enabling:
+
+**Proactive Sandbox Configuration**: The outer frame configures iframe `allow` attributes:
+
+```javascript
+const allowValue = requestedPermissions.map((p) => p.name).join("; ");
+iframe.setAttribute("allow", allowValue);
+```
+
+**Transparent User Consent**: Outer frames can display permission requests with clear explanations before embedding.
+
+**Permission Structure**:
+
+```typescript
+export interface PermissionRequirement {
+  /** Standard permission name (e.g., "camera", "clipboard-read") */
+  name: string;
+
+  /** Phases when needed: 'setup' and/or 'transport' */
+  phase: ("setup" | "transport")[];
+
+  /** Whether required for core functionality */
+  required: boolean;
+
+  /** User-facing explanation of why needed */
+  purpose: string;
+}
+```
+
+**Recommended Sandbox Attributes**:
+
+Production Environment:
+
+```javascript
+iframe.sandbox.value =
+  "allow-scripts allow-forms allow-storage-access-by-user-activation allow-modals";
+```
+
+Testing/Development (same-origin only):
+
+```javascript
+iframe.sandbox.value =
+  "allow-scripts allow-same-origin allow-forms allow-storage-access-by-user-activation allow-modals";
+```
+
+<Warning>
+
+`allow-same-origin` combined with `allow-scripts` significantly reduces sandbox effectiveness and should only be used in testing environments or when the inner frame is served from a trusted same-origin source.
+
+</Warning>
+
+## Session Management
+
+Sessions are orchestrated by the **MCP Client**, which generates and provides the `sessionId`. The **MCP Server** uses this ID to scope persistent storage.
+
+**Cross-Phase Workflow**:
+
+1. **Setup Phase**: Client provides sessionId during setup handshake
+2. **Server Storage**: Server stores configuration (API keys, preferences) scoped by sessionId
+3. **Transport Phase**: Client provides same sessionId during transport handshake
+4. **Data Retrieval**: Server uses sessionId to retrieve previously stored configuration
+
+**Implementation Example**:
+
+```javascript
+// During setup phase
+const configKey = `server-config-${sessionId}`;
+localStorage.setItem(configKey, JSON.stringify({ apiKey, preferences }));
+
+// During transport phase
+const config = JSON.parse(localStorage.getItem(`server-config-${sessionId}`));
+```
+
+**Session Continuity**: The Outer Frame can reuse session IDs across Inner Frame reloads, allowing state restoration across page refreshes.
+
+## Use Cases
+
+### Zero Installation
+
+- MCP servers distributed as URLs
+- No software installation required
+- Instant access to capabilities in browser sandbox
+
+### Privacy-First Processing
+
+- Healthcare and financial data processed locally
+- Sensitive information never leaves user's device
+- Full browser security model protection
+
+### Interactive Visualization Tools
+
+- Rich UI tools embedded directly
+- Real-time collaborative interfaces
+- Progressive enhancement of client applications
+
+### Edge Computing
+
+- Computation in user's browser context
+- Reduced latency and server costs
+- Improved data locality
+
+## Implementation Notes
+
+### Race Condition Prevention
+
+The Outer Frame **must** start listening for messages _before_ navigating the Inner Frame to prevent missing the initial handshake message.
+
+### State Persistence
+
+Server state **must** be persisted using the provided `sessionId` as a key to ensure proper isolation and retrieval across sessions.
+
+### Error Handling
+
+Implement proper timeout handling for handshake phases and validate all message structures before processing.

--- a/docs/specification/draft/changelog.mdx
+++ b/docs/specification/draft/changelog.mdx
@@ -9,7 +9,9 @@ the previous revision, [2025-06-18](/specification/2025-06-18).
 
 ## Major changes
 
-1. Enhance authorization server discovery with support for [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html). (PR [#797](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/797))
+1. Add **[postMessage transport](/specification/draft/basic/transports/postmessage)** for secure, zero-installation communication between browser contexts (iframes and popups). This transport enables new use cases including privacy-preserving edge computing, rich interactive UIs, and inverted architectures where applications provide tools to embedded AI clients.
+
+2. Enhance authorization server discovery with support for [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html). (PR [#797](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/797))
 
 ## Other schema changes
 

--- a/schema/draft/postmessage-transport-schema.ts
+++ b/schema/draft/postmessage-transport-schema.ts
@@ -1,0 +1,357 @@
+/**
+ * PostMessage Transport Protocol - Message Interfaces
+ * 
+ * This protocol defines a two-phase approach to MCP server connections:
+ * 1. Setup Phase - One-time configuration when adding a server
+ * 2. Transport Phase - Active MCP communication with configured servers
+ * 
+ * PHASE DETECTION:
+ * - Setup: Server URL includes #setup hash parameter
+ * - Transport: Server URL has no hash parameter
+ * 
+ * SECURITY: Servers must always validate message origins using event.origin
+ * from the browser's MessageEvent API. This is the only trusted source of
+ * origin information in the postMessage security model.
+ * 
+ * TARGET ORIGINS:
+ * - Server's first message in each phase uses targetOrigin '*' (doesn't know client yet)
+ * - After receiving client's first message, server pins event.origin and uses it exclusively
+ * - Client always uses server's origin (known from iframe URL) as targetOrigin
+ */
+
+// ============================================================================
+// SETUP PHASE MESSAGES
+// ============================================================================
+
+/**
+ * Permission requirements for browser capabilities
+ */
+export interface PermissionRequirement {
+  /**
+   * Standard permission name from Permissions API / Feature Policy.
+   * Examples: "camera", "microphone", "clipboard-read", "display-capture"
+   */
+  name: string;
+
+  /**
+   * One or more phases during which this permission is needed.
+   * At least one phase must be specified.
+   */
+  phase: ('setup' | 'transport')[];
+
+  /**
+   * Whether this permission is required for core functionality.
+   * - true: Connection may fail without it.
+   * - false: Tool can degrade gracefully.
+   */
+  required: boolean;
+
+  /**
+   * User-facing explanation of why this permission is being requested.
+   * Should be concise and written in plain language.
+   * Example: "To analyze copied text and generate diagrams"
+   */
+  purpose: string;
+}
+
+/**
+ * Setup Handshake (Inner Frame → Outer Frame)
+ * 
+ * Context: The Outer Frame has created a subordinate window (Inner Frame) and
+ * navigated it to a URL with a `#setup` hash. The code in the Inner Frame
+ * detects this and initiates the setup phase by sending this message.
+ * 
+ * TARGET ORIGIN: The Inner Frame must use '*' because it cannot know the
+ * origin of its parent/opener at this stage. This is the only message where
+ * the initiating party uses a wildcard target origin.
+ */
+export interface SetupHandshakeMessage {
+  type: 'MCP_SETUP_HANDSHAKE';
+  
+  /**
+   * Minimum protocol version required by the inner frame.
+   * Example: "1.0"
+   */
+  minProtocolVersion: string;
+
+  /**
+   * Maximum protocol version supported by the inner frame.
+   * Example: "2.0"
+   */
+  maxProtocolVersion: string;
+  
+  /** Whether the server needs to show UI during setup */
+  requiresVisibleSetup: boolean;
+
+  /**
+   * Optional permissions this inner frame needs during setup and/or transport phases.
+   * Used by outer frame to configure iframe sandbox and user consent flows.
+   */
+  requestedPermissions?: PermissionRequirement[];
+}
+
+/**
+ * Setup Handshake Reply (Outer Frame → Inner Frame)
+ * 
+ * Context: The Outer Frame receives the `SetupHandshakeMessage` and replies
+ * to confirm its willingness to proceed with setup. If `requiresVisibleSetup`
+ * was true, the Outer Frame is responsible for making the Inner Frame visible.
+ * 
+ * TARGET ORIGIN: The Outer Frame uses the origin of the Inner Frame, which
+ * it knows from the iframe's `src` or the popup's URL.
+ * 
+ * SECURITY: Upon receiving this message, the Inner Frame must:
+ * 1. Validate that `event.origin` matches the expected Outer Frame's origin.
+ * 2. Pin `event.origin` for all subsequent communication in this session.
+ */
+export interface SetupHandshakeReplyMessage {
+  type: 'MCP_SETUP_HANDSHAKE_REPLY';
+  
+  /**
+   * The agreed-upon protocol version chosen by the outer frame,
+   * which must fall within [minProtocolVersion, maxProtocolVersion].
+   * Must be a valid semantic version string.
+   */
+  protocolVersion: string;
+  
+  /** 
+   * Unique identifier for this connection instance.
+   * The MCP Client provides this ID, and the MCP Server uses it to
+   * scope any persistent storage (e.g., localStorage).
+   */
+  sessionId: string;
+}
+
+/**
+ * Setup Complete (Inner Frame → Outer Frame)
+ * 
+ * Context: The setup process within the Inner Frame is complete (e.g., user
+ * authenticated, configuration set). The Inner Frame sends this final message
+ * to the Outer Frame, which can then persist the configuration and close
+ * or hide the setup window.
+ * 
+ * TARGET ORIGIN: The Inner Frame uses the pinned origin of the Outer Frame.
+ */
+export interface SetupCompleteMessage {
+  type: 'MCP_SETUP_COMPLETE';
+  
+  /** Whether setup succeeded or failed */
+  status: 'success' | 'error';
+  
+  /** 
+   * A user-facing name for the inner frame's application.
+   * In the Standard Architecture, this is the MCP Server's title (e.g., "Pi Calculator").
+   * In the Inverted Architecture, this could be the MCP Client's title (e.g., "AI Copilot").
+   * This appears in the Outer Frame's UI.
+   */
+  displayName: string;
+  
+  /** 
+   * Optional message to briefly show the user (toast/notification style)
+   * Examples: "Successfully authenticated!", "Configuration saved"
+   */
+  ephemeralMessage?: string;
+  
+  /** 
+   * Visibility behavior during transport phase
+   */
+  transportVisibility: {
+    /** 
+     * Visibility requirement:
+     * - 'required': Server must be visible (e.g., shows live visualizations)
+     * - 'optional': User can choose (e.g., can show logs but not necessary)
+     * - 'hidden': Server should stay hidden (most common case)
+     */
+    requirement: 'required' | 'optional' | 'hidden';
+    
+    /**
+     * If `requirement` is 'optional', this user-facing string describes
+     * the benefit of keeping the transport visible. The Outer Frame's UI
+     * should display this next to a show/hide control.
+     *
+     * @example "Show to see live diagram previews."
+     */
+    description?: string;
+  };
+  
+  /** If status is 'error', details about what went wrong */
+  error?: {
+    code: 'USER_CANCELLED' | 'AUTH_FAILED' | 'TIMEOUT' | 'CONFIG_ERROR' | 'VERSION_MISMATCH' | 'INSUFFICIENT_PERMISSIONS';
+    message: string;
+  };
+}
+
+// ============================================================================
+// TRANSPORT PHASE MESSAGES
+// ============================================================================
+
+/**
+ * Transport Handshake (Inner Frame → Outer Frame)
+ * 
+ * Context: The Outer Frame has created a subordinate window (Inner Frame) for
+ * an active transport session (i.e., no `#setup` hash). The Inner Frame
+ * initiates the connection by sending this message.
+ * 
+ * TARGET ORIGIN: The Inner Frame must use '*' because, as a new window
+ * instance, it does not yet know its controller's origin.
+ */
+export interface TransportHandshakeMessage {
+  type: 'MCP_TRANSPORT_HANDSHAKE';
+  
+  /** Protocol version for compatibility checking */
+  protocolVersion: '1.0';
+}
+
+/**
+ * Transport Handshake Reply (Outer Frame → Inner Frame)
+ * 
+ * Context: The Outer Frame receives the `TransportHandshakeMessage` and replies
+ * with the `sessionId` for this connection, authorizing the transport to begin.
+ * 
+ * TARGET ORIGIN: The Outer Frame uses the Inner Frame's origin.
+ * 
+ * SECURITY: Upon receiving this message, the Inner Frame must:
+ * 1. Validate that `event.origin` is an allowed origin.
+ * 2. Pin `event.origin` for all subsequent communication in this session.
+ */
+export interface TransportHandshakeReplyMessage {
+  type: 'MCP_TRANSPORT_HANDSHAKE_REPLY';
+  
+  /** 
+   * Unique identifier for this connection instance.
+   * The MCP Client provides this ID, and the MCP Server uses it to
+   * scope any persistent storage (e.g., localStorage).
+   */
+  sessionId: string;
+  
+  /** Protocol version for compatibility checking */
+  protocolVersion: '1.0';
+}
+
+/**
+ * Transport Accepted (Inner Frame → Outer Frame)
+ * 
+ * Context: The Inner Frame has received the handshake reply, validated the
+ * Outer Frame's origin, and is now ready for MCP communication. This message
+ * signals to the Outer Frame that the transport is fully established.
+ * 
+ * TARGET ORIGIN: The Inner Frame uses the pinned origin of the Outer Frame.
+ */
+export interface TransportAcceptedMessage {
+  type: 'MCP_TRANSPORT_ACCEPTED';
+  
+  /** Echo back the session ID to confirm */
+  sessionId: string;
+}
+
+/**
+ * After the transport handshake is complete, the client and server exchange
+ * standard MCP protocol messages (JSON-RPC 2.0 format). All MCP messages
+ * use the pinned origins established during handshake:
+ * - Server → Client: Uses the pinned client origin from Step 2
+ * - Client → Server: Uses the server origin from the iframe URL
+ */
+
+/**
+ * MCP Message Wrapper (Bidirectional)
+ * 
+ * Context: After TransportAccepted, all MCP protocol messages are wrapped
+ * in this message type. This allows the transport to distinguish between
+ * transport control messages and MCP protocol messages.
+ * 
+ * TARGET ORIGIN: Both parties use their respective pinned origins.
+ */
+export interface MCPMessage {
+  type: 'MCP_MESSAGE';
+  
+  /** The complete MCP JSON-RPC 2.0 message */
+  payload: {
+    jsonrpc: '2.0';
+    id?: string | number;
+    method?: string;
+    params?: any;
+    result?: any;
+    error?: any;
+  };
+}
+
+// ============================================================================
+// RUNTIME MESSAGES (During Active Transport)
+// ============================================================================
+
+/**
+ * (Inner Frame → Outer Frame) (Optional)
+ * 
+ * Context: During an active session, the Inner Frame determines it needs 
+ * to re-run the setup phase. For example:
+ * - OAuth token has expired
+ * - API key is no longer valid  
+ * - Server configuration has changed
+ * - User permissions have changed
+ * 
+ * The Outer Frame should prompt the user to re-run setup for this server.
+ * 
+ * TARGET ORIGIN: The Inner Frame uses the pinned origin from the session.
+ */
+export interface SetupRequiredMessage {
+  type: 'MCP_SETUP_REQUIRED';
+  
+  /** Why setup is needed again */
+  reason: 'AUTH_EXPIRED' | 'CONFIG_CHANGED' | 'PERMISSIONS_CHANGED' | 'OTHER';
+  
+  /** Human-readable explanation */
+  message: string;
+  
+  /** 
+   * Whether the current session can continue working
+   * - true: Session works but setup recommended soon
+   * - false: Session will fail, setup required immediately
+   */
+  canContinue: boolean;
+}
+
+// ============================================================================
+// TYPE GUARDS AND UTILITIES
+// ============================================================================
+
+/** All setup phase messages */
+export type SetupMessage = 
+  | SetupHandshakeMessage 
+  | SetupHandshakeReplyMessage 
+  | SetupCompleteMessage;
+
+/** All transport phase messages */
+export type TransportMessage = 
+  | TransportHandshakeMessage 
+  | TransportHandshakeReplyMessage 
+  | TransportAcceptedMessage
+  | SetupRequiredMessage
+  | MCPMessage;
+
+/** All PostMessage protocol messages */
+export type PostMessageProtocolMessage = 
+  | SetupMessage 
+  | TransportMessage;
+
+/** Check if a message is a PostMessage protocol message */
+export function isPostMessageProtocol(message: any): message is PostMessageProtocolMessage {
+  return message?.type?.startsWith('MCP_');
+}
+
+/** Check if a message is from setup phase */
+export function isSetupMessage(message: any): message is SetupMessage {
+  return message?.type?.startsWith('MCP_SETUP_') && 
+         message.type !== 'MCP_SETUP_REQUIRED';
+}
+
+/** Check if a message is from transport phase */
+export function isTransportMessage(message: any): message is TransportMessage {
+  return message?.type?.startsWith('MCP_TRANSPORT_') ||
+         message?.type === 'MCP_SETUP_REQUIRED' ||
+         message?.type === 'MCP_MESSAGE';
+}
+
+/** Check if a message is an MCP message wrapper */
+export function isMCPMessage(message: any): message is MCPMessage {
+  return message?.type === 'MCP_MESSAGE';
+}


### PR DESCRIPTION
# Add postMessage transport to MCP specification

## Motivation and Context

This PR adds a postMessage transport that enables:

- **Zero-installation servers** distributed as URLs, reducing security risks from local software installation
- **Privacy-first processing** where sensitive data stays in the user's browser without remote transmission
- **Interactive UIs** beyond text-based tool responses

## How Has This Been Tested?

This has been tested with a reference implementation at https://github.com/jmandel/mcp-postmessage. See #1005 for details.


## Breaking Changes

None.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed