### PR TITLE
docs: Mark Zed as supporting tools

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -89,7 +89,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [WhatsMCP][WhatsMCP]                             | ❌          | ❌        | ✅      | ❌                     | ❌         | ❌    | ❓            |
 | [Windsurf Editor][Windsurf]                      | ❌          | ❌        | ✅      | ✅                     | ❌         | ❌    | ❓            |
 | [Witsy][Witsy]                                   | ❌          | ❌        | ✅      | ❓                     | ❌         | ❌    | ❓            |
-| [Zed][Zed]                                       | ❌          | ✅        | ❌      | ❌                     | ❌         | ❌    | ❓            |
+| [Zed][Zed]                                       | ❌          | ✅        | ✅      | ❌                     | ❌         | ❌    | ❓            |
 | [Zencoder][Zencoder]                             | ❌          | ❌        | ✅      | ❌                     | ❌         | ❌    | ❓            |
 
 


### PR DESCRIPTION
This PR updates the docs to indicate that Zed supports MCP tools.

Zed has supported tools since the introduction of the Agent Panel ([launch post](https://zed.dev/blog/fastest-ai-code-editor#custom-models-custom-tools)).