### PR TITLE
Fix awkward wrapping in blog post metadata

### DIFF
--- a/blog/assets/css/extended/custom.css
+++ b/blog/assets/css/extended/custom.css
@@ -12,3 +12,8 @@
 .dark .mermaid {
     filter: invert(0.85) hue-rotate(180deg);
 }
+
+/* Prevent awkward wrapping in post metadata. See https://github.com/adityatelange/hugo-PaperMod/issues/1789 */
+.post-meta {
+    display: block !important;
+}


### PR DESCRIPTION
## Summary
- Fixes awkward text wrapping in blog post metadata where the separator and reading time would appear at the start of a new line

## Changes
- Added CSS rule to ensure `.post-meta` displays as a block element, preventing mid-separator wrapping

Fixes https://github.com/adityatelange/hugo-PaperMod/issues/1789