### PR TITLE
Add missing Langflow link

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -146,6 +146,7 @@ This page provides an overview of applications that support the Model Context Pr
 [Jenova]: https://www.jenova.ai
 [JetBrains AI Assistant]: https://plugins.jetbrains.com/plugin/22282-jetbrains-ai-assistant
 [Kilo Code]: https://github.com/Kilo-Org/kilocode
+[Langflow]: https://github.com/langflow-ai/langflow
 [LibreChat]: https://github.com/danny-avila/LibreChat
 [LM Studio]: https://lmstudio.ai
 [Lutra]: https://lutra.ai


### PR DESCRIPTION
This fixes a dead link in the client table.

| Before | After |
| --- | --- |
| <img width="660" height="164" alt="before" src="https://github.com/user-attachments/assets/8424a486-ebc0-46df-845b-de08369edba0" /> | <img width="660" height="166" alt="after" src="https://github.com/user-attachments/assets/ff52e7d1-e61f-4614-b08d-11f7e052ec4b" /> |
