### PR TITLE
Add blog testing instructions to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,16 @@ npm run check:docs
 npm run format
 ```
 
+## Blog changes
+
+The blog is built using [Hugo](https://gohugo.io/installation/) and located in the [`blog`](./blog) directory.
+
+To preview blog changes locally:
+
+```bash
+npm run serve:blog
+```
+
 ### Documentation Guidelines
 
 When contributing to the documentation:


### PR DESCRIPTION
Added documentation for testing the blog locally, including:
- Link to Hugo installation guide
- Instructions for running the blog server
