### PR TITLE
Use list markdown for list

### DIFF
--- a/docs/docs/sdk.mdx
+++ b/docs/docs/sdk.mdx
@@ -64,10 +64,10 @@ Build MCP servers and clients using our official SDKs. All SDKs provide the same
 
 Each SDK provides the same functionality but follows the idioms and best practices of its language. All SDKs support:
 
-• Creating MCP servers that expose tools, resources, and prompts
-• Building MCP clients that can connect to any MCP server
-• Local and remote transport protocols
-• Protocol compliance with type safety
+- Creating MCP servers that expose tools, resources, and prompts
+- Building MCP clients that can connect to any MCP server
+- Local and remote transport protocols
+- Protocol compliance with type safety
 
 Visit the SDK page for your chosen language to find installation instructions, documentation, and examples.
 


### PR DESCRIPTION
This causes the content to be rendered as a list instead of a paragraph.

| Before | After |
| --- | --- |
| <img width="685" height="330" alt="before" src="https://github.com/user-attachments/assets/2d9a874a-e44c-4445-b703-ba7495265ef0" /> | <img width="685" height="381" alt="after" src="https://github.com/user-attachments/assets/2460f13f-41b1-49ce-aee2-62d7ea4032b9" /> |
