### PR TITLE
Clean up deprecated contributing page file

### DIFF
--- a/docs/development/contributing.mdx
+++ b/docs/development/contributing.mdx
@@ -1,8 +1,0 @@
----
-title: Contributing
-description: How to participate in Model Context Protocol development
----
-
-{/* NB: hidden from docs, deprecated page */}
-
-We welcome contributions from the community! Most repositories should have a README.md or CONTRIBUTING.md file with instructions for how to get started.


### PR DESCRIPTION
The /docs/development/contributing.mdx file was deprecated and hidden from docs. A redirect rule already exists in docs.json to redirect /development/contributing to /community/communication, so the physical file is no longer needed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Additional context
Fixes #1478