### PR TITLE
Remove Cody client (replaced by Amp)

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -81,7 +81,6 @@ This page provides an overview of applications that support the Model Context Pr
 | [Shortwave][Shortwave]                           | ❌          | ❌        | ✅      | ❓                     | ❌         | ❌    | ❓            |
 | [Simtheory][Simtheory]                           | ✅          | ✅        | ✅      | ✅                     | ❌         | ❌    | ❓            |
 | [Slack MCP Client][Slack MCP Client]             | ❌          | ❌        | ✅      | ❓                     | ❌         | ❌    | ❓            |
-| [Sourcegraph Cody][Cody]                         | ✅          | ❌        | ❌      | ❓                     | ❌         | ❌    | ❓            |
 | [SpinAI][SpinAI]                                 | ❌          | ❌        | ✅      | ❓                     | ❌         | ❌    | ❓            |
 | [Superinterface][Superinterface]                 | ❌          | ❌        | ✅      | ❓                     | ❌         | ❌    | ❓            |
 | [Superjoin][Superjoin]                           | ❌          | ❌        | ✅      | ❓                     | ❌         | ❌    | ❓            |
@@ -175,7 +174,6 @@ This page provides an overview of applications that support the Model Context Pr
 [Shortwave]: https://www.shortwave.com
 [Simtheory]: https://simtheory.ai
 [Slack MCP Client]: https://github.com/tuannvm/slack-mcp-client
-[Cody]: https://sourcegraph.com/cody
 [SpinAI]: https://spinai.dev
 [Superinterface]: https://superinterface.ai
 [Superjoin]: https://superjoin.ai
@@ -1019,17 +1017,6 @@ Simtheory is an agentic AI workspace that unifies multiple AI models, tools, and
 - **Supports Popular LLM Providers:** Integrates seamlessly with leading large language model providers such as OpenAI, Anthropic, and Ollama, allowing users to leverage advanced conversational AI and orchestration capabilities within Slack.
 - **Dynamic and Secure Integration:** Supports dynamic registration of MCP tools, works in both channels and direct messages and manages credentials securely via environment variables or Kubernetes secrets.
 - **Easy Deployment and Extensibility:** Offers official Docker images, a Helm chart for Kubernetes, and Docker Compose for local development, making it simple to deploy, configure, and extend with additional MCP servers or tools.
-
-### Sourcegraph Cody
-
-[Cody](https://openctx.org/docs/providers/modelcontextprotocol) is Sourcegraph's AI coding assistant, which implements MCP through OpenCTX.
-
-**Key features:**
-
-- Support for MCP resources
-- Integration with Sourcegraph's code intelligence
-- Uses OpenCTX as an abstraction layer
-- Future support planned for additional MCP features
 
 ### SpinAI
 


### PR DESCRIPTION
Remove Cody, because it got replaced by Amp.

- https://www.reddit.com/r/ClaudeAI/comments/1ll0kow/sourcegraph_cody_discontinued_replaced_by_cody/
- https://sourcegraph.com/blog/changes-to-cody-free-pro-and-enterprise-starter-plans