### PR TITLE
Upgrade the deprecated 3-5-sonnet to 4-sonnet across docs

### DIFF
--- a/docs/docs/develop/build-client.mdx
+++ b/docs/docs/develop/build-client.mdx
@@ -178,7 +178,7 @@ async def process_query(self, query: str) -> str:
 
     # Initial Claude API call
     response = self.anthropic.messages.create(
-        model="claude-3-5-sonnet-20241022",
+        model="claude-3-7-sonnet-latest",
         max_tokens=1000,
         messages=messages,
         tools=available_tools
@@ -218,7 +218,7 @@ async def process_query(self, query: str) -> str:
 
             # Get next response from Claude
             response = self.anthropic.messages.create(
-                model="claude-3-5-sonnet-20241022",
+                model="claude-3-7-sonnet-latest",
                 max_tokens=1000,
                 messages=messages,
                 tools=available_tools
@@ -643,7 +643,7 @@ async processQuery(query: string) {
   ];
 
   const response = await this.anthropic.messages.create({
-    model: "claude-3-5-sonnet-20241022",
+    model: "claude-3-7-sonnet-latest",
     max_tokens: 1000,
     messages,
     tools: this.tools,
@@ -672,7 +672,7 @@ async processQuery(query: string) {
       });
 
       const response = await this.anthropic.messages.create({
-        model: "claude-3-5-sonnet-20241022",
+        model: "claude-3-7-sonnet-latest",
         max_tokens: 1000,
         messages,
       });
@@ -1226,7 +1226,7 @@ Now let's add the core functionality for processing queries and handling tool ca
 
 ```kotlin
 private val messageParamsBuilder: MessageCreateParams.Builder = MessageCreateParams.builder()
-    .model(Model.CLAUDE_3_5_SONNET_20241022)
+    .model(Model.CLAUDE_3_7_SONNET_LATEST)
     .maxTokens(1024)
 
 suspend fun processQuery(query: String): String {
@@ -1561,7 +1561,7 @@ using var anthropicClient = new AnthropicClient(new APIAuthentication(builder.Co
 var options = new ChatOptions
 {
     MaxOutputTokens = 1000,
-    ModelId = "claude-3-5-sonnet-20241022",
+    ModelId = "claude-3-7-sonnet-latest",
     Tools = [.. tools]
 };
 

--- a/docs/docs/develop/build-client.mdx
+++ b/docs/docs/develop/build-client.mdx
@@ -178,7 +178,7 @@ async def process_query(self, query: str) -> str:
 
     # Initial Claude API call
     response = self.anthropic.messages.create(
-        model="claude-3-7-sonnet-latest",
+        model="claude-sonnet-4-20250514",
         max_tokens=1000,
         messages=messages,
         tools=available_tools
@@ -218,7 +218,7 @@ async def process_query(self, query: str) -> str:
 
             # Get next response from Claude
             response = self.anthropic.messages.create(
-                model="claude-3-7-sonnet-latest",
+                model="claude-sonnet-4-20250514",
                 max_tokens=1000,
                 messages=messages,
                 tools=available_tools
@@ -643,7 +643,7 @@ async processQuery(query: string) {
   ];
 
   const response = await this.anthropic.messages.create({
-    model: "claude-3-7-sonnet-latest",
+    model: "claude-sonnet-4-20250514",
     max_tokens: 1000,
     messages,
     tools: this.tools,
@@ -672,7 +672,7 @@ async processQuery(query: string) {
       });
 
       const response = await this.anthropic.messages.create({
-        model: "claude-3-7-sonnet-latest",
+        model: "claude-sonnet-4-20250514",
         max_tokens: 1000,
         messages,
       });
@@ -1226,7 +1226,7 @@ Now let's add the core functionality for processing queries and handling tool ca
 
 ```kotlin
 private val messageParamsBuilder: MessageCreateParams.Builder = MessageCreateParams.builder()
-    .model(Model.CLAUDE_3_7_SONNET_LATEST)
+    .model(Model.CLAUDE_SONNET_4_20250514)
     .maxTokens(1024)
 
 suspend fun processQuery(query: String): String {
@@ -1561,7 +1561,7 @@ using var anthropicClient = new AnthropicClient(new APIAuthentication(builder.Co
 var options = new ChatOptions
 {
     MaxOutputTokens = 1000,
-    ModelId = "claude-3-7-sonnet-latest",
+    ModelId = "claude-sonnet-4-20250514",
     Tools = [.. tools]
 };
 

--- a/docs/docs/learn/client-concepts.mdx
+++ b/docs/docs/learn/client-concepts.mdx
@@ -197,7 +197,7 @@ The flow ensures security through multiple human-in-the-loop checkpoints. Users 
   ],
   modelPreferences: {
     hints: [{
-      name: "claude-3-5-sonnet"  // Suggested model
+      name: "claude-3-7-sonnet"  // Suggested model
     }],
     costPriority: 0.3,      // Less concerned about API cost
     speedPriority: 0.2,     // Can wait for thorough analysis

--- a/docs/docs/learn/client-concepts.mdx
+++ b/docs/docs/learn/client-concepts.mdx
@@ -197,7 +197,7 @@ The flow ensures security through multiple human-in-the-loop checkpoints. Users 
   ],
   modelPreferences: {
     hints: [{
-      name: "claude-3-7-sonnet"  // Suggested model
+      name: "claude-sonnet-4-20250514"  // Suggested model
     }],
     costPriority: 0.3,      // Less concerned about API cost
     speedPriority: 0.2,     // Can wait for thorough analysis

--- a/docs/specification/draft/basic/security_best_practices.mdx
+++ b/docs/specification/draft/basic/security_best_practices.mdx
@@ -284,6 +284,7 @@ The MCP client **SHOULD** implement additional checks and guardrails to mitigate
 - Use platform-appropriate sandboxing technologies (containers, chroot, application sandboxes, etc.)
 
 MCP servers intending for their servers to be run locally **SHOULD** implement measures to prevent unauthorized usage from malicious processes:
+
 - Use the `stdio` transport to limit access to just the MCP client
 - Restrict access if using an HTTP transport, such as:
   - Require an authorization token

--- a/docs/tutorials/building-a-client-node.mdx
+++ b/docs/tutorials/building-a-client-node.mdx
@@ -192,7 +192,7 @@ Now add the core functionality for processing queries and handling tool calls:
 
     const finalText: string[] = [];
     let currentResponse = await this.anthropic.messages.create({
-      model: "claude-3-7-sonnet-latest",
+      model: "claude-sonnet-4-20250514",
       max_tokens: 1000,
       messages,
       tools: availableTools,
@@ -246,7 +246,7 @@ Now add the core functionality for processing queries and handling tool calls:
 
           // Get next response from Claude with tool results
           currentResponse = await this.anthropic.messages.create({
-            model: "claude-3-7-sonnet-latest",
+            model: "claude-sonnet-4-20250514",
             max_tokens: 1000,
             messages,
             tools: availableTools,

--- a/docs/tutorials/building-a-client-node.mdx
+++ b/docs/tutorials/building-a-client-node.mdx
@@ -192,7 +192,7 @@ Now add the core functionality for processing queries and handling tool calls:
 
     const finalText: string[] = [];
     let currentResponse = await this.anthropic.messages.create({
-      model: "claude-3-5-sonnet-20241022",
+      model: "claude-3-7-sonnet-latest",
       max_tokens: 1000,
       messages,
       tools: availableTools,
@@ -246,7 +246,7 @@ Now add the core functionality for processing queries and handling tool calls:
 
           // Get next response from Claude with tool results
           currentResponse = await this.anthropic.messages.create({
-            model: "claude-3-5-sonnet-20241022",
+            model: "claude-3-7-sonnet-latest",
             max_tokens: 1000,
             messages,
             tools: availableTools,


### PR DESCRIPTION
## Motivation and Context
`claude-3-5-sonnet` was deprecated and this code is now showing a warning when running examples. Please see https://docs.claude.com/en/docs/about-claude/model-deprecations#model-status

## How Has This Been Tested?
I run the docs and checked locally.

## Breaking Changes
No breaking changes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

