### PR TITLE
Update client capability example

### DIFF
--- a/docs/docs/learn/architecture.mdx
+++ b/docs/docs/learn/architecture.mdx
@@ -162,7 +162,7 @@ MCP begins with lifecycle management through a capability negotiation handshake.
     "params": {
       "protocolVersion": "2025-06-18",
       "capabilities": {
-        "tools": {}
+        "elicitation": {}
       },
       "clientInfo": {
         "name": "example-client",
@@ -206,7 +206,7 @@ In this example, the capability negotiation demonstrates how MCP primitives are 
 
 **Client Capabilities**:
 
-- `"tools": {}` - The client declares it can work with the tools primitive (can call `tools/list` and `tools/call` methods)
+- `"elicitation": {}` - The client declares it can work with user interaction requests (can receive `elicitation/create` method calls)
 
 **Server Capabilities**:
 


### PR DESCRIPTION
This example for the client capabilities mentions that the client needs to advertise that it can use tool calls.  This seems incorrect to me.  This PR changes the example to use elicitation.

## Motivation and Context

The docs seem incorrect in this area.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

