### PR TITLE
Restore `--font-mono` CSS variable

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1,4 +1,6 @@
 #content-area {
+  --font-mono: var(--font-jetbrains-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; /* via Mintlify theme */
+
   h5 {
     font-weight: 500;
   }


### PR DESCRIPTION
This was accidentally removed in #1044 and missed in #1074.
