### PR TITLE
Add ECA to MCP client documentation

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -38,6 +38,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [Copilot-MCP][CopilotMCP]                        | ✅          | ❌        | ✅      | ❓                     | ❌         | ❌    | ❓            |
 | [Cursor][Cursor]                                 | ✅          | ✅        | ✅      | ❌                     | ✅         | ✅    | ✅            |
 | [Daydreams Agents][Daydreams]                    | ✅          | ✅        | ✅      | ❌                     | ❌         | ❌    | ❓            |
+| [ECA][ECA]                                       | ✅          | ✅        | ✅      | ❌                     | ❌         | ✅    | ❓            |
 | [Emacs Mcp][Mcp.el]                              | ❌          | ❌        | ✅      | ❌                     | ❌         | ❌    | ❓            |
 | [fast-agent][fast-agent]                         | ✅          | ✅        | ✅      | ✅                     | ✅         | ✅    | ✅            |
 | [FlowDown][FlowDown]                             | ❌          | ❌        | ✅      | ❓                     | ❌         | ❌    | ❌            |
@@ -133,6 +134,7 @@ This page provides an overview of applications that support the Model Context Pr
 [CopilotMCP]: https://github.com/VikashLoomba/copilot-mcp
 [Cursor]: https://cursor.com
 [Daydreams]: https://github.com/daydreamsai/daydreams
+[ECA]: https://eca.dev
 [Klavis AI]: https://www.klavis.ai/
 [Mcp.el]: https://github.com/lizqwerscott/mcp.el
 [fast-agent]: https://github.com/evalstate/fast-agent
@@ -488,6 +490,22 @@ The Claude desktop application provides comprehensive support for MCP, enabling 
 
 - Supports MCP Servers in config
 - Exposes MCP Client
+
+### ECA - Editor Code Assistant
+
+[ECA](https://eca.dev) is a Free and open-source editor-agnostic tool that aims to easily link LLMs <-> Editors, giving the best UX possible for AI pair programming using a well-defined protocol
+
+- :page_facing_up: **Editor-agnostic**: protocol for any editor to integrate.
+- :gear: **Single configuration**: Configure eca making it work the same in any editor via global or local configs.
+- :loop: **Chat** interface: ask questions, review code, work together to code.
+- :coffee: **Agentic**: let LLM work as an agent with its native tools and MCPs you can configure.
+- :syringe: **Context**: support: giving more details about your code to the LLM, including MCP resources and prompts.
+- :rocket: **Multi models**: Login to OpenAI, Anthropic, Copilot, Ollama local models and many more.
+- :chart_with_upwards_trend: **OpenTelemetry**: Export metrics of tools, prompts, server usage.
+
+**Learn more:**
+
+- [eca website](https://eca.dev)
 
 ### Emacs Mcp
 


### PR DESCRIPTION
Add [ECA](https://eca.dev) as a MCP client 

## Motivation and Context
ECA allows pair with AI in multiple editors with a good UX and multiple capabiltiies.

## How Has This Been Tested?
Yes, I'm the maintainer and there are multiple users already.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
None
