### PR TITLE
Tutorials > Connect to local MCPs: Make short description client-agnostic

### DIFF
--- a/docs/quickstart/user.mdx
+++ b/docs/quickstart/user.mdx
@@ -1,6 +1,6 @@
 ---
 title: Connect to Local MCP Servers
-description: Learn how to extend Claude Desktop with local MCP servers to enable file system access and other powerful integrations
+description: Learn how to extend AI applications with local MCP servers to enable file system access and other powerful integrations
 ---
 
 Model Context Protocol (MCP) servers extend AI applications' capabilities by providing secure, controlled access to local resources and tools. Many clients support MCP, enabling diverse integration possibilities across different platforms and applications.


### PR DESCRIPTION
## Motivation and Context

Both the title and the introduction of this page make it clear that Claude Desktop is used as an example for MCP-enabled AI clients, but the short description gives the opposite impression, by only mentioning Claude Desktop.

This proposed rephrasing makes the short description more in line with the title and the introduction.

## How Has This Been Tested?

N/A

## Breaking Changes

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

N/A