### PR TITLE
Fix dead links in clients list

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -24,7 +24,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [Augment Code][AugmentCode]                      | ❌          | ❌        | ✅      | ❌                     | ❌         | ❌    | ❓            |
 | [BeeAI Framework][BeeAI Framework]               | ❌          | ❌        | ✅      | ❌                     | ❌         | ❌    | ❓            |
 | [BoltAI][BoltAI]                                 | ❌          | ❌        | ✅      | ❓                     | ❌         | ❌    | ❓            |
-| [Call Chirp][Call Chirp]                         | ❌          | ✅        | ✅      | ❌                     | ❌         | ❌    | ❓            |                                                                                   
+| [Call Chirp][Call Chirp]                         | ❌          | ✅        | ✅      | ❌                     | ❌         | ❌    | ❓            |
 | [ChatGPT][ChatGPT]                               | ❌          | ❌        | ✅      | ❌                     | ❌         | ❌    | ❓            |
 | [ChatWise][ChatWise]                             | ❌          | ❌        | ✅      | ❌                     | ❌         | ❌    | ❓            |
 | [Claude.ai][Claude.ai]                           | ✅          | ✅        | ✅      | ❌                     | ❌         | ❌    | ❓            |
@@ -112,7 +112,7 @@ This page provides an overview of applications that support the Model Context Pr
 [Amp]: https://ampcode.com
 [Apify MCP Tester]: https://apify.com/jiri.spilka/tester-mcp-client
 [AugmentCode]: https://augmentcode.com
-[BeeAI Framework]: https://i-am-bee.github.io/beeai-framework
+[BeeAI Framework]: https://framework.beeai.dev
 [BoltAI]: https://boltai.com
 [Call Chirp]: https://www.call-chirp.com
 [ChatGPT]: https://chatgpt.com
@@ -162,7 +162,7 @@ This page provides an overview of applications that support the Model Context Pr
 [Shortwave]: https://www.shortwave.com
 [Slack MCP Client]: https://github.com/tuannvm/slack-mcp-client
 [Cody]: https://sourcegraph.com/cody
-[SpinAI]: https://spinai.dev
+[SpinAI]: https://docs.spinai.dev
 [Superinterface]: https://superinterface.ai
 [Superjoin]: https://superjoin.ai
 [systemprompt]: https://systemprompt.io
@@ -303,7 +303,7 @@ It uses plain JavaScript (old-school style) and is hosted on Apify, allowing you
 
 ### BeeAI Framework
 
-[BeeAI Framework](https://i-am-bee.github.io/beeai-framework) is an open-source framework for building, deploying, and serving powerful agentic workflows at scale. The framework includes the **MCP Tool**, a native feature that simplifies the integration of MCP servers into agentic workflows.
+[BeeAI Framework](https://framework.beeai.dev) is an open-source framework for building, deploying, and serving powerful agentic workflows at scale. The framework includes the **MCP Tool**, a native feature that simplifies the integration of MCP servers into agentic workflows.
 
 **Key features:**
 
@@ -918,7 +918,7 @@ MooPoint is a web-based AI chat platform built for developers and advanced users
 
 ### SpinAI
 
-[SpinAI](https://spinai.dev) is an open-source TypeScript framework for building observable AI agents. The framework provides native MCP compatibility, allowing agents to seamlessly integrate with MCP servers and tools.
+[SpinAI](https://docs.spinai.dev) is an open-source TypeScript framework for building observable AI agents. The framework provides native MCP compatibility, allowing agents to seamlessly integrate with MCP servers and tools.
 
 **Key features:**
 


### PR DESCRIPTION
## Motivation and Context

The links to BeeAI Framework and SpinAI were dead. They have been updated to the following new sites, respectively.

- BeeAI Framework ... The link is being updated to https://framework.beeai.dev as the new destination, as shown in the About section of https://github.com/i-am-bee/beeai-framework.
- SpinAI ... The link is being updated to https://docs.spinai.dev as the new destination, as shown in the About section of https://github.com/fallomai/spinai.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
