### PR TITLE
docs: explain the discovery client feature

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -7,6 +7,10 @@ This page provides an overview of applications that support the Model Context Pr
 
 ## Feature support matrix
 
+### Discovery
+
+Discovery is a client feature that allows the client to listen for tools, prompts, or resources changed notifications (for example, [tools list changed notification](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#list-changed-notification)). This allows an MCP server to change the toolkit in the session dynamically based on how the client interacts with the server.
+
 <div id="feature-support-matrix-wrapper">
 
 {/* prettier-ignore-start */}
@@ -98,7 +102,7 @@ This page provides an overview of applications that support the Model Context Pr
 [Resources]: /docs/concepts/resources
 [Prompts]: /docs/concepts/prompts
 [Tools]: /docs/concepts/tools
-[Discovery]: /docs/concepts/tools#tool-discovery-and-updates
+[Discovery]: /docs/clients#discovery
 [Sampling]: /docs/concepts/sampling
 [Roots]: /docs/concepts/roots
 [Elicitation]: /docs/concepts/elicitation


### PR DESCRIPTION
This PR adds an explanation of the **discovery** client feature to the clients documentation page.

## Motivation and Context
The original link that explained discovery was removed and is no longer valid. Keeping the explanation section on the same page may prevent this from happening again and will make it easier for users to find.

## How Has This Been Tested?
No

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

