### PR TITLE
Fix description punctuation in working-interest-groups.mdx

### DIFF
--- a/docs/community/working-interest-groups.mdx
+++ b/docs/community/working-interest-groups.mdx
@@ -1,6 +1,6 @@
 ---
 title: Working and Interest Groups
-description: Learn about the two forms of collaborative groups within the Model Context Protocol's governance structure: Working Groups and Interest Groups.
+description: Learn about the two forms of collaborative groups within the Model Context Protocol's governance structure - Working Groups and Interest Groups.
 ---
 
 Within the MCP contributor community we maintain two types of collaboration formats - **Interest** and **Working** groups.


### PR DESCRIPTION
## Motivation and Context
New Working and Interest Groups page is going to 404 after being published.

## How Has This Been Tested?
Not yet, fairly sure this is the bug causing the page to 404.

## Breaking Changes
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

