### PR TITLE
Fix incorrect name/title fields in ResourceContents documentation

### DIFF
--- a/docs/specification/draft/server/prompts.mdx
+++ b/docs/specification/draft/server/prompts.mdx
@@ -251,8 +251,6 @@ Embedded resources allow referencing server-side resources directly in messages:
   "type": "resource",
   "resource": {
     "uri": "resource://example",
-    "name": "example",
-    "title": "My Example Resource",
     "mimeType": "text/plain",
     "text": "Resource content"
   }

--- a/docs/specification/draft/server/resources.mdx
+++ b/docs/specification/draft/server/resources.mdx
@@ -157,8 +157,6 @@ To retrieve resource contents, clients send a `resources/read` request:
     "contents": [
       {
         "uri": "file:///project/src/main.rs",
-        "name": "main.rs",
-        "title": "Rust Software Application Main File",
         "mimeType": "text/x-rust",
         "text": "fn main() {\n    println!(\"Hello world!\");\n}"
       }
@@ -240,8 +238,7 @@ to specific resources and receive notifications when they change:
   "jsonrpc": "2.0",
   "method": "notifications/resources/updated",
   "params": {
-    "uri": "file:///project/src/main.rs",
-    "title": "Rust Software Application Main File"
+    "uri": "file:///project/src/main.rs"
   }
 }
 ```
@@ -293,8 +290,6 @@ Resources can contain either text or binary data:
 ```json
 {
   "uri": "file:///example.txt",
-  "name": "example.txt",
-  "title": "Example Text File",
   "mimeType": "text/plain",
   "text": "Resource content"
 }
@@ -305,8 +300,6 @@ Resources can contain either text or binary data:
 ```json
 {
   "uri": "file:///example.png",
-  "name": "example.png",
-  "title": "Example Image",
   "mimeType": "image/png",
   "blob": "base64-encoded-data"
 }

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -283,7 +283,6 @@ or data using a suitable [URI scheme](./resources#common-uri-schemes). Servers t
   "type": "resource",
   "resource": {
     "uri": "file:///project/src/main.rs",
-    "title": "Project Rust Main File",
     "mimeType": "text/x-rust",
     "text": "fn main() {\n    println!(\"Hello world!\");\n}",
     "annotations": {


### PR DESCRIPTION
Commit https://github.com/modelcontextprotocol/modelcontextprotocol/commit/1c54a7737c2b156be26e0c94cf7b269c24396122 (PR https://github.com/modelcontextprotocol/modelcontextprotocol/pull/663) incorrectly added 'name' and 'title' fields
to ResourceContents examples in the documentation. According to the schema,
these fields only exist on Resource objects (used in resources/list), not
on ResourceContents (TextResourceContents/BlobResourceContents) which are
used in:
- resources/read responses
- embedded resources in prompts and tools
- resource update notifications

This commit removes the incorrectly documented fields to match the actual
schema definition where ResourceContents only contains:
- uri (required)
- mimeType (optional)
- text or blob field depending on content type