### PR TITLE
(docs) Update the Remote MCP page link to Remote servers specifically

### DIFF
--- a/docs/docs/develop/connect-remote-servers.mdx
+++ b/docs/docs/develop/connect-remote-servers.mdx
@@ -125,11 +125,11 @@ Now that you've connected Claude to a remote MCP server, you can explore its cap
     services
   </Card>
   <Card
-    title="Explore available servers"
+    title="Explore Remote servers"
     icon="grid"
-    href="https://github.com/modelcontextprotocol/servers"
+    href="https://github.com/jaw9c/awesome-remote-mcp-servers"
   >
-    Browse our collection of official and community-created MCP servers
+    Browse a curated list of offical and community-created *Remote* MCP servers
   </Card>
   <Card
     title="Connect local servers"


### PR DESCRIPTION
I think its strange that the Connect to remote MCP Servers section still lists to all MCP server types. I curate the most popular list of remote servers here, so proposing a link instead: https://github.com/jaw9c/awesome-remote-mcp-servers.

## Motivation and Context
Connect to remote MCP Servers section still lists to all MCP server type, rather than focusing on Remote MCPs like the section does.

## How Has This Been Tested?
N/A

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
N/A