### PR TITLE
Add Transports Working Group to MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -110,6 +110,7 @@ This document lists current maintainers and working groups in the Model Context 
 
 - [Kurtis Van Gent](https://github.com/kurtisvg)
 - [Jonathan Hefner](https://github.com/jonathanhefner)
+- [Shaun Smith](https://github.com/evalstate)
 
 ## About This Document
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -106,6 +106,11 @@ This document lists current maintainers and working groups in the Model Context 
 - [Harald Kirschner](https://github.com/digitarald)
 - [Connor Peet](https://github.com/connor4312)
 
+### Transports Working Group
+
+- [Kurtis Van Gent](https://github.com/kurtisvg)
+- [Jonathan Hefner](https://github.com/jonathanhefner)
+
 ## About This Document
 
 This document is updated by the MCP maintainers and reflects the current

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -111,6 +111,7 @@ This document lists current maintainers and working groups in the Model Context 
 - [Kurtis Van Gent](https://github.com/kurtisvg)
 - [Jonathan Hefner](https://github.com/jonathanhefner)
 - [Shaun Smith](https://github.com/evalstate)
+- [Harvey Tuch](https://github.com/htuch)
 
 ## About This Document
 


### PR DESCRIPTION
Adding the pre-existing Transports working group to the MAINTAINERS.md document per discussion with @dsp-ant. We're currently using the MAINTAINERS.md file to define permissioned Discord roles in the MCP Contributor Discord server, so this brings us up to parity with the proper permissions while we work to formalize the notion of Working Groups beyond this initial MAINTAINERS.md list.
