### PR TITLE
Add Discord invite link to communication docs

### DIFF
--- a/docs/community/communication.mdx
+++ b/docs/community/communication.mdx
@@ -9,14 +9,15 @@ All communication within the MCP community is governed by our [Code of Conduct](
 
 ## Communication Channels
 
-We support three primary communication channels: the public Discord server, [GitHub Issues](https://github.com/modelcontextprotocol/modelcontextprotocol/issues), and [GitHub Discussions](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions) in the [main project repository](https://github.com/modelcontextprotocol/modelcontextprotocol).
+We support three primary communication channels: the [public Discord server][discord-join], [GitHub Issues](https://github.com/modelcontextprotocol/modelcontextprotocol/issues), and [GitHub Discussions](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions) in the [main project repository](https://github.com/modelcontextprotocol/modelcontextprotocol).
 
 ### Discord
-
 For real-time contributor discussion and collaboration. The server is designed around **MCP contributors** and is not intended
 to be a place for general MCP support.
 
 The Discord server will have both public and private channels.
+
+[Join the Discord server here][discord-join].
 
 #### Public Channels (Default)
 
@@ -96,3 +97,5 @@ When documenting decisions, we will retain as much context as possible:
 - Options that were considered
 - Rationale for the chosen approach
 - Implementation steps
+
+[discord-join]: https://discord.gg/6CSzBmMkjX

--- a/docs/community/governance.mdx
+++ b/docs/community/governance.mdx
@@ -19,7 +19,7 @@ All maintainers are expected to have a strong bias towards MCP's design philosop
 
 ### Channels
 
-Technical Governance is facilitated through a [shared Discord server](/community/communication#discord) of all **maintainers, core maintainers** and **lead maintainers**. Each maintainer group can choose additional communication channels, but all decisions and their supporting discussions must be recorded and made transparently available on the Discord server.
+Technical Governance is facilitated through a shared [Discord server](/community/communication#discord) of all **maintainers, core maintainers** and **lead maintainers**. Each maintainer group can choose additional communication channels, but all decisions and their supporting discussions must be recorded and made transparently available on the Discord server.
 
 ### Maintainers
 

--- a/docs/community/governance.mdx
+++ b/docs/community/governance.mdx
@@ -19,7 +19,7 @@ All maintainers are expected to have a strong bias towards MCP's design philosop
 
 ### Channels
 
-Technical Governance is facilitated through a shared Discord server of all **maintainers, core maintainers** and **lead maintainers**. Each maintainer group can choose additional communication channels, but all decisions and their supporting discussions must be recorded and made transparently available on the core group Discord server.
+Technical Governance is facilitated through a [shared Discord server](/community/communication#discord) of all **maintainers, core maintainers** and **lead maintainers**. Each maintainer group can choose additional communication channels, but all decisions and their supporting discussions must be recorded and made transparently available on the Discord server.
 
 ### Maintainers
 
@@ -92,7 +92,7 @@ Both must:
 Projects and working groups without specified processes default to:
 
 - GitHub pull requests and issues for contributions
-- A public channel in the official MCP Discord (TBD)
+- A public channel in the official [MCP Contributor Discord](/community/communication#discord)
 
 #### Maintenance Responsibilities
 
@@ -118,7 +118,7 @@ The core maintainer group meets on a bi-weekly basis to discuss proposals and th
 
 ### Public Chat
 
-The MCP project maintains a public Discord server with open chats for interest groups. The MCP project may have private channels for certain communications.
+The MCP project maintains a [public Discord server](/community/communication#discord) with open chats for interest groups. The MCP project may have private channels for certain communications.
 
 ## Nominating, Confirming and Removing Maintainers
 


### PR DESCRIPTION
I realized as I started linking folks to the [governance](https://modelcontextprotocol.io/community/governance) and [communication](https://modelcontextprotocol.io/community/communication) pages, that there is no way to find the Discord link (which is only present on [the blog post announcement](https://blog.modelcontextprotocol.io/posts/2025-07-31-governance-for-mcp/) at the moment). Added it in relevant places on both pages.

Tested with running `npm run serve:docs` and verifying the links are linking up properly.