### PR TITLE
docs: update Gemini CLI client to support prompts

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -41,7 +41,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [FLUJO][FLUJO]                                   | ❌          | ❌        | ✅      | ❓                     | ❌         | ❌    | ❓            |
 | [Genkit][Genkit]                                 | ⚠️          | ✅        | ✅      | ❓                     | ❌         | ❌    | ❓            |
 | [Glama][Glama]                                   | ✅          | ✅        | ✅      | ❓                     | ❌         | ❌    | ❓            |
-| [Gemini CLI][Gemini CLI]                         | ❌          | ❌        | ✅      | ❓                     | ❌         | ❌    | ❓            |
+| [Gemini CLI][Gemini CLI]                         | ❌          | ✅        | ✅      | ❓                     | ❌         | ❌    | ❓            |
 | [GenAIScript][GenAIScript]                       | ❌          | ❌        | ✅      | ❓                     | ❌         | ❌    | ❓            |
 | [GitHub Copilot coding agent][GitHubCopilotCodingAgent]                       | ❌          | ❌        | ✅      | ❌                     | ❌         | ❌    | ❌            |
 | [Goose][Goose]                                   | ✅          | ✅        | ✅      | ❓                     | ❌         | ❌    | ❓            |


### PR DESCRIPTION
Gemini CLI now supports MCP Prompts! 🎉 
- [Announcement blog](https://cloud.google.com/blog/topics/developers-practitioners/gemini-cli-custom-slash-commands?e=48754805)
- MCP Prompt support [PR ](https://github.com/google-gemini/gemini-cli/pull/4828)

Updating appropriate documentation to reflect this ✅ 
