### PR TITLE
Fix issue 1406 - unique names for code tab in architecture.mdx to avoid scrolling

### DIFF
--- a/docs/docs/learn/architecture.mdx
+++ b/docs/docs/learn/architecture.mdx
@@ -154,7 +154,7 @@ This section provides a step-by-step walkthrough of an MCP client-server interac
 MCP begins with lifecycle management through a capability negotiation handshake. As described in the [lifecycle management](#lifecycle-management) section, the client sends an `initialize` request to establish the connection and negotiate supported features.
 
 <CodeGroup>
-  ```json Request
+  ```json Initialize Request
   {
     "jsonrpc": "2.0",
     "id": 1,
@@ -171,7 +171,7 @@ MCP begins with lifecycle management through a capability negotiation handshake.
     }
   }
   ```
-  ```json Response
+  ```json Initialize Response
   {
     "jsonrpc": "2.0",
     "id": 1,
@@ -242,14 +242,14 @@ async with stdio_client(server_config) as (read, write):
 Now that the connection is established, the client can discover available tools by sending a `tools/list` request. This request is fundamental to MCP's tool discovery mechanism — it allows clients to understand what tools are available on the server before attempting to use them.
 
 <CodeGroup>
-  ```json Request
+  ```json Tools List Request
   {
     "jsonrpc": "2.0",
     "id": 2,
     "method": "tools/list"
   }
   ```
-  ```json Response
+  ```json Tools List Response
   {
     "jsonrpc": "2.0",
     "id": 2,
@@ -335,7 +335,7 @@ The client can now execute a tool using the `tools/call` method. This demonstrat
 The `tools/call` request follows a structured format that ensures type safety and clear communication between client and server. Note that we're using the proper tool name from the discovery response (`weather_current`) rather than a simplified name:
 
 <CodeGroup>
-  ```json Request
+  ```json Tool Call Request
   {
     "jsonrpc": "2.0",
     "id": 3,
@@ -349,7 +349,7 @@ The `tools/call` request follows a structured format that ensures type safety an
     }
   }
   ```
-  ```json Response
+  ```json Tool Call Response
   {
     "jsonrpc": "2.0",
     "id": 3,


### PR DESCRIPTION
Fixes issue 1406 where Architecture would scroll when changing from Request to Response tabs in the CodeGroups. This scrolling happens because mintlify uses shared state for all tabs, so changing one group's tab changes the others, and changing tabs earlier in the page changes the content length leading to unwanted scrolling. This seems to be keyed on the tab name (presumably with the intent that you are choosing between languages).

Fix here is to give each tab a unique name. Not a huge fan of this fix, but there doesn't appear to be any other way to prevent the behavior in mintlify. Open to suggestions.

## Motivation and Context
https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1406

## How Has This Been Tested?
https://github.com/user-attachments/assets/02961395-4367-4f3d-b924-362843c8b014

## Breaking Changes
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x]  New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed