### PR TITLE
HTML encode dollar sign in schema reference

### DIFF
--- a/typedoc.plugin.mjs
+++ b/typedoc.plugin.mjs
@@ -167,7 +167,9 @@ function renderReflection(reflection, context) {
     replaceAll(/\n+</g, " <"). // Newlines around tags are not significant
     replaceAll("[", "&#x5B;"). // `[` inside HTML tags != link
     replaceAll("_", "&#x5F;"). // `_` inside HTML tags != emphasis
-    replaceAll("{", "&#x7B;"); // Plain *.md is not supported, so must escape JSX interpolation
+    replaceAll("{", "&#x7B;"). // Plain *.md is not supported, so must escape JSX interpolation
+    replaceAll("$", "&#x24;"); // `$` does not demarcate LaTeX(?)
+
 
   // Remove `@TJS-type` tags.  (Ideally, we would include this tag in
   // `excludeTags`, but a TypeDoc bug rejects tag names with dashes.)


### PR DESCRIPTION
Mintlify's Markdown parser treats dollar signs as special characters in some cases.  The exact cause is not clear, but it might be related to MDX's [LaTeX support](https://mdxjs.com/guides/math/).

An example of this behavior can be seen in the [build failure](https://github.com/modelcontextprotocol/modelcontextprotocol/actions/runs/17779025550/job/50533858211?pr=881#step:6:10) for #881, in which `npm run check:docs:links` failed to parse `schema.mdx` due to newly introduced `$schema` properties.

This commit modifies the `schema.mdx` generator to HTML encode dollar signs, thus preventing such parse errors.

