### PR TITLE
docs: small docs change + bundled schema formatting script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,8 @@ npm install  # install dependencies
 ## Making Changes
 
 Note that schema changes are made to `schema.ts`, and `schema.json` is generated from
-`schema.ts`.
+`schema.ts`. Changes proposed for the next version of the spec should be made to `draft`
+branch.
 
 1. Create a new branch:
 
@@ -56,6 +57,9 @@ npm run generate:schema
 npm run check:docs
 npm run format
 ```
+
+> [!NOTE]
+> steps 3-4 can be run together using `npm run prep:schema-changes`.
 
 5. Preview documentation locally (optional):
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "generate:schema:json": "for f in schema/*/schema.ts; do typescript-json-schema --defaultNumberType integer --required --skipLibCheck \"$f\" \"*\" -o \"${f%.ts}.json\"; done",
     "generate:schema:md": "for f in docs/specification/*/schema.mdx; do typedoc --entryPoints \"schema/$(basename -- $(dirname -- \"$f\"))/schema.ts\" > \"$f\"; done",
     "format": "prettier --write \"**/*.{md,mdx}\" --ignore \"docs/specification/*/schema.mdx\" ",
+    "prep:schema": "npm run check:schema:ts && npm run generate:schema && npm run check:docs && npm run format",
     "serve:docs": "cd docs && mintlify dev",
     "serve:blog": "cd blog && hugo serve"
   },


### PR DESCRIPTION
A small change to the docs to add information/a script that I would have found helpful.

## Motivation and Context
When starting to contribute, it wasn't clear to me which schema I should be updating — adding a small note to nudge folks towards the `draft` folder.

I also ended up chaining a bunch of scripts when making changes and syncing from [my PR](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/955) and the accompanying [SEP](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/955). Adding the `prep:schema` script which combines these steps.

## How Has This Been Tested?
I ran the new command via `npm run prep:schema` and it worked.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
