### PR TITLE
Change invalid resource URI error code from -32002 to -32602

### DIFF
--- a/docs/specification/2025-06-18/server/resources.mdx
+++ b/docs/specification/2025-06-18/server/resources.mdx
@@ -375,7 +375,7 @@ taking the above guidance in to account.
 
 Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
 
-- Resource not found: `-32602`
+- Resource not found: `-32002`
 - Internal errors: `-32603`
 
 Example error:
@@ -385,7 +385,7 @@ Example error:
   "jsonrpc": "2.0",
   "id": 5,
   "error": {
-    "code": -32602,
+    "code": -32002,
     "message": "Resource not found",
     "data": {
       "uri": "file:///nonexistent.txt"


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Change error code from `-32002` to `-32602` when invalid resource name is provided. `-32002` is a non-standard JSON-RPC code. Using `-32602` is also consistent with how tools and prompts behave when given invalid names e.g. "Invalid prompt name: `-32602` (Invalid params)".

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Use a standard JSON-RPC error code when an invalid resource URI is requested. This creates consistency with how prompts and tools respond to analogous situations.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Doc-only changes.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Breaking change in spec if clients have behavior dependent on the old error code.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
