### PR TITLE
Adjust initialization lifecycle wording for stateless cases

### DIFF
--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -39,7 +39,7 @@ sequenceDiagram
 
 ### Initialization
 
-The initialization phase **MUST** be the first interaction between client and server.
+The initialization phase **MAY** be the first interaction between client and server.
 During this phase, the client and server:
 
 - Establish protocol version compatibility


### PR DESCRIPTION
One word change:
>The initialization phase **MUST** be the first interaction between client and server.

to
>The initialization phase **MAY** be the first interaction between client and server.

...to account for SDKs skipping initialization for stateless interaction cases.

## Motivation and Context
I imagine we all hope to see more guidance for stateless behavior going forward.

## How Has This Been Tested?
generated & checked

## Breaking Changes
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
N/A
