### PR TITLE
SEP-1309: Add spec and SDK versioning guidelines

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -363,6 +363,30 @@
       "destination": "/specification/2025-06-18/basic/transports"
     },
     {
+      "source": "/docs/concepts/cancellation",
+      "destination": "/specification/2025-06-18/basic/utilities/cancellation"
+    },
+    {
+      "source": "/docs/concepts/ping",
+      "destination": "/specification/2025-06-18/basic/utilities/ping"
+    },
+    {
+      "source": "/docs/concepts/progress",
+      "destination": "/specification/2025-06-18/basic/utilities/progress"
+    },
+    {
+      "source": "/docs/concepts/completion",
+      "destination": "/specification/2025-06-18/server/utilities/completion"
+    },
+    {
+      "source": "/docs/concepts/logging",
+      "destination": "/specification/2025-06-18/server/utilities/logging"
+    },
+    {
+      "source": "/docs/concepts/pagination",
+      "destination": "/specification/2025-06-18/server/utilities/pagination"
+    },
+    {
       "source": "/docs/tools/debugging",
       "destination": "/legacy/tools/debugging"
     },

--- a/docs/docs/sdk.mdx
+++ b/docs/docs/sdk.mdx
@@ -60,6 +60,175 @@ Build MCP servers and clients using our official SDKs. All SDKs provide the same
   />
 </CardGroup>
 
+## Implementation Tracking Matrix
+
+This matrix tracks the support status of protocol specification releases across all official MCP SDKs.
+
+<div id="tracking-matrix-legend-wrapper">
+
+- ✅ - Launched
+- 🚧 - In Development
+- ❌ - No Compliant Versions
+- ❓ - Range of Compliant Versions Unknown
+
+</div>
+
+<div id="implementation-tracking-matrix-wrapper">
+
+{/* prettier-ignore-start */}
+
+| Specification Version    	| Status 	| [Typescript] 	| [Python] 	| [Go] 	| [Kotlin] 	| [Swift] 	| [Java] 	| [C#] 	| [Ruby] 	| [Rust] 	| [PHP] 	|
+|--------------------------	|--------	|--------------	|-----------	|-------	|-----------	|-----------	|---------	|-------	|---------	|---------	|-------	|
+| [2024-11-05][2024-11-05] 	| ✅      	| ❓            	| ❓         	| ❓     	| ❓         	| ❓         	| ❓       	| ❓     	| ❓       	| ❓       	| ❓     	|
+| [2025-03-26][2025-03-26] 	| ✅      	| ❓            	| ❓         	| ❓     	| ❓         	| ❓         	| ❓       	| ❓     	| ❓       	| ❓       	| ❓     	|
+| [2025-06-18][2025-06-18] 	| ✅      	| ❓            	| ❓         	| ❓     	| ❓         	| ❓         	| ❓       	| ❓     	| ❓       	| ❓       	| ❓     	|
+| 2025-11-25               	| 🚧      	| ❓            	| ❓         	| ❓     	| ❓         	| ❓         	| ❓       	| ❓     	| ❓       	| ❓       	| ❓     	|
+
+{/* prettier-ignore-end */}
+
+[Typescript]: https://github.com/modelcontextprotocol/typescript-sdk
+[Python]: https://github.com/modelcontextprotocol/python-sdk
+[Go]: https://github.com/modelcontextprotocol/go-sdk
+[Kotlin]: https://github.com/modelcontextprotocol/kotlin-sdk
+[Swift]: https://github.com/modelcontextprotocol/swift-sdk
+[Java]: https://github.com/modelcontextprotocol/java-sdk
+[C#]: https://github.com/modelcontextprotocol/csharp-sdk
+[Ruby]: https://github.com/modelcontextprotocol/ruby-sdk
+[Rust]: https://github.com/modelcontextprotocol/rust-sdk
+[PHP]: https://github.com/modelcontextprotocol/php-sdk
+[2024-11-05]: /specification/2024-11-05
+[2025-03-26]: /specification/2025-03-26
+[2025-06-18]: /specification/2025-06-18
+
+</div>
+
+## Feature Support Matrix
+
+This matrix tracks the support status of MCP features across all official MCP SDKs.
+
+<div id="tracking-matrix-legend-wrapper">
+
+- ✅ - Full Support
+- 🚧 - Partial Support
+- ❌ - No Support
+- ❓ - Support Status Unknown
+
+</div>
+
+### Base Protocol Features
+
+<div id="feature-support-matrix-wrapper">
+
+{/* prettier-ignore-start */}
+
+| SDK          	| [Progress] 	| [Ping] 	| [Cancellation] 	| Tasks 	|
+|--------------	|-----------	|--------	|---------------	|-------	|
+| [Typescript] 	| ❓         	| ❓      	| ❓             	| ❓     	|
+| [Python]     	| ❓         	| ❓      	| ❓             	| ❓     	|
+| [Go]         	| ❓         	| ❓      	| ❓             	| ❓     	|
+| [Kotlin]     	| ❓         	| ❓      	| ❓             	| ❓     	|
+| [Swift]      	| ❓         	| ❓      	| ❓             	| ❓     	|
+| [Java]       	| ❓         	| ❓      	| ❓             	| ❓     	|
+| [C#]         	| ❓         	| ❓      	| ❓             	| ❓     	|
+| [Ruby]       	| ❓         	| ❓      	| ❓             	| ❓     	|
+| [Rust]       	| ❓         	| ❓      	| ❓             	| ❓     	|
+| [PHP]        	| ❓         	| ❓      	| ❓             	| ❓     	|
+
+{/* prettier-ignore-end */}
+
+[Typescript]: https://github.com/modelcontextprotocol/typescript-sdk
+[Python]: https://github.com/modelcontextprotocol/python-sdk
+[Go]: https://github.com/modelcontextprotocol/go-sdk
+[Kotlin]: https://github.com/modelcontextprotocol/kotlin-sdk
+[Swift]: https://github.com/modelcontextprotocol/swift-sdk
+[Java]: https://github.com/modelcontextprotocol/java-sdk
+[C#]: https://github.com/modelcontextprotocol/csharp-sdk
+[Ruby]: https://github.com/modelcontextprotocol/ruby-sdk
+[Rust]: https://github.com/modelcontextprotocol/rust-sdk
+[PHP]: https://github.com/modelcontextprotocol/php-sdk
+[Progress]: /docs/concepts/progress
+[Ping]: /docs/concepts/ping
+[Cancellation]: /docs/concepts/cancellation
+
+</div>
+
+### Client Features
+
+<div id="feature-support-matrix-wrapper">
+
+{/* prettier-ignore-start */}
+
+| SDK          	| [Roots] 	| [Sampling] 	| [Elicitation] 	|
+|--------------	|---------	|------------	|---------------	|
+| [Typescript] 	| ❓       	| ❓          	| ❓             	|
+| [Python]     	| ❓       	| ❓          	| ❓             	|
+| [Go]         	| ❓       	| ❓          	| ❓             	|
+| [Kotlin]     	| ❓       	| ❓          	| ❓             	|
+| [Swift]      	| ❓       	| ❓          	| ❓             	|
+| [Java]       	| ❓       	| ❓          	| ❓             	|
+| [C#]         	| ❓       	| ❓          	| ❓             	|
+| [Ruby]       	| ❓       	| ❓          	| ❓             	|
+| [Rust]       	| ❓       	| ❓          	| ❓             	|
+| [PHP]        	| ❓       	| ❓          	| ❓             	|
+
+{/* prettier-ignore-end */}
+
+[Typescript]: https://github.com/modelcontextprotocol/typescript-sdk
+[Python]: https://github.com/modelcontextprotocol/python-sdk
+[Go]: https://github.com/modelcontextprotocol/go-sdk
+[Kotlin]: https://github.com/modelcontextprotocol/kotlin-sdk
+[Swift]: https://github.com/modelcontextprotocol/swift-sdk
+[Java]: https://github.com/modelcontextprotocol/java-sdk
+[C#]: https://github.com/modelcontextprotocol/csharp-sdk
+[Ruby]: https://github.com/modelcontextprotocol/ruby-sdk
+[Rust]: https://github.com/modelcontextprotocol/rust-sdk
+[PHP]: https://github.com/modelcontextprotocol/php-sdk
+[Roots]: /docs/concepts/roots
+[Sampling]: /docs/concepts/sampling
+[Elicitation]: /docs/concepts/elicitation
+
+</div>
+
+### Server Features
+
+<div id="feature-support-matrix-wrapper">
+
+{/* prettier-ignore-start */}
+
+| SDK          	| [Prompts] 	| [Resources] 	| [Tools] 	| [Completion] 	| [Logging] 	| [Pagination] 	|
+|--------------	|-----------	|-------------	|---------	|--------------	|-----------	|--------------	|
+| [Typescript] 	| ❓         	| ❓           	| ❓       	| ❓             	| ❓         	| ❓            	|
+| [Python]     	| ❓         	| ❓           	| ❓       	| ❓             	| ❓         	| ❓            	|
+| [Go]         	| ❓         	| ❓           	| ❓       	| ❓             	| ❓         	| ❓            	|
+| [Kotlin]     	| ❓         	| ❓           	| ❓       	| ❓             	| ❓         	| ❓            	|
+| [Swift]      	| ❓         	| ❓           	| ❓       	| ❓             	| ❓         	| ❓            	|
+| [Java]       	| ❓         	| ❓           	| ❓       	| ❓             	| ❓         	| ❓            	|
+| [C#]         	| ❓         	| ❓           	| ❓       	| ❓             	| ❓         	| ❓            	|
+| [Ruby]       	| ❓         	| ❓           	| ❓       	| ❓             	| ❓         	| ❓            	|
+| [Rust]       	| ❓         	| ❓           	| ❓       	| ❓             	| ❓         	| ❓            	|
+| [PHP]        	| ❓         	| ❓           	| ❓       	| ❓             	| ❓         	| ❓            	|
+
+{/* prettier-ignore-end */}
+
+[Typescript]: https://github.com/modelcontextprotocol/typescript-sdk
+[Python]: https://github.com/modelcontextprotocol/python-sdk
+[Go]: https://github.com/modelcontextprotocol/go-sdk
+[Kotlin]: https://github.com/modelcontextprotocol/kotlin-sdk
+[Swift]: https://github.com/modelcontextprotocol/swift-sdk
+[Java]: https://github.com/modelcontextprotocol/java-sdk
+[C#]: https://github.com/modelcontextprotocol/csharp-sdk
+[Ruby]: https://github.com/modelcontextprotocol/ruby-sdk
+[Rust]: https://github.com/modelcontextprotocol/rust-sdk
+[PHP]: https://github.com/modelcontextprotocol/php-sdk
+[Prompts]: /docs/concepts/prompts
+[Resources]: /docs/concepts/resources
+[Tools]: /docs/concepts/tools
+[Completion]: /docs/concepts/completion
+[Logging]: /docs/concepts/logging
+[Pagination]: /docs/concepts/pagination
+
+</div>
+
 ## Getting Started
 
 Each SDK provides the same functionality but follows the idioms and best practices of its language. All SDKs support:

--- a/docs/style.css
+++ b/docs/style.css
@@ -28,7 +28,49 @@
   text-align: left;
 }
 
+#implementation-tracking-matrix-wrapper td,
+#implementation-tracking-matrix-wrapper th {
+  padding: 0.3rem 0rem;
+  text-align: center;
+  white-space: nowrap;
+}
 
+#implementation-tracking-matrix-wrapper td:first-child,
+#implementation-tracking-matrix-wrapper th:first-child {
+  text-align: left;
+  width: 12%;
+}
+
+#implementation-tracking-matrix-wrapper th:first-child {
+  white-space: normal;
+}
+
+#implementation-tracking-matrix-wrapper table {
+  width: 100%;
+  table-layout: fixed;
+  font-size: 0.6rem;
+}
+
+#implementation-tracking-matrix-wrapper td,
+#implementation-tracking-matrix-wrapper th {
+  padding: 0.3rem 0rem;
+  text-align: center;
+  white-space: nowrap;
+}
+
+#implementation-tracking-matrix-wrapper td:first-child,
+#implementation-tracking-matrix-wrapper th:first-child {
+  text-align: left;
+  width: 12%;
+}
+
+#implementation-tracking-matrix-wrapper th:first-child {
+  white-space: normal;
+}
+
+#tracking-matrix-legend-wrapper {
+  font-size: 0.7rem;
+}
 
 /*** Add automatic section numbers to headings and table of contents items ***/
 


### PR DESCRIPTION
## Motivation and Context
This PR adds the specification and SDK versioning guidelines introduced in the accepted #1309 to the specification documentation.

## How Has This Been Tested?
Tested locally using the instructions in CONTRIBUTING.md.

## Breaking Changes
None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
There is some confusion regarding the best place to add these guidelines. The implementation tracking matrix should live in the SDKs section under Documentation tab. However, I am open to suggestion for the versioning guidelines. Currently I have added them in the Versioning section under Documentation tab. There can also be a case made to break them up and add them to the Governance and Stewardship section under the Community tab or to actually add them within the Specification tab somewhere near the Version Negotiation guidelines. Open to feedback on this.
