### PR TITLE
Clarify HTTP 403 status for invalid Origin headers

### DIFF
--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -76,6 +76,8 @@ URL like `https://example.com/mcp`.
 When implementing Streamable HTTP transport:
 
 1. Servers **MUST** validate the `Origin` header on all incoming connections to prevent DNS rebinding attacks
+   - If the `Origin` header is present and invalid, servers **MUST** respond with HTTP 403 Forbidden. The HTTP response
+     body **MAY** comprise a JSON-RPC *error response* that has no `id`
 2. When running locally, servers **SHOULD** bind only to localhost (127.0.0.1) rather than all network interfaces (0.0.0.0)
 3. Servers **SHOULD** implement proper authentication for all connections
 

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -77,7 +77,7 @@ When implementing Streamable HTTP transport:
 
 1. Servers **MUST** validate the `Origin` header on all incoming connections to prevent DNS rebinding attacks
    - If the `Origin` header is present and invalid, servers **MUST** respond with HTTP 403 Forbidden. The HTTP response
-     body **MAY** comprise a JSON-RPC *error response* that has no `id`
+     body **MAY** comprise a JSON-RPC _error response_ that has no `id`
 2. When running locally, servers **SHOULD** bind only to localhost (127.0.0.1) rather than all network interfaces (0.0.0.0)
 3. Servers **SHOULD** implement proper authentication for all connections
 

--- a/docs/specification/draft/changelog.mdx
+++ b/docs/specification/draft/changelog.mdx
@@ -12,6 +12,10 @@ the previous revision, [2025-06-18](/specification/2025-06-18).
 1. Enhance authorization server discovery with support for [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html). (PR [#797](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/797))
 2. Allow servers to expose icons as additional metadata for tools, resources and prompts ([SEP-973](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/973)).
 
+## Minor changes
+
+1. Clarify that servers must respond with HTTP 403 Forbidden for invalid Origin headers in Streamable HTTP transport. (PR [#1439](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1439))
+
 ## Other schema changes
 
 ## Full changelog


### PR DESCRIPTION
Add explicit guidance that servers MUST respond with HTTP 403 Forbidden when the Origin header is present but invalid. This addresses part of issue #1398 regarding inconsistent error responses across SDKs. Currently TypeScript returns 403, but Python return 400. 403 seems like the most appropriate response here, so going with that (and will update Python if this is accepted).

## Motivation and Context
Spec does not specify the response, so implementations have diverged.

https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1398

## How Has This Been Tested?
```
npm serve:docs
```

## Breaking Changes
Technically this could be a breaking change if there are some clients somewhere are relying on specific implementation of this from specific SDKs, but since e.g. TypeScript SDK already returns 403, it's already behavior that clients have to deal with depending on the server.

Marking as "breaking change" as a precaution, but I think this should be a safe change.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed
