### PR TITLE
Reorganize docs: move quickstart guides to develop section and update content

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -36,7 +36,8 @@
             "pages": [
               "docs/learn/architecture",
               "docs/learn/server-concepts",
-              "docs/learn/client-concepts"
+              "docs/learn/client-concepts",
+              "specification/versioning"
             ]
           },
           {
@@ -65,7 +66,6 @@
             "pages": [
               "specification/2025-06-18/index",
               "specification/2025-06-18/changelog",
-              "specification/versioning",
               "specification/2025-06-18/architecture/index",
               {
                 "group": "Base Protocol",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -25,43 +25,36 @@
       {
         "tab": "Documentation",
         "pages": [
-          "docs/getting-started/intro",
-          "docs/sdk",
           {
-            "group": "Concepts",
+            "group": "Get started",
+            "pages": [
+              "docs/getting-started/intro"
+            ]
+          },
+          {
+            "group": "About MCP",
             "pages": [
               "docs/learn/architecture",
               "docs/learn/server-concepts",
-              "docs/learn/client-concepts",
-              "specification/versioning"
+              "docs/learn/client-concepts"
             ]
           },
           {
-            "group": "Tutorials",
+            "group": "Develop with MCP",
             "pages": [
-              {
-                "group": "Using MCP",
-                "pages": [
-                  "docs/tutorials/use-remote-mcp-server",
-                  "quickstart/user"
-                ]
-              },
-              {
-                "group": "Server Development",
-                "pages": [
-                  "quickstart/server",
-                  "legacy/tools/inspector"
-                ]
-              },
-              {
-                "group": "Client Development",
-                "pages": [
-                  "quickstart/client"
-                ]
-              }
+              "docs/develop/connect-local-servers",
+              "docs/develop/connect-remote-servers",
+              "docs/develop/build-server",
+              "docs/develop/build-client",
+              "docs/sdk"
             ]
           },
-          "faqs"
+          {
+            "group": "Developer tools",
+            "pages": [
+              "legacy/tools/inspector"
+            ]
+          }
         ]
       },
       {
@@ -72,6 +65,7 @@
             "pages": [
               "specification/2025-06-18/index",
               "specification/2025-06-18/changelog",
+              "specification/versioning",
               "specification/2025-06-18/architecture/index",
               {
                 "group": "Base Protocol",
@@ -305,11 +299,11 @@
   "redirects": [
     {
       "source": "/tutorials/building-a-client",
-      "destination": "/quickstart/client"
+      "destination": "/docs/develop/build-client"
     },
     {
       "source": "/quickstart",
-      "destination": "/quickstart/server"
+      "destination": "/docs/develop/build-server"
     },
     {
       "source": "/specification/latest",
@@ -367,6 +361,22 @@
     {
       "source": "/docs/tools",
       "destination": "/legacy/tools/inspector"
+    },
+    {
+      "source": "/docs/tutorials/use-remote-mcp-server",
+      "destination": "/docs/develop/connect-remote-servers"
+    },
+    {
+      "source": "/docs/quickstart/user",
+      "destination": "/docs/develop/connect-local-servers"
+    },
+    {
+      "source": "/quickstart/server",
+      "destination": "/docs/develop/build-server"
+    },
+    {
+      "source": "/quickstart/client",
+      "destination": "/docs/develop/build-client"
     }
   ],
   "contextual": {

--- a/docs/docs/develop/build-client.mdx
+++ b/docs/docs/develop/build-client.mdx
@@ -1,9 +1,11 @@
 ---
-title: "Build an MCP Client"
+title: "Build an MCP client"
 description: "Get started building your own client that can integrate with all MCP servers."
 ---
 
-In this tutorial, you'll learn how to build an LLM-powered chatbot client that connects to MCP servers. It helps to have gone through the [Server quickstart](/quickstart/server) that guides you through the basics of building your first server.
+In this tutorial, you'll learn how to build an LLM-powered chatbot client that connects to MCP servers.
+
+Before you begin, it helps to have gone through our [Build an MCP Server](/docs//build-server) tutorial so you can understand how clients and servers communicate.
 
 <Tabs>
 <Tab title="Python">
@@ -1651,21 +1653,7 @@ Here's an example of what it should look like it connected to a weather server q
   <Card title="Example servers" icon="grid" href="/examples">
     Check out our gallery of official MCP servers and implementations
   </Card>
-  <Card title="Clients" icon="cubes" href="/clients">
+  <Card title="Example clients" icon="cubes" href="/clients">
     View the list of clients that support MCP integrations
-  </Card>
-  <Card
-    title="Building MCP with LLMs"
-    icon="comments"
-    href="/tutorials/building-mcp-with-llms"
-  >
-    Learn how to use LLMs like Claude to speed up your MCP development
-  </Card>
-  <Card
-    title="Core architecture"
-    icon="sitemap"
-    href="/legacy/concepts/architecture"
-  >
-    Understand how MCP connects clients, servers, and LLMs
   </Card>
 </CardGroup>

--- a/docs/docs/develop/build-client.mdx
+++ b/docs/docs/develop/build-client.mdx
@@ -5,7 +5,7 @@ description: "Get started building your own client that can integrate with all M
 
 In this tutorial, you'll learn how to build an LLM-powered chatbot client that connects to MCP servers.
 
-Before you begin, it helps to have gone through our [Build an MCP Server](/docs//build-server) tutorial so you can understand how clients and servers communicate.
+Before you begin, it helps to have gone through our [Build an MCP Server](/docs/develop/build-server) tutorial so you can understand how clients and servers communicate.
 
 <Tabs>
 <Tab title="Python">

--- a/docs/docs/develop/build-server.mdx
+++ b/docs/docs/develop/build-server.mdx
@@ -1,26 +1,21 @@
 ---
-title: "Build an MCP Server"
+title: "Build an MCP server"
 description: "Get started building your own server to use in Claude for Desktop and other clients."
 ---
 
-In this tutorial, we'll build a simple MCP weather server and connect it to a host, Claude for Desktop. We'll start with a basic setup, and then progress to more complex use cases.
+In this tutorial, we'll build a simple MCP weather server and connect it to a host, Claude for Desktop.
 
 ### What we'll be building
 
-Many LLMs do not currently have the ability to fetch the forecast and severe weather alerts. Let's use MCP to solve that!
-
 We'll build a server that exposes two tools: `get_alerts` and `get_forecast`. Then we'll connect the server to an MCP host (in this case, Claude for Desktop):
 
-<Frame>
-  <img src="/images/weather-alerts.png" />
-</Frame>
 <Frame>
   <img src="/images/current-weather.png" />
 </Frame>
 
 <Note>
 
-Servers can connect to any client. We've chosen Claude for Desktop here for simplicity, but we also have guides on [building your own client](/quickstart/client) as well as a [list of other clients here](/clients).
+Servers can connect to any client. We've chosen Claude for Desktop here for simplicity, but we also have guides on [building your own client](/docs/develop/build-client) as well as a [list of other clients here](/clients).
 
 </Note>
 
@@ -28,9 +23,9 @@ Servers can connect to any client. We've chosen Claude for Desktop here for simp
 
 MCP servers can provide three main types of capabilities:
 
-1. **Resources**: File-like data that can be read by clients (like API responses or file contents)
-2. **Tools**: Functions that can be called by the LLM (with user approval)
-3. **Prompts**: Pre-written templates that help users accomplish specific tasks
+1. **[Resources](/docs/learn/server-concepts#resources-context-data)**: File-like data that can be read by clients (like API responses or file contents)
+2. **[Tools](/docs/learn/server-concepts#tools-ai-actions)**: Functions that can be called by the LLM (with user approval)
+3. **[Prompts](docs/learn/server-concepts#prompts-interaction-templates)**: Pre-written templates that help users accomplish specific tasks
 
 This tutorial will primarily focus on tools.
 
@@ -270,7 +265,7 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 
 <Note>
 
-Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/quickstart/client) tutorial to build an MCP client that connects to the server we just built.
+Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/docs/develop/build-client) tutorial to build an MCP client that connects to the server we just built.
 
 </Note>
 
@@ -754,7 +749,7 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 
 <Note>
 
-Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/quickstart/client) tutorial to build an MCP client that connects to the server we just built.
+Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/docs/develop/build-client) tutorial to build an MCP client that connects to the server we just built.
 
 </Note>
 
@@ -1443,7 +1438,7 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 
 <Note>
 
-Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/quickstart/client) tutorial to build an MCP client that connects to the server we just built.
+Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/docs/develop/build-client) tutorial to build an MCP client that connects to the server we just built.
 
 </Note>
 
@@ -1724,7 +1719,7 @@ This will start the server and listen for incoming requests on standard input/ou
 
 <Note>
 
-Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/quickstart/client) tutorial to build an MCP client that connects to the server we just built.
+Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/docs/develop/build-client) tutorial to build an MCP client that connects to the server we just built.
 
 </Note>
 
@@ -1904,7 +1899,7 @@ For more advanced troubleshooting, check out our guide on [Debugging MCP](/legac
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Building a client" icon="outlet" href="/quickstart/client">
+  <Card title="Building a client" icon="outlet" href="/docs/develop/build-client">
     Learn how to build your own MCP client that can connect to your server
   </Card>
   <Card title="Example servers" icon="grid" href="/examples">

--- a/docs/docs/develop/build-server.mdx
+++ b/docs/docs/develop/build-server.mdx
@@ -23,9 +23,9 @@ Servers can connect to any client. We've chosen Claude for Desktop here for simp
 
 MCP servers can provide three main types of capabilities:
 
-1. **[Resources](/docs/learn/server-concepts#resources-context-data)**: File-like data that can be read by clients (like API responses or file contents)
-2. **[Tools](/docs/learn/server-concepts#tools-ai-actions)**: Functions that can be called by the LLM (with user approval)
-3. **[Prompts](docs/learn/server-concepts#prompts-interaction-templates)**: Pre-written templates that help users accomplish specific tasks
+1. **[Resources](/docs/learn/server-concepts#resources)**: File-like data that can be read by clients (like API responses or file contents)
+2. **[Tools](/docs/learn/server-concepts#tools)**: Functions that can be called by the LLM (with user approval)
+3. **[Prompts](/docs/learn/server-concepts#prompts)**: Pre-written templates that help users accomplish specific tasks
 
 This tutorial will primarily focus on tools.
 

--- a/docs/docs/develop/build-server.mdx
+++ b/docs/docs/develop/build-server.mdx
@@ -1899,7 +1899,11 @@ For more advanced troubleshooting, check out our guide on [Debugging MCP](/legac
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Building a client" icon="outlet" href="/docs/develop/build-client">
+  <Card
+    title="Building a client"
+    icon="outlet"
+    href="/docs/develop/build-client"
+  >
     Learn how to build your own MCP client that can connect to your server
   </Card>
   <Card title="Example servers" icon="grid" href="/examples">

--- a/docs/docs/develop/connect-local-servers.mdx
+++ b/docs/docs/develop/connect-local-servers.mdx
@@ -1,5 +1,5 @@
 ---
-title: Connect to Local MCP Servers
+title: Connect to local MCP servers
 description: Learn how to extend Claude Desktop with local MCP servers to enable file system access and other powerful integrations
 ---
 
@@ -309,14 +309,14 @@ Now that you've successfully connected Claude Desktop to a local MCP server, exp
     Browse our collection of official and community-created MCP servers for
     additional capabilities
   </Card>
-  <Card title="Build your own server" icon="code" href="/quickstart/server">
+  <Card title="Build your own server" icon="code" href="/docs/develop/build-server">
     Create custom MCP servers tailored to your specific workflows and
     integrations
   </Card>
   <Card
     title="Connect to remote servers"
     icon="cloud"
-    href="/docs/tutorials/use-remote-mcp-server"
+    href="/docs/develop/connect-remote-servers"
   >
     Learn how to connect Claude to remote MCP servers for cloud-based tools and
     services

--- a/docs/docs/develop/connect-local-servers.mdx
+++ b/docs/docs/develop/connect-local-servers.mdx
@@ -309,7 +309,11 @@ Now that you've successfully connected Claude Desktop to a local MCP server, exp
     Browse our collection of official and community-created MCP servers for
     additional capabilities
   </Card>
-  <Card title="Build your own server" icon="code" href="/docs/develop/build-server">
+  <Card
+    title="Build your own server"
+    icon="code"
+    href="/docs/develop/build-server"
+  >
     Create custom MCP servers tailored to your specific workflows and
     integrations
   </Card>

--- a/docs/docs/develop/connect-remote-servers.mdx
+++ b/docs/docs/develop/connect-remote-servers.mdx
@@ -1,5 +1,5 @@
 ---
-title: Connect to Remote MCP Servers
+title: Connect to remote MCP Servers
 description: Learn how to connect Claude to remote MCP servers and extend its capabilities with internet-hosted tools and data sources
 ---
 

--- a/docs/docs/develop/connect-remote-servers.mdx
+++ b/docs/docs/develop/connect-remote-servers.mdx
@@ -131,7 +131,11 @@ Now that you've connected Claude to a remote MCP server, you can explore its cap
   >
     Browse our collection of official and community-created MCP servers
   </Card>
-  <Card title="Connect local servers" icon="computer" href="/docs/develop/connect-local-servers">
+  <Card
+    title="Connect local servers"
+    icon="computer"
+    href="/docs/develop/connect-local-servers"
+  >
     Learn how to connect Claude Desktop to local MCP servers for direct system
     access
   </Card>

--- a/docs/docs/develop/connect-remote-servers.mdx
+++ b/docs/docs/develop/connect-remote-servers.mdx
@@ -131,7 +131,7 @@ Now that you've connected Claude to a remote MCP server, you can explore its cap
   >
     Browse our collection of official and community-created MCP servers
   </Card>
-  <Card title="Connect local servers" icon="computer" href="/quickstart/user">
+  <Card title="Connect local servers" icon="computer" href="/docs/develop/connect-local-servers">
     Learn how to connect Claude Desktop to local MCP servers for direct system
     access
   </Card>

--- a/docs/docs/getting-started/intro.mdx
+++ b/docs/docs/getting-started/intro.mdx
@@ -1,41 +1,49 @@
 ---
-title: Introduction
-description: "Get started with the Model Context Protocol (MCP)"
+title: What is the Model Context Protocol (MCP)?
+sidebarTitle: What is MCP?
 ---
 
-MCP is an open protocol that standardizes how applications provide context to large language models (LLMs). Think of MCP like a USB-C port for AI applications. Just as USB-C provides a standardized way to connect your devices to various peripherals and accessories, MCP provides a standardized way to connect AI models to different data sources and tools. MCP enables you to build agents and complex workflows on top of LLMs and connects your models with the world.
+MCP (Model Context Protocol) is an open-source standard for connecting AI applications to external systems.
 
-MCP provides:
+Using MCP, AI applications like Claude or ChatGPT can connect to data sources (e.g. local files, databases), tools (e.g. search engines, calculators) and workflows (e.g. specialized prompts)—enabling them to access key information and perform tasks.
 
-- **A growing list of pre-built integrations** that your LLM can directly plug into
-- **A standardized way** to build custom integrations for AI applications
-- **An open protocol** that everyone is free to implement and use
-- **The flexibility to change** between different apps and take your context with you
+Think of MCP like a USB-C port for AI applications. Just as USB-C provides a standardized way to connect electronic devices, MCP provides a standardized way to connect AI applications to external systems.
 
-## Choose Your Path
+<Frame>
+  <img src="/images/mcp-simple-diagram.png" />
+</Frame>
+
+## What can MCP enable?
+
+- Agents can access your Google Calendar and Notion, acting as a more personalized AI assistant.
+- Claude Code can generate an entire web app using a Figma design.
+- Enterprise chatbots can connect to multiple databases across an organization, empowering users to analyze data using chat.
+- AI models can create 3D designs on Blender and print them out using a 3D printer.
+
+## Why does MCP matter?
+
+Depending on where you sit in the ecosystem, MCP can have a range of benefits.
+
+- **Developers**: MCP reduces development time and complexity when building, or integrating with, an AI application or agent.
+- **AI applications or agents**: MCP provides access to an ecosystem of data sources, tools and apps which will enhance capabilities and improve the end-user experience.
+- **End-users**: MCP results in more capable AI applications or agents which can access your data and take actions on your behalf when necessary.
+
+## Start Building
 
 <CardGroup cols={2}>
-  <Card title="Understand Concepts" icon="book" href="/docs/learn/architecture">
-    Learn the core concepts and architecture of MCP
+  <Card title="Build servers" icon="server" href="/docs/develop/build-server">
+    Create MCP servers to expose your data and tools
   </Card>
 
-{" "}
-
-<Card title="Use MCP" icon="plug" href="/docs/tutorials/use-remote-mcp-server">
-  Connect to existing MCP servers and start using them
-</Card>
-
-{" "}
-
-<Card title="Build Servers" icon="server" href="/quickstart/server">
-  Create MCP servers to expose your data and tools
-</Card>
-
-  <Card title="Build Clients" icon="computer" href="/quickstart/client">
+  <Card title="Build clients" icon="computer" href="/docs/develop/build-client">
     Develop applications that connect to MCP servers
   </Card>
 </CardGroup>
 
-## Ready to Build?
+## Learn more
 
-MCP provides official **SDKs** in multiple languages, see the [SDK documentation](/docs/sdk) to find the right SDK for your project. The SDKs handle the protocol details so you can focus on building your features.
+<CardGroup cols={2}>
+  <Card title="Understand concepts" icon="book" href="/docs/learn/architecture">
+    Learn the core concepts and architecture of MCP
+  </Card>
+</CardGroup>

--- a/docs/docs/learn/architecture.mdx
+++ b/docs/docs/learn/architecture.mdx
@@ -1,5 +1,6 @@
 ---
-title: Architecture Overview
+title: Architecture overview
+sidebarTitle: Architecture
 type: docs
 ---
 

--- a/docs/docs/learn/client-concepts.mdx
+++ b/docs/docs/learn/client-concepts.mdx
@@ -11,11 +11,11 @@ Understanding the distinction is important: the _host_ is the application users 
 
 In addition to making use of context provided by servers, clients may provide several features to servers. These client features allow server authors to build richer interactions.
 
-| Feature | Explanation | Example |
-| ------- | ----------- | ------- |
-| **Sampling** | Sampling allows servers to request LLM completions through the client, enabling an agentic workflow. This approach puts the client in complete control of user permissions and security measures. | A server for booking travel may send a list of flights to an LLM and request that the LLM pick the best flight for the user. |
-| **Roots** | Roots allow clients to specify which files servers can access, guiding them to relevant directories while maintaining security boundaries. | A server for booking travel may be given access to a specific directory, from which it can read a user's calendar. |
-| **Elicitation** | Elicitation enables servers to request specific information from users during interactions, providing a structured way for servers to gather information on demand. | A server booking travel may ask for the user's preferences on airplane seats, room type or their contact number to finalise a booking. |
+| Feature         | Explanation                                                                                                                                                                                       | Example                                                                                                                                |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| **Sampling**    | Sampling allows servers to request LLM completions through the client, enabling an agentic workflow. This approach puts the client in complete control of user permissions and security measures. | A server for booking travel may send a list of flights to an LLM and request that the LLM pick the best flight for the user.           |
+| **Roots**       | Roots allow clients to specify which files servers can access, guiding them to relevant directories while maintaining security boundaries.                                                        | A server for booking travel may be given access to a specific directory, from which it can read a user's calendar.                     |
+| **Elicitation** | Elicitation enables servers to request specific information from users during interactions, providing a structured way for servers to gather information on demand.                               | A server booking travel may ask for the user's preferences on airplane seats, room type or their contact number to finalise a booking. |
 
 ### Elicitation
 

--- a/docs/docs/learn/client-concepts.mdx
+++ b/docs/docs/learn/client-concepts.mdx
@@ -1,6 +1,6 @@
 ---
-title: Client Concepts
-description: "Understanding MCP client concepts"
+title: Understanding MCP clients
+sidebarTitle: Clients
 ---
 
 MCP clients are instantiated by host applications to communicate with particular MCP servers. The host application, like Claude.ai or an IDE, manages the overall user experience and coordinates multiple clients. Each client handles one direct communication with one server.
@@ -9,135 +9,13 @@ Understanding the distinction is important: the _host_ is the application users 
 
 ## Core Client Features
 
-In addition to making use of context provided by servers, clients may provide several features to servers. These client features allow server authors to build richer interactions. For example, clients can allow MCP servers to request additional information from the user via elicitations. Clients can offer the following capabilities:
+In addition to making use of context provided by servers, clients may provide several features to servers. These client features allow server authors to build richer interactions.
 
-### Sampling
-
-Sampling allows servers to request language model completions through the client, enabling agentic behaviors while maintaining security and user control.
-
-#### Overview
-
-Sampling enables servers to perform AI-dependent tasks without directly integrating with or paying for AI models. Instead, servers can request that the client—which already has AI model access—handle these tasks on their behalf. This approach puts the client in complete control of user permissions and security measures. Because sampling requests occur within the context of other operations—like a tool analyzing data—and are processed as separate model calls, they maintain clear boundaries between different contexts, allowing for more efficient use of the context window.
-
-**Sampling flow:**
-
-```mermaid
-sequenceDiagram
-    participant LLM
-    participant User
-    participant Client
-    participant Server
-
-    Note over Server,Client: Server initiates sampling
-    Server->>Client: sampling/createMessage
-
-    Note over Client,User: Human-in-the-loop review
-    Client->>User: Present request for approval
-    User-->>Client: Review and approve/modify
-
-    Note over Client,LLM: Model interaction
-    Client->>LLM: Forward approved request
-    LLM-->>Client: Return generation
-
-    Note over Client,User: Response review
-    Client->>User: Present response for approval
-    User-->>Client: Review and approve/modify
-
-    Note over Server,Client: Complete request
-    Client-->>Server: Return approved response
-```
-
-The flow ensures security through multiple human-in-the-loop checkpoints. Users review and can modify both the initial request and the generated response before it returns to the server.
-
-**Request parameters example:**
-
-```typescript
-{
-  messages: [
-    {
-      role: "user",
-      content: "Analyze these flight options and recommend the best choice:\n" +
-               "[47 flights with prices, times, airlines, and layovers]\n" +
-               "User preferences: morning departure, max 1 layover"
-    }
-  ],
-  modelPreferences: {
-    hints: [{
-      name: "claude-3-5-sonnet"  // Suggested model
-    }],
-    costPriority: 0.3,      // Less concerned about API cost
-    speedPriority: 0.2,     // Can wait for thorough analysis
-    intelligencePriority: 0.9  // Need complex trade-off evaluation
-  },
-  systemPrompt: "You are a travel expert helping users find the best flights based on their preferences",
-  maxTokens: 1500
-}
-```
-
-#### Example: Flight Analysis Tool
-
-Consider a travel booking server with a tool called `findBestFlight` that uses sampling to analyze available flights and recommend the optimal choice. When a user asks "Book me the best flight to Barcelona next month," the tool needs AI assistance to evaluate complex trade-offs.
-
-The tool queries airline APIs and gathers 47 flight options. It then requests AI assistance to analyze these options: "Analyze these flight options and recommend the best choice: [47 flights with prices, times, airlines, and layovers] User preferences: morning departure, max 1 layover."
-
-The client asks the user: "Allow sampling request?" Upon approval, the AI evaluates trade-offs—like cheaper red-eye flights versus convenient morning departures. The tool uses this analysis to present the top three recommendations.
-
-#### User Interaction Model
-
-Sampling is designed with human-in-the-loop control as a fundamental principle. Users maintain oversight through several mechanisms:
-
-**Approval controls**: Every sampling request needs explicit user consent. Clients show what the server wants to analyze and why. Users can approve, deny, or modify requests.
-
-**Transparency features**: Clients display the exact prompt, model selection, and token limits. Users review AI responses before they return to the server.
-
-**Configuration options**: Users can set model preferences, configure auto-approval for trusted operations, or require approval for everything. Clients may provide options to redact sensitive information. Users decide how much conversation context may be included in sampling requests through the `includeContext` parameter.
-
-**Isolation**: Sampling requests are isolated from the main conversation context by default. Servers cannot access user conversations.
-
-**Security considerations**: Both clients and servers must handle sensitive data appropriately during sampling. Clients should implement rate limiting and validate all message content. The human-in-the-loop design ensures that server-initiated AI interactions cannot compromise security or access sensitive data without explicit user consent.
-
-### Roots
-
-Roots define filesystem boundaries for server operations, allowing clients to specify which directories servers should focus on.
-
-#### Overview
-
-Roots are a mechanism for clients to communicate filesystem access boundaries to servers. They consist of file URIs that indicate directories where servers can operate, helping servers understand the scope of available files and folders. Rather than giving servers unrestricted filesystem access, roots guide them to relevant working directories while maintaining security boundaries.
-
-**Root structure:**
-
-```json
-{
-  "uri": "file:///Users/agent/travel-planning",
-  "name": "Travel Planning Workspace"
-}
-```
-
-Roots are exclusively filesystem paths and always use the `file://` URI scheme. They help servers understand project boundaries, workspace organization, and accessible directories. The roots list can be updated dynamically as users work with different projects or folders, with servers receiving notifications through `roots/list_changed` when boundaries change.
-
-It's important to note that while roots provide guidance to servers about where to operate, the client is always in full control of file access. Roots simply communicate intended boundaries—actual file access is always mediated by the client's security policies.
-
-#### Example: Travel Planning Workspace
-
-A travel agent working with multiple client trips benefits from roots to organize filesystem access. Consider a workspace with different directories for various aspects of travel planning.
-
-The client provides filesystem roots to the travel planning server:
-
-- `file:///Users/agent/travel-planning` - Main workspace containing all travel files
-- `file:///Users/agent/travel-templates` - Reusable itinerary templates and resources
-- `file:///Users/agent/client-documents` - Client passports and travel documents
-
-When the agent creates a Barcelona itinerary, the server works within these boundaries—accessing templates, saving the new itinerary, and referencing client documents. It cannot access files outside these roots. Servers typically access files within roots by using relative paths from the root directories or by utilizing file search tools that respect the root boundaries.
-
-If the agent opens an archive folder like `file:///Users/agent/archive/2023-trips`, the client updates the roots list via `roots/list_changed`.
-
-#### User Interaction Model
-
-Roots are typically managed automatically by host applications based on user actions, though some applications may expose manual root management:
-
-**Automatic root detection**: When users open folders, clients automatically expose them as roots. Opening a travel workspace gives servers access to itineraries and documents within that directory.
-
-**Manual root configuration**: Advanced users can specify roots through configuration. For example, adding `/travel-templates` for reusable resources while excluding directories with financial records.
+| Feature | Explanation | Example |
+| ------- | ----------- | ------- |
+| **Sampling** | Sampling allows servers to request LLM completions through the client, enabling an agentic workflow. This approach puts the client in complete control of user permissions and security measures. | A server for booking travel may send a list of flights to an LLM and request that the LLM pick the best flight for the user. |
+| **Roots** | Roots allow clients to specify which files servers can access, guiding them to relevant directories while maintaining security boundaries. | A server for booking travel may be given access to a specific directory, from which it can read a user's calendar. |
+| **Elicitation** | Elicitation enables servers to request specific information from users during interactions, providing a structured way for servers to gather information on demand. | A server booking travel may ask for the user's preferences on airplane seats, room type or their contact number to finalise a booking. |
 
 ### Elicitation
 
@@ -223,3 +101,129 @@ Elicitation interactions are designed to be clear, contextual, and respectful of
 **Response options**: Users can provide the requested information through appropriate UI controls (text fields, dropdowns, checkboxes), decline to provide information with optional explanation, or cancel the entire operation. Clients validate responses against the provided schema before returning them to servers.
 
 **Privacy considerations**: Elicitation never requests passwords or API keys. Clients warn about suspicious requests and let users review data before sending.
+
+### Roots
+
+Roots define filesystem boundaries for server operations, allowing clients to specify which directories servers should focus on.
+
+#### Overview
+
+Roots are a mechanism for clients to communicate filesystem access boundaries to servers. They consist of file URIs that indicate directories where servers can operate, helping servers understand the scope of available files and folders. Rather than giving servers unrestricted filesystem access, roots guide them to relevant working directories while maintaining security boundaries.
+
+**Root structure:**
+
+```json
+{
+  "uri": "file:///Users/agent/travel-planning",
+  "name": "Travel Planning Workspace"
+}
+```
+
+Roots are exclusively filesystem paths and always use the `file://` URI scheme. They help servers understand project boundaries, workspace organization, and accessible directories. The roots list can be updated dynamically as users work with different projects or folders, with servers receiving notifications through `roots/list_changed` when boundaries change.
+
+It's important to note that while roots provide guidance to servers about where to operate, the client is always in full control of file access. Roots simply communicate intended boundaries—actual file access is always mediated by the client's security policies.
+
+#### Example: Travel Planning Workspace
+
+A travel agent working with multiple client trips benefits from roots to organize filesystem access. Consider a workspace with different directories for various aspects of travel planning.
+
+The client provides filesystem roots to the travel planning server:
+
+- `file:///Users/agent/travel-planning` - Main workspace containing all travel files
+- `file:///Users/agent/travel-templates` - Reusable itinerary templates and resources
+- `file:///Users/agent/client-documents` - Client passports and travel documents
+
+When the agent creates a Barcelona itinerary, the server works within these boundaries—accessing templates, saving the new itinerary, and referencing client documents. It cannot access files outside these roots. Servers typically access files within roots by using relative paths from the root directories or by utilizing file search tools that respect the root boundaries.
+
+If the agent opens an archive folder like `file:///Users/agent/archive/2023-trips`, the client updates the roots list via `roots/list_changed`.
+
+#### User Interaction Model
+
+Roots are typically managed automatically by host applications based on user actions, though some applications may expose manual root management:
+
+**Automatic root detection**: When users open folders, clients automatically expose them as roots. Opening a travel workspace gives servers access to itineraries and documents within that directory.
+
+**Manual root configuration**: Advanced users can specify roots through configuration. For example, adding `/travel-templates` for reusable resources while excluding directories with financial records.
+
+### Sampling
+
+Sampling allows servers to request language model completions through the client, enabling agentic behaviors while maintaining security and user control.
+
+#### Overview
+
+Sampling enables servers to perform AI-dependent tasks without directly integrating with or paying for AI models. Instead, servers can request that the client—which already has AI model access—handle these tasks on their behalf. This approach puts the client in complete control of user permissions and security measures. Because sampling requests occur within the context of other operations—like a tool analyzing data—and are processed as separate model calls, they maintain clear boundaries between different contexts, allowing for more efficient use of the context window.
+
+**Sampling flow:**
+
+```mermaid
+sequenceDiagram
+    participant LLM
+    participant User
+    participant Client
+    participant Server
+
+    Note over Server,Client: Server initiates sampling
+    Server->>Client: sampling/createMessage
+
+    Note over Client,User: Human-in-the-loop review
+    Client->>User: Present request for approval
+    User-->>Client: Review and approve/modify
+
+    Note over Client,LLM: Model interaction
+    Client->>LLM: Forward approved request
+    LLM-->>Client: Return generation
+
+    Note over Client,User: Response review
+    Client->>User: Present response for approval
+    User-->>Client: Review and approve/modify
+
+    Note over Server,Client: Complete request
+    Client-->>Server: Return approved response
+```
+
+The flow ensures security through multiple human-in-the-loop checkpoints. Users review and can modify both the initial request and the generated response before it returns to the server.
+
+**Request parameters example:**
+
+```typescript
+{
+  messages: [
+    {
+      role: "user",
+      content: "Analyze these flight options and recommend the best choice:\n" +
+               "[47 flights with prices, times, airlines, and layovers]\n" +
+               "User preferences: morning departure, max 1 layover"
+    }
+  ],
+  modelPreferences: {
+    hints: [{
+      name: "claude-3-5-sonnet"  // Suggested model
+    }],
+    costPriority: 0.3,      // Less concerned about API cost
+    speedPriority: 0.2,     // Can wait for thorough analysis
+    intelligencePriority: 0.9  // Need complex trade-off evaluation
+  },
+  systemPrompt: "You are a travel expert helping users find the best flights based on their preferences",
+  maxTokens: 1500
+}
+```
+
+#### Example: Flight Analysis Tool
+
+Consider a travel booking server with a tool called `findBestFlight` that uses sampling to analyze available flights and recommend the optimal choice. When a user asks "Book me the best flight to Barcelona next month," the tool needs AI assistance to evaluate complex trade-offs.
+
+The tool queries airline APIs and gathers 47 flight options. It then requests AI assistance to analyze these options: "Analyze these flight options and recommend the best choice: [47 flights with prices, times, airlines, and layovers] User preferences: morning departure, max 1 layover."
+
+The client initiates the sampling request, allowing the AI to evaluate trade-offs—like cheaper red-eye flights versus convenient morning departures. The tool uses this analysis to present the top three recommendations.
+
+#### User Interaction Model
+
+While not a requirement, sampling is designed to allow human-in-the-loop control. Users can maintain oversight through several mechanisms:
+
+**Approval controls**: Sampling requests may require explicit user consent. Clients can show what the server wants to analyze and why. Users can approve, deny, or modify requests.
+
+**Transparency features**: Clients can display the exact prompt, model selection, and token limits, allowing users to review AI responses before they return to the server.
+
+**Configuration options**: Users can set model preferences, configure auto-approval for trusted operations, or require approval for everything. Clients may provide options to redact sensitive information.
+
+**Security considerations**: Both clients and servers must handle sensitive data appropriately during sampling. Clients should implement rate limiting and validate all message content. The human-in-the-loop design ensures that server-initiated AI interactions cannot compromise security or access sensitive data without explicit user consent.

--- a/docs/docs/learn/server-concepts.mdx
+++ b/docs/docs/learn/server-concepts.mdx
@@ -11,11 +11,11 @@ Common examples include file system servers for document access, database server
 
 Servers provide functionality through three building blocks:
 
-| Feature | Explanation | Examples | Who controls it |
-| ------- | ----------- | -------- | --------------- |
-| **Tools** | Functions that your LLM can actively call, and decides when to use them based on user requests. Tools can write to databases, call external APIs, modify files, or trigger other logic. | Search flights<br />Send messages<br />Create calendar events | Model |
-| **Resources** | Passive data sources that provide read-only access to information for context, such as file contents, database schemas, or API documentation. | Retrieve documents<br />Access knowledge bases<br />Read calendars | Application |
-| **Prompts** | Pre-built instruction templates that tell the model to work with specific tools and resources. | Plan a vacation<br />Summarize my meetings<br />Draft an email | User |
+| Feature       | Explanation                                                                                                                                                                             | Examples                                                           | Who controls it |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | --------------- |
+| **Tools**     | Functions that your LLM can actively call, and decides when to use them based on user requests. Tools can write to databases, call external APIs, modify files, or trigger other logic. | Search flights<br />Send messages<br />Create calendar events      | Model           |
+| **Resources** | Passive data sources that provide read-only access to information for context, such as file contents, database schemas, or API documentation.                                           | Retrieve documents<br />Access knowledge bases<br />Read calendars | Application     |
+| **Prompts**   | Pre-built instruction templates that tell the model to work with specific tools and resources.                                                                                          | Plan a vacation<br />Summarize my meetings<br />Draft an email     | User            |
 
 We will use a hypothetical scenario to demonstrate the role of each of these features, and show how they can work together.
 
@@ -57,21 +57,27 @@ Tools are schema-defined interfaces that LLMs can invoke. MCP uses JSON Schema f
 Tools enable AI applications to perform actions on behalf of users. In a travel planning scenario, the AI application might use several tools to help book a vacation:
 
 **Flight Search**
+
 ```
 searchFlights(origin: "NYC", destination: "Barcelona", date: "2024-06-15")
 ```
+
 Queries multiple airlines and returns structured flight options.
 
 **Calendar Blocking**
+
 ```
 createCalendarEvent(title: "Barcelona Trip", startDate: "2024-06-15", endDate: "2024-06-22")
 ```
+
 Marks the travel dates in the user's calendar.
 
 **Email notification**
+
 ```
 sendEmail(to: "team@work.com", subject: "Out of Office", body: "...")
 ```
+
 Sends an automated out-of-office message to colleagues.
 
 #### User Interaction Model
@@ -96,7 +102,7 @@ Resources expose data from files, APIs, databases, or any other source that an A
 Each resource has a unique URI (like `file:///path/to/document.md`) and declares its MIME type for appropriate content handling. They declare MIME types for appropriate content handling and support two discovery patterns:
 
 - **Direct Resources** - fixed URIs that point to specific data. Example: `calendar://events/2024` - returns calendar availability for 2024
-- **Resource Templates** - dynamic URIs with parameters for flexible queries. Example: 
+- **Resource Templates** - dynamic URIs with parameters for flexible queries. Example:
   - `travel://activities/{city}/{category}` - returns activities by city and category
   - `travel://activities/barcelona/museums` - returns all museums in Barcelona
 
@@ -216,6 +222,7 @@ Prompts are user-controlled, requiring explicit invocation. The protocol gives i
 - Transparent display of the prompt's underlying template
 
 Applications typically expose prompts through various UI patterns such as:
+
 - Slash commands (typing "/" to see available prompts like /plan-vacation)
 - Command palettes for searchable access
 - Dedicated UI buttons for frequently used prompts
@@ -262,7 +269,7 @@ Consider a personalized AI travel planner application, with three connected serv
    Using this context, the AI then executes a series of Tools:
    - `searchFlights()` - Queries airlines for NYC to Barcelona flights
    - `checkWeather()` - Retrieves climate forecasts for travel dates
-   
+
    The AI then uses this information to create the booking and following steps, requesting approval from the user where necessary:
    - `bookHotel()` - Finds hotels within the specified budget
    - `createCalendarEvent()` - Adds the trip to the user's calendar

--- a/docs/docs/learn/server-concepts.mdx
+++ b/docs/docs/learn/server-concepts.mdx
@@ -1,29 +1,31 @@
 ---
-title: Server Concepts
-description: "Understanding MCP server concepts"
+title: Understanding MCP servers
+sidebarTitle: Servers
 ---
 
-MCP servers are programs that expose specific capabilities to AI applications through standardized protocol interfaces. Each server provides focused functionality for a particular domain.
+MCP servers are programs that expose specific capabilities to AI applications through standardized protocol interfaces.
 
-Common examples include file system servers for document management, email servers for message handling, travel servers for trip planning, and database servers for data queries. Each server brings domain-specific capabilities to the AI application.
+Common examples include file system servers for document access, database servers for data queries, GitHub servers for code management, Slack servers for team communication, and calendar servers for scheduling.
 
-## Core Building Blocks
+## Core Server Features
 
 Servers provide functionality through three building blocks:
 
-| Building Block | Purpose                   | Who Controls It        | Real-World Example                                           |
-| -------------- | ------------------------- | ---------------------- | ------------------------------------------------------------ |
-| **Tools**      | For AI actions            | Model-controlled       | Search flights, send messages, create calendar events        |
-| **Resources**  | For context data          | Application-controlled | Documents, calendars, emails, weather data                   |
-| **Prompts**    | For interaction templates | User-controlled        | "Plan a vacation", "Summarize my meetings", "Draft an email" |
+| Feature | Explanation | Examples | Who controls it |
+| ------- | ----------- | -------- | --------------- |
+| **Tools** | Functions that your LLM can actively call, and decides when to use them based on user requests. Tools can write to databases, call external APIs, modify files, or trigger other logic. | Search flights<br />Send messages<br />Create calendar events | Model |
+| **Resources** | Passive data sources that provide read-only access to information for context, such as file contents, database schemas, or API documentation. | Retrieve documents<br />Access knowledge bases<br />Read calendars | Application |
+| **Prompts** | Pre-built instruction templates that tell the model to work with specific tools and resources. | Plan a vacation<br />Summarize my meetings<br />Draft an email | User |
 
-### Tools - AI Actions
+We will use a hypothetical scenario to demonstrate the role of each of these features, and show how they can work together.
 
-Tools enable AI models to perform actions through server-implemented functions. Each tool defines a specific operation with typed inputs and outputs. The model requests tool execution based on context.
+### Tools
 
-#### Overview
+Tools enable AI models to perform actions. Each tool defines a specific operation with typed inputs and outputs. The model requests tool execution based on context.
 
-Tools are schema-defined interfaces that LLMs can invoke. MCP uses JSON Schema for validation. Each tool performs a single operation with clearly defined inputs and outputs. Most importantly, tool execution requires explicit user approval, ensuring users maintain control over actions taken by a model.
+#### How Tools Work
+
+Tools are schema-defined interfaces that LLMs can invoke. MCP uses JSON Schema for validation. Each tool performs a single operation with clearly defined inputs and outputs. Tools may require user consent prior to execution, helping to ensure users maintain control over actions taken by a model.
 
 **Protocol operations:**
 
@@ -50,49 +52,55 @@ Tools are schema-defined interfaces that LLMs can invoke. MCP uses JSON Schema f
 }
 ```
 
-#### Example: Taking Action
+#### Example: Travel Booking
 
-Tools enable AI applications to perform actions on behalf of users. In a travel planning scenario, the AI application might use several tools to help book a vacation.
+Tools enable AI applications to perform actions on behalf of users. In a travel planning scenario, the AI application might use several tools to help book a vacation:
 
-First, it searches for flights using
-
+**Flight Search**
 ```
 searchFlights(origin: "NYC", destination: "Barcelona", date: "2024-06-15")
 ```
+Queries multiple airlines and returns structured flight options.
 
-`searchFlights` queries multiple airlines and returns structured flight options. Once flights are selected, it creates a calendar event with
-
+**Calendar Blocking**
 ```
 createCalendarEvent(title: "Barcelona Trip", startDate: "2024-06-15", endDate: "2024-06-22")
 ```
+Marks the travel dates in the user's calendar.
 
-to mark the travel dates. Finally, it sends an out-of-office notification using
-
+**Email notification**
 ```
 sendEmail(to: "team@work.com", subject: "Out of Office", body: "...")
 ```
-
-to inform colleagues about the absence.
-
-Each tool execution requires explicit user approval, ensuring full control over actions taken.
+Sends an automated out-of-office message to colleagues.
 
 #### User Interaction Model
 
-Tools are model-controlled, meaning AI models can discover and invoke them automatically. However, MCP emphasizes human oversight through several mechanisms. Applications should clearly display available tools in the UI and provide visual indicators when tools are being considered or used. Before any tool execution, users must be presented with clear approval dialogs that explain exactly what the tool will do.
+Tools are model-controlled, meaning AI models can discover and invoke them automatically. However, MCP emphasizes human oversight through several mechanisms.
 
-For trust and safety, applications often enforce manual approval to give humans the ability to deny tool invocations. Applications typically implement this through approval dialogs, permission settings for pre-approving certain safe operations, and activity logs that show all tool executions with their results.
+For trust and safety, applications can implement user control through various mechanisms, such as:
 
-### Resources - Context Data
+- Displaying available tools in the UI, enabling users to define whether a tool should be made available in specific interactions
+- Approval dialogs for individual tool executions
+- Permission settings for pre-approving certain safe operations
+- Activity logs that show all tool executions with their results
 
-Resources provide structured access to information that the host application can retrieve and provide to AI models as context.
+### Resources
 
-#### Overview
+Resources provide structured access to information that the AI application can retrieve and provide to models as context.
+
+#### How Resources Work
 
 Resources expose data from files, APIs, databases, or any other source that an AI needs to understand context. Applications can access this information directly and decide how to use it - whether that's selecting relevant portions, searching with embeddings, or passing it all to the model.
 
-Resources use URI-based identification, with each resource having a unique URI such as `file:///path/to/document.md`. They declare MIME types for appropriate content handling and support two discovery patterns: **direct resources** with fixed URIs, and **resource templates** with parameterized URIs.
+Each resource has a unique URI (like `file:///path/to/document.md`) and declares its MIME type for appropriate content handling. They declare MIME types for appropriate content handling and support two discovery patterns:
 
-**Resource Templates** enable dynamic resource access through URI templates. A template like `travel://activities/{city}/{category}` would access filtered activity data by substituting both `{city}` and `{category}` parameters. For example, `travel://activities/barcelona/museums` would return all museums in Barcelona. Resource Templates include metadata such as title, description, and expected MIME type, making them discoverable and self-documenting.
+- **Direct Resources** - fixed URIs that point to specific data. Example: `calendar://events/2024` - returns calendar availability for 2024
+- **Resource Templates** - dynamic URIs with parameters for flexible queries. Example: 
+  - `travel://activities/{city}/{category}` - returns activities by city and category
+  - `travel://activities/barcelona/museums` - returns all museums in Barcelona
+
+Resource Templates include metadata such as title, description, and expected MIME type, making them discoverable and self-documenting.
 
 **Protocol operations:**
 
@@ -103,15 +111,17 @@ Resources use URI-based identification, with each resource having a unique URI s
 | `resources/read`           | Retrieve resource contents      | Resource data with metadata            |
 | `resources/subscribe`      | Monitor resource changes        | Subscription confirmation              |
 
-#### Example: Accessing Context Data
+#### Example: Getting Travel Planning Context
 
 Continuing with the travel planning example, resources provide the AI application with access to relevant information:
 
-- **Calendar data** (`calendar://events/2024`) - To check availability
-- **Travel documents** (`file:///Documents/Travel/passport.pdf`) - For important information
-- **Previous itineraries** (`trips://history/barcelona-2023`) - User selects which past trip style to follow
+- **Calendar data** (`calendar://events/2024`) - Checks user availability
+- **Travel documents** (`file:///Documents/Travel/passport.pdf`) - Accesses important documents
+- **Previous itineraries** (`trips://history/barcelona-2023`) - References past trips and preferences
 
-Instead of manually copying this information, resources provide raw information to AI applications. The application can choose how to best handle the data. Applications might choose to select a subset of data, using embeddings or keyword search, or pass the raw data from a resource directly to a model. In our example, during the planning phase, the AI application can pass the calendar data, weather data and travel preferences, so that the model can check availability, look up weather patterns, and reference travel preferences.
+The AI application retrieves these resources and decides how to process them, whether selecting a subset of data using embeddings or keyword search, or passing raw data directly to the model.
+
+In this case, it provides calendar data, weather information, and travel preferences to the model, enabling it to check availability, look up weather patterns, and reference past travel preferences.
 
 **Resource Template Examples:**
 
@@ -140,21 +150,28 @@ These templates enable flexible queries. For weather data, users can access fore
 Dynamic resources support parameter completion. For example:
 
 - Typing "Par" as input for `weather://forecast/{city}` might suggest "Paris" or "Park City"
-- The system helps discover valid values without requiring exact format knowledge
+- Typing "JFK" for `flights://search/{airport}` might suggest "JFK - John F. Kennedy International"
+
+The system helps discover valid values without requiring exact format knowledge.
 
 #### User Interaction Model
 
-Resources are application-driven, giving hosts flexibility in how they retrieve, process, and present available context. Common interaction patterns include tree or list views for browsing resources in familiar folder-like structures, search and filter interfaces for finding specific resources, automatic context inclusion based on heuristics or AI selection, and manual selection interfaces.
+Resources are application-driven, giving them flexibility in how they retrieve, process, and present available context. Common interaction patterns include:
+
+- Tree or list views for browsing resources in familiar folder-like structures
+- Search and filter interfaces for finding specific resources
+- Automatic context inclusion or smart suggestions based on heuristics or AI selection
+- Manual or bulk selection interfaces for including single or multiple resources
 
 Applications are free to implement resource discovery through any interface pattern that suits their needs. The protocol doesn't mandate specific UI patterns, allowing for resource pickers with preview capabilities, smart suggestions based on current conversation context, bulk selection for including multiple resources, or integration with existing file browsers and data explorers.
 
-### Prompts - Interaction Templates
+### Prompts
 
 Prompts provide reusable templates. They allow MCP server authors to provide parameterized prompts for a domain, or showcase how to best use the MCP server.
 
-#### Overview
+#### How Prompts Work
 
-Prompts are structured templates that define expected inputs and interaction patterns. They are user-controlled, requiring explicit invocation rather than automatic triggering. Prompts can be context-aware, referencing available resources and tools to create comprehensive workflows. Like resources, prompts support parameter completion to help users discover valid argument values.
+Prompts are structured templates that define expected inputs and interaction patterns. They are user-controlled, requiring explicit invocation rather than automatic triggering. Prompts can be context-aware, referencing available resources and tools to create comprehensive workflows. Similar to resources, prompts support parameter completion to help users discover valid argument values.
 
 **Protocol operations:**
 
@@ -191,21 +208,30 @@ Rather than unstructured natural language input, the prompt system enables:
 
 #### User Interaction Model
 
-Prompts are user-controlled, requiring explicit invocation. Applications typically expose prompts through various UI patterns such as slash commands (typing "/" to see available prompts like /plan-vacation), command palettes for searchable access, dedicated UI buttons for frequently used prompts, or context menus that suggest relevant prompts.
+Prompts are user-controlled, requiring explicit invocation. The protocol gives implementers freedom to design interfaces that feel natural within their application. Key principles include:
 
-The protocol gives implementers freedom to design interfaces that feel natural within their application. Key principles include easy discovery of available prompts, clear descriptions of what each prompt does, natural argument input with validation, and transparent display of the prompt's underlying template.
+- Easy discovery of available prompts
+- Clear descriptions of what each prompt does
+- Natural argument input with validation
+- Transparent display of the prompt's underlying template
 
-## How It All Works Together
+Applications typically expose prompts through various UI patterns such as:
+- Slash commands (typing "/" to see available prompts like /plan-vacation)
+- Command palettes for searchable access
+- Dedicated UI buttons for frequently used prompts
+- Context menus that suggest relevant prompts
+
+## Bringing Servers Together
 
 The real power of MCP emerges when multiple servers work together, combining their specialized capabilities through a unified interface.
 
 ### Example: Multi-Server Travel Planning
 
-Consider an AI application with three connected servers:
+Consider a personalized AI travel planner application, with three connected servers:
 
-1. **Travel Server** - Handles flights, hotels, and itineraries
-2. **Weather Server** - Provides climate data and forecasts
-3. **Calendar/Email Server** - Manages schedules and communications
+- **Travel Server** - Handles flights, hotels, and itineraries
+- **Weather Server** - Provides climate data and forecasts
+- **Calendar/Email Server** - Manages schedules and communications
 
 #### The Complete Flow
 
@@ -229,8 +255,17 @@ Consider an AI application with three connected servers:
    - `travel://preferences/europe` (from Travel Server)
    - `travel://past-trips/Spain-2023` (from Travel Server)
 
-3. **AI processes the request:**
+3. **AI processes the request using tools:**
 
-   The AI first reads all selected resources to gather context. From the calendar, it identifies available dates. From travel preferences, it learns preferred airlines and hotel types. From past trips, it discovers previously enjoyed locations. From weather data, it checks climate conditions for the travel period.
+   The AI first reads all selected resources to gather context - identifying available dates from the calendar, learning preferred airlines and hotel types from travel preferences, and discovering previously enjoyed locations from past trips.
 
-   Using this context, the AI then requests user approval to execute a series of coordinated actions: searching for flights from NYC to Barcelona, finding hotels within the specified budget, creating a calendar event for the trip duration, and sending confirmation emails with the trip details.
+   Using this context, the AI then executes a series of Tools:
+   - `searchFlights()` - Queries airlines for NYC to Barcelona flights
+   - `checkWeather()` - Retrieves climate forecasts for travel dates
+   
+   The AI then uses this information to create the booking and following steps, requesting approval from the user where necessary:
+   - `bookHotel()` - Finds hotels within the specified budget
+   - `createCalendarEvent()` - Adds the trip to the user's calendar
+   - `sendEmail()` - Sends confirmation with trip details
+
+**The result:** Through multiple MCP servers, the user researched and booked a Barcelona trip tailored to their schedule. The "Plan a Vacation" prompt guided the AI to combine Resources (calendar availability and travel history) with Tools (searching flights, booking hotels, updating calendars) across different servers—gathering context and executing the booking. A task that could've taken hours was completed in minutes using MCP.

--- a/docs/docs/sdk.mdx
+++ b/docs/docs/sdk.mdx
@@ -79,7 +79,11 @@ Ready to start building with MCP? Choose your path:
   <Card title="Build a Server" icon="server" href="/docs/develop/build-server">
     Learn how to create your first MCP server
   </Card>
-  <Card title="Build a Client" icon="computer" href="/docs/develop/build-client">
+  <Card
+    title="Build a Client"
+    icon="computer"
+    href="/docs/develop/build-client"
+  >
     Create applications that connect to MCP servers
   </Card>
 </CardGroup>

--- a/docs/docs/sdk.mdx
+++ b/docs/docs/sdk.mdx
@@ -1,9 +1,9 @@
 ---
 title: SDKs
-description: Official SDKs for building with the Model Context Protocol
+description: Official SDKs for building with Model Context Protocol
 ---
 
-Build MCP servers and clients using our official SDKs. Choose the SDK that matches your technology stack - all SDKs provide the same core functionality and full protocol support.
+Build MCP servers and clients using our official SDKs. All SDKs provide the same core functionality and full protocol support.
 
 ## Available SDKs
 
@@ -64,10 +64,10 @@ Build MCP servers and clients using our official SDKs. Choose the SDK that match
 
 Each SDK provides the same functionality but follows the idioms and best practices of its language. All SDKs support:
 
-- Creating MCP servers that expose tools, resources, and prompts
-- Building MCP clients that can connect to any MCP server
-- Local and Remote transport protocols
-- Protocol compliance with type safety
+• Creating MCP servers that expose tools, resources, and prompts
+• Building MCP clients that can connect to any MCP server
+• Local and remote transport protocols
+• Protocol compliance with type safety
 
 Visit the SDK page for your chosen language to find installation instructions, documentation, and examples.
 
@@ -76,24 +76,10 @@ Visit the SDK page for your chosen language to find installation instructions, d
 Ready to start building with MCP? Choose your path:
 
 <CardGroup cols={2}>
-  <Card title="Build a Server" icon="server" href="/quickstart/server">
+  <Card title="Build a Server" icon="server" href="/docs/develop/build-server">
     Learn how to create your first MCP server
   </Card>
-  <Card title="Build a Client" icon="computer" href="/quickstart/client">
+  <Card title="Build a Client" icon="computer" href="/docs/develop/build-client">
     Create applications that connect to MCP servers
-  </Card>
-  <Card
-    title="Explore Examples"
-    icon="code"
-    href="https://github.com/modelcontextprotocol/servers"
-  >
-    Browse pre-built servers for inspiration
-  </Card>
-  <Card
-    title="Understand the Architecture"
-    icon="book"
-    href="/docs/learn/architecture"
-  >
-    Dive deeper into how MCP works
   </Card>
 </CardGroup>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -58,7 +58,11 @@ Choose the path that best fits your needs:
   <Card title="For Client Developers" icon="bolt" href="/quickstart/client">
     Get started building your own client that can integrate with all MCP servers
   </Card>
-  <Card title="For Claude Desktop Users" icon="bolt" href="/docs/develop/connect-local-servers">
+  <Card
+    title="For Claude Desktop Users"
+    icon="bolt"
+    href="/docs/develop/connect-local-servers"
+  >
     Get started using pre-built servers in Claude for Desktop
   </Card>
 </CardGroup>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -58,7 +58,7 @@ Choose the path that best fits your needs:
   <Card title="For Client Developers" icon="bolt" href="/quickstart/client">
     Get started building your own client that can integrate with all MCP servers
   </Card>
-  <Card title="For Claude Desktop Users" icon="bolt" href="/quickstart/user">
+  <Card title="For Claude Desktop Users" icon="bolt" href="/docs/develop/connect-local-servers">
     Get started using pre-built servers in Claude for Desktop
   </Card>
 </CardGroup>

--- a/docs/legacy/tools/inspector.mdx
+++ b/docs/legacy/tools/inspector.mdx
@@ -1,5 +1,5 @@
 ---
-title: Inspector
+title: MCP Inspector
 description: In-depth guide to using the MCP Inspector for testing and debugging Model Context Protocol servers
 ---
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

- Move quickstart guides (client, server, user) to docs/develop/ directory
- Rename user.mdx to connect-local-servers.mdx for clarity
- Move remote server tutorial to develop/connect-remote-servers.mdx
- Update navigation structure in docs.json
- Improve content clarity across getting-started, learn, and SDK pages
- Fix minor formatting and readability issues throughout

## Motivation and Context

Clarify usage guidance in public documentation

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Local documentation build succeeds.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
