### PR TITLE
feat: add Langdock to the MCP clients community documentation

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -162,7 +162,7 @@ This page provides an overview of applications that support the Model Context Pr
 [JetBrains AI Assistant]: https://plugins.jetbrains.com/plugin/22282-jetbrains-ai-assistant
 [JetBrains Junie]: https://www.jetbrains.com/junie
 [Kilo Code]: https://github.com/Kilo-Org/kilocode
-[Langdock]: https://langdock.com
+[Langdock]: https://docs.langdock.com/resources/integrations/mcp
 [Langflow]: https://github.com/langflow-ai/langflow
 [LibreChat]: https://github.com/danny-avila/LibreChat
 [LM-Kit.NET]: https://lm-kit.com/products/lm-kit-net/


### PR DESCRIPTION
I implemented the Host part of the MCP specification for Langdock, which now supports connecting to remote MCP servers and using their tools
 
## Motivation and Context
Adding langdock to the documentation will bring visibility to both langdock and MCP as more clients will encourge the development of more servers.

## How Has This Been Tested?
The Langdock MCP implementation is live in production and already in use by customers, I have tested running the docs with `npm run serve:docs` everything works well and my changes are visible.

## Breaking Changes
No.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Screenshot of Linear's MCP server being connected in langdock:
<img width="1289" height="986" alt="Screenshot 2025-07-29 at 17 00 39" src="https://github.com/user-attachments/assets/ce126ae2-2c0a-4d9b-bbce-8b34a0440a79" />
