### PR TITLE
Remove links to nonexistent schema reference pages

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -169,8 +169,7 @@
                     ]
                   }
                 ]
-              },
-               "specification/2025-03-26/schema"
+              }
             ]
           },
           {
@@ -218,8 +217,7 @@
                     ]
                   }
                 ]
-              },
-               "specification/2024-11-05/schema"
+              }
             ]
           },
           {
@@ -275,7 +273,7 @@
             ]
           }
         ]
-      },     
+      },
       {
         "tab": "Community",
         "pages": [
@@ -284,7 +282,7 @@
           "development/roadmap",
           "development/contributing",
           "clients",
-          "examples"         
+          "examples"
         ]
       }
     ]


### PR DESCRIPTION
Follow-up to #1044.

The schema reference page is currently generated only for the 2025-06-18 and draft versions of the spec.
