### PR TITLE
Fix redirect for `/quickstart/user`

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -363,7 +363,7 @@
       "destination": "/docs/develop/connect-remote-servers"
     },
     {
-      "source": "/docs/quickstart/user",
+      "source": "/quickstart/user",
       "destination": "/docs/develop/connect-local-servers"
     },
     {


### PR DESCRIPTION
This file was moved in b02d5231cc2eaccb6286ecb5f34390a507b92604, and a redirect was added, but the original URL was `/quickstart/user` rather than `/docs/quickstart/user`.

Fixes #1486.
