### PR TITLE
Change gist URL to the official MCP quickstart repo

### DIFF
--- a/docs/docs/develop/build-client.mdx
+++ b/docs/docs/develop/build-client.mdx
@@ -279,7 +279,7 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-You can find the complete `client.py` file [here.](https://gist.github.com/zckly/f3f28ea731e096e53b39b47bf0a2d4b1)
+You can find the complete `client.py` file [here](https://github.com/modelcontextprotocol/quickstart-resources/blob/main/mcp-client-python/client.py).
 
 ## Key Components Explained
 


### PR DESCRIPTION
## Motivation and Context
A link to gist can easily become outdated as we keep updating these quick start tutorials. Better to link to the tutorial itself.

## How Has This Been Tested?
Tested locally

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
N/a