### PR TITLE
Organize project maintainers by individual projects

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -70,14 +70,28 @@ This document lists current maintainers and working groups in the Model Context 
 
 ## Project Maintainers
 
-- [Glen Maddern](https://github.com/geelen) (use-mcp)
-- [Ola Hungerford](https://github.com/olaservo) (Inspector, Reference Servers)
-- [Cliff Hall](https://github.com/cliffhall) (Inspector, Reference Servers)
-- [Toby Padilla](https://github.com/toby) (Registry)
-- [Tadas Antanavicius](https://github.com/tadasant) (Registry, Reference Servers)
-- [Shaun Smith](https://github.com/evalstate) (Reference Servers)
-- [Jonathan Hefner](https://github.com/jonathanhefner) (Reference Servers)
-- [Adam Jones](https://github.com/domdomegg) (Registry)
+### use-mcp
+
+- [Glen Maddern](https://github.com/geelen)
+
+### Inspector
+
+- [Ola Hungerford](https://github.com/olaservo)
+- [Cliff Hall](https://github.com/cliffhall)
+
+### Registry
+
+- [Toby Padilla](https://github.com/toby)
+- [Tadas Antanavicius](https://github.com/tadasant)
+- [Adam Jones](https://github.com/domdomegg)
+
+### Reference Servers
+
+- [Ola Hungerford](https://github.com/olaservo)
+- [Cliff Hall](https://github.com/cliffhall)
+- [Tadas Antanavicius](https://github.com/tadasant)
+- [Shaun Smith](https://github.com/evalstate)
+- [Jonathan Hefner](https://github.com/jonathanhefner)
 
 ## Community Moderators
 


### PR DESCRIPTION
## Summary
- Split out the Project Maintainers section to list maintainers grouped by their specific projects (use-mcp, Inspector, Registry, Reference Servers)
- This matches the structure used for SDK maintainers, making it clearer who maintains each project