### PR TITLE
Use correct article "an" before "MCP" in docs

### DIFF
--- a/docs/community/sep-guidelines.mdx
+++ b/docs/community/sep-guidelines.mdx
@@ -31,7 +31,7 @@ Consider proposing a SEP if your change involves any of the following:
 There are three kinds of SEP:
 
 1. **Standards Track** SEP describes a new feature or implementation for the Model Context Protocol. It may also describe an interoperability standard that will be supported outside the core protocol specification.
-2. **Informational** SEP describes a Model Context Protocol design issue, or provides general guidelines or information to the MCP community, but does not propose a new feature. Informational SEPs do not necessarily represent a MCP community consensus or recommendation.
+2. **Informational** SEP describes a Model Context Protocol design issue, or provides general guidelines or information to the MCP community, but does not propose a new feature. Informational SEPs do not necessarily represent an MCP community consensus or recommendation.
 3. **Process** SEP describes a process surrounding MCP, or proposes a change to (or an event in) a process. Process SEPs are like Standards Track SEPs but apply to areas other than the MCP protocol itself.
 
 ## Submitting a SEP

--- a/docs/quickstart/client.mdx
+++ b/docs/quickstart/client.mdx
@@ -1537,7 +1537,7 @@ static (string command, string[] arguments) GetCommandAndArguments(string[] args
 }
 ```
 
-This creates a MCP client that will connect to a server that is provided as a command line argument. It then lists the available tools from the connected server.
+This creates an MCP client that will connect to a server that is provided as a command line argument. It then lists the available tools from the connected server.
 
 ### Query processing logic
 

--- a/docs/quickstart/server.mdx
+++ b/docs/quickstart/server.mdx
@@ -1076,7 +1076,7 @@ Save the file, and restart **Claude for Desktop**.
 
 ## Testing your server with Java client
 
-### Create a MCP Client manually
+### Create an MCP Client manually
 
 Use the `McpClient` to connect to the server:
 
@@ -1127,7 +1127,7 @@ For more information, see the [MCP Client Boot Starters](https://docs.spring.io/
 
 ## More Java MCP Server examples
 
-The [starter-webflux-server](https://github.com/spring-projects/spring-ai-examples/tree/main/model-context-protocol/weather/starter-webflux-server) demonstrates how to create a MCP server using SSE transport.
+The [starter-webflux-server](https://github.com/spring-projects/spring-ai-examples/tree/main/model-context-protocol/weather/starter-webflux-server) demonstrates how to create an MCP server using SSE transport.
 It showcases how to define and register MCP Tools, Resources, and Prompts, using the Spring Boot's auto-configuration capabilities.
 
 </Tab>

--- a/docs/specification/2025-06-18/basic/authorization.mdx
+++ b/docs/specification/2025-06-18/basic/authorization.mdx
@@ -354,7 +354,7 @@ registered client before forwarding to third-party authorization servers (which 
 
 ### Access Token Privilege Restriction
 
-An attacker can gain unauthorized access or otherwise compromise a MCP server if the server accepts tokens issued for other resources.
+An attacker can gain unauthorized access or otherwise compromise an MCP server if the server accepts tokens issued for other resources.
 
 This vulnerability has two critical dimensions:
 

--- a/docs/specification/draft/basic/authorization.mdx
+++ b/docs/specification/draft/basic/authorization.mdx
@@ -380,7 +380,7 @@ registered client before forwarding to third-party authorization servers (which 
 
 ### Access Token Privilege Restriction
 
-An attacker can gain unauthorized access or otherwise compromise a MCP server if the server accepts tokens issued for other resources.
+An attacker can gain unauthorized access or otherwise compromise an MCP server if the server accepts tokens issued for other resources.
 
 This vulnerability has two critical dimensions:
 


### PR DESCRIPTION
## Motivation and Context

Replaced incorrect "a MCP" with "an MCP" across multiple documentation files to match the correct usage based on pronunciation.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
