### PR TITLE
Add favicon to blog

### DIFF
--- a/blog/hugo.toml
+++ b/blog/hugo.toml
@@ -31,6 +31,9 @@ theme = 'github.com/adityatelange/hugo-PaperMod'
   # Custom copyright
   copyright = '© 2025 Model Context Protocol Project'
 
+  [params.assets]
+    favicon = "favicon.svg"
+
   [[params.socialIcons]]
     name = "github"
     url = "https://github.com/modelcontextprotocol"

--- a/blog/static/favicon.svg
+++ b/blog/static/favicon.svg
@@ -1,0 +1,11 @@
+<svg width="180" height="180" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="180" height="180" rx="24" fill="black"/>
+<mask id="mask0_246_1229" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="7" y="7" width="166" height="166">
+<path d="M173 7H7V173H173V7Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_246_1229)">
+<path d="M23.5996 85.2532L86.2021 22.6507C94.8457 14.0071 108.86 14.0071 117.503 22.6507C126.147 31.2942 126.147 45.3083 117.503 53.9519L70.2254 101.23" stroke="white" stroke-width="11.0667" stroke-linecap="round"/>
+<path d="M70.8789 100.578L117.504 53.952C126.148 45.3083 140.163 45.3083 148.806 53.952L149.132 54.278C157.776 62.9216 157.776 76.9357 149.132 85.5792L92.5139 142.198C89.6327 145.079 89.6327 149.75 92.5139 152.631L104.14 164.257" stroke="white" stroke-width="11.0667" stroke-linecap="round"/>
+<path d="M101.853 38.3013L55.553 84.6011C46.9094 93.2447 46.9094 107.258 55.553 115.902C64.1966 124.546 78.2106 124.546 86.8543 115.902L133.154 69.6025" stroke="white" stroke-width="11.0667" stroke-linecap="round"/>
+</g>
+</svg>


### PR DESCRIPTION
This copies the favicon from the documentation site to the blog.

Tested locally:

| Before | After |
| --- | --- |
| <img width="267" height="91" alt="before" src="https://github.com/user-attachments/assets/5db70555-fcda-429e-bd69-95f848da4720" /> | <img width="267" height="91" alt="after" src="https://github.com/user-attachments/assets/5172ad74-aae5-44c0-ab9b-6cea85b8f32a" /> |

