### PR TITLE
Fix mermaid diagram contrast in dark mode

### DIFF
--- a/blog/assets/css/extended/custom.css
+++ b/blog/assets/css/extended/custom.css
@@ -7,3 +7,14 @@
 .dark.list {
     background: var(--theme);
 }
+
+/* Mermaid diagram styling for dark mode */
+.dark .mermaid {
+    filter: invert(0.85) hue-rotate(180deg);
+    background: transparent !important;
+}
+
+/* Ensure mermaid diagrams have proper background in light mode */
+.mermaid {
+    background: transparent;
+}

--- a/blog/assets/css/extended/custom.css
+++ b/blog/assets/css/extended/custom.css
@@ -11,10 +11,4 @@
 /* Mermaid diagram styling for dark mode */
 .dark .mermaid {
     filter: invert(0.85) hue-rotate(180deg);
-    background: transparent !important;
-}
-
-/* Ensure mermaid diagrams have proper background in light mode */
-.mermaid {
-    background: transparent;
 }


### PR DESCRIPTION
Adds CSS filters to properly display mermaid diagrams in dark mode. The invert filter with hue-rotate ensures text is readable while maintaining natural color relationships.

Fixes #1432

🤖 Generated with [Claude Code](https://claude.ai/code)

## Motivation and Context
https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1432

## How Has This Been Tested?
Before
<img width="1510" height="1324" alt="image" src="https://github.com/user-attachments/assets/b337200c-d1fe-4518-9f4a-42ab110c65b5" />

After
<img width="688" height="440" alt="image" src="https://github.com/user-attachments/assets/28306f8d-8415-4111-af6e-4d42740d2cd4" />

## Breaking Changes
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
