### PR TITLE
Docs: Fix oudated server path on 'Build an MCP client' guide

### DIFF
--- a/docs/docs/develop/build-client.mdx
+++ b/docs/docs/develop/build-client.mdx
@@ -344,7 +344,7 @@ uv run client.py path/to/build/index.js # node server
 
 <Note>
 
-If you're continuing the weather tutorial from the server quickstart, your command might look something like this: `python client.py .../weather/weather.py`
+If you're continuing [the weather tutorial from the server quickstart](https://github.com/modelcontextprotocol/quickstart-resources/tree/main/weather-server-python), your command might look something like this: `python client.py .../quickstart-resources/weather-server-python/weather.py`
 
 </Note>
 
@@ -758,7 +758,7 @@ node build/index.js path/to/build/index.js # node server
 
 <Note>
 
-If you're continuing the weather tutorial from the server quickstart, your command might look something like this: `node build/index.js .../quickstart-resources/weather-server-typescript/build/index.js`
+If you're continuing [the weather tutorial from the server quickstart](https://github.com/modelcontextprotocol/quickstart-resources/tree/main/weather-server-typescript), your command might look something like this: `node build/index.js .../quickstart-resources/weather-server-typescript/build/index.js`
 
 </Note>
 


### PR DESCRIPTION
## Fix outdated server path reference

## Motivation and Context
Documentation contains an old path to server file from Build an MCP server guide, causing confusion for users.

## How Has This Been Tested?
Docs

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
- Ensures documentation matches current codebase
