### PR TITLE
spec(auth, draft): clarify pre-provisioned registration fallback

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -917,7 +917,7 @@ MooPoint is a web-based AI chat platform built for developers and advanced users
 
 ### Needle
 
-[Needle](https://needle.app) is a RAG worflow platform that also works as an MCP client, letting you connect and use MCP servers in seconds. 
+[Needle](https://needle.app) is a RAG worflow platform that also works as an MCP client, letting you connect and use MCP servers in seconds.
 
 **Key features:**
 

--- a/docs/specification/draft/basic/authorization.mdx
+++ b/docs/specification/draft/basic/authorization.mdx
@@ -206,15 +206,16 @@ for MCP because:
 - It enables seamless connection to new MCP servers and their authorization servers.
 - Authorization servers can implement their own registration policies.
 
-Any authorization servers that _do not_ support Dynamic Client Registration need to provide
-alternative ways to obtain a client ID (and, if applicable, client credentials). For one of
-these authorization servers, MCP clients will have to either:
+### Pre-provisioned registration fallback
 
-1. Hardcode a client ID (and, if applicable, client credentials) specifically for the MCP client to use when
-   interacting with that authorization server, or
-2. Present a UI to users that allows them to enter these details, after registering an
-   OAuth client themselves (e.g., through a configuration interface hosted by the
-   server).
+MCP **clients MUST** support a pre-provisioned registration path in addition to Dynamic Client Registration (DCR). Clients **MUST** provide either:
+
+1. A user-facing input mechanism for a pre-provisioned `client_id`; or
+2. A managed configuration mechanism (e.g., a configuration file).
+
+When a corresponding authorization server does not support DCR—or when enterprise policy requires pre-registration, clients **MUST** allow users or administrators to supply these values.
+
+**Authorization servers** that do not support DCR **MUST** provide a non-DCR mechanism to register a client and obtain the resulting `client_id` (e.g., an administrative portal), allowing **users or administrators** to supply any required **client metadata** (such as redirect URIs) during registration.
 
 #### Scope Selection Strategy
 


### PR DESCRIPTION
**Summary**
Minor clarifications to the Draft Authorization spec to make pre-registration a first-class fallback when DCR is unavailable or enterprise policy requires it.

**Changes**
- In the draft “Authorization” page, replace the “hardcode or present UI” section with:
  - a client **MUST** to support a pre-provisioned path (via user input or managed configuration), and
  - a server **MUST** to provide a non-DCR registration path to obtain a `client_id` (e.g., administrative portal), allowing users/administrators to supply required client metadata (e.g., redirect URIs).
- Removed the prior security note and all references to credentials to keep this PR narrowly scoped.
- Formatting-only fix for `docs/clients.mdx` to satisfy Prettier CI (No content changes).

**Motivation and Context**
Many enterprises require pre-registered/static clients for change control, scoped blast radius, and incident isolation. This gives a spec-blessed fallback to DCR, that popular clients can implement with minimal work.

**How Has This Been Tested?**
Doc-only change. No code changes.

**Breaking Changes**
None. Backward compatible; no protocol flow changes.

**Types of changes**
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

**Checklist**
- [x] I’ve read the MCP documentation.
- [x] My change only updates documentation.
- [x] I’ve verified formatting/markdown renders correctly in preview.


**Additional context**
This change reflects discussion in the MCP WG Discord (Aug 23–26, 2025) on pre-registration, with input from Paul Carleton (Anthropic) and others. It captures:

- Agreement that supporting a pre-registration fallback alongside DCR is a pragmatic choice.
- Concern about client-secret sprawl and rotation/lifecycle risks.
- Enterprise need for predictable/manual configuration in addition to DCR.

Discord link: https://discord.com/channels/1358869848138059966/1408762963807961138
