### PR TITLE
Add Configuration Schema to Server Initialization

### DIFF
--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -185,6 +185,114 @@ Capability objects can describe sub-capabilities like:
   tools)
 - `subscribe`: Support for subscribing to individual items' changes (resources only)
 
+#### Configuration Schema Declaration
+
+Servers can optionally declare their configuration requirements during initialization by including a `configurationSchema` field in the `InitializeResult`. This enables clients to detect and assist with missing configuration before attempting tool execution.
+
+**Purpose**
+
+Configuration schema declaration solves several critical usability issues:
+
+1. **Chicken-and-egg Problem**: Clients must successfully connect to discover tools, but servers often fail to start without proper configuration
+2. **Poor User Experience**: Users only discover missing configuration after connection failures with cryptic error messages
+3. **Fragmented Documentation**: Configuration requirements are scattered across READMEs and error messages
+4. **No Programmatic Discovery**: Clients cannot automatically detect or assist with configuration setup
+
+**Schema Structure**
+
+The `configurationSchema` field contains three optional arrays:
+
+- `environmentVariables`: Environment variables needed by the server
+- `arguments`: Command-line arguments required for stdio servers
+- `other`: Other configuration (files, URLs, etc.)
+
+Each parameter declaration includes:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | ✓ | Unique identifier (e.g., "GITHUB_TOKEN", "allowed-directory") |
+| `description` | string | ✓ | Human-readable explanation of the parameter |
+| `type` | string | ✓ | One of: "string", "number", "boolean", "path", "url" |
+| `required` | boolean | ✓ | Whether this parameter is required |
+| `sensitive` | boolean |  | Whether this contains sensitive data (passwords, API keys) |
+| `default` | string\|number\|boolean |  | Default value if not provided |
+| `multiple` | boolean |  | Whether multiple values are allowed |
+| `pattern` | string |  | Validation regex for string parameters |
+| `examples` | string[] |  | Example values to guide users |
+
+**Example: Filesystem Server**
+
+A filesystem server that requires directory paths as command-line arguments:
+
+```json
+{
+  "protocolVersion": "2025-06-18",
+  "serverInfo": {
+    "name": "filesystem",
+    "version": "1.0.0"
+  },
+  "capabilities": {},
+  "configurationSchema": {
+    "arguments": [
+      {
+        "name": "allowed-directory",
+        "description": "Directory path that the server is allowed to access",
+        "type": "path",
+        "required": true,
+        "multiple": true,
+        "examples": ["/home/user/projects", "/tmp"]
+      }
+    ]
+  }
+}
+```
+
+**Example: GitHub Server**
+
+An API-based server that requires an authentication token:
+
+```json
+{
+  "protocolVersion": "2025-06-18",
+  "serverInfo": {
+    "name": "github",
+    "version": "1.0.0"
+  },
+  "capabilities": {},
+  "configurationSchema": {
+    "environmentVariables": [
+      {
+        "name": "GITHUB_TOKEN",
+        "description": "GitHub personal access token with repo permissions",
+        "type": "string",
+        "required": true,
+        "sensitive": true,
+        "pattern": "^ghp_[a-zA-Z0-9]{36}$"
+      }
+    ]
+  }
+}
+```
+
+**Benefits**
+
+For **server developers**:
+- Self-documenting configuration
+- Better error messages from clients
+- Programmatic validation
+
+For **client developers**:
+- Proactive configuration detection
+- Build setup wizards and configuration tools
+- Better user experience
+
+For **end users**:
+- Clear guidance on what's needed upfront
+- Interactive setup assistance
+- Fewer connection failures
+
+The `configurationSchema` field is **optional** and **fully backward compatible** - servers that don't provide it continue to work as before.
+
 ### Operation
 
 During the operation phase, the client and server exchange messages according to the

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -183,6 +183,90 @@ export interface InitializeRequest extends JSONRPCRequest {
 }
 
 /**
+ * Describes a configuration parameter needed by the server.
+ *
+ * @category initialize
+ */
+export interface ConfigurationParameter {
+  /**
+   * Unique identifier for this parameter (e.g., "GITHUB_TOKEN", "allowed-directory")
+   */
+  name: string;
+
+  /**
+   * Human-readable description of what this parameter is for
+   */
+  description: string;
+
+  /**
+   * Type of the parameter value
+   */
+  type: "string" | "number" | "boolean" | "path" | "url";
+
+  /**
+   * Whether this parameter is required for the server to function
+   */
+  required: boolean;
+
+  /**
+   * Whether this contains sensitive data (passwords, API keys).
+   * If true, clients should mask input when prompting users.
+   */
+  sensitive?: boolean;
+
+  /**
+   * Default value if not provided by the user
+   */
+  default?: string | number | boolean;
+
+  /**
+   * Whether multiple values are allowed (for array parameters)
+   */
+  multiple?: boolean;
+
+  /**
+   * Validation pattern (regex) for string parameters
+   */
+  pattern?: string;
+
+  /**
+   * Example values to help users understand expected format
+   */
+  examples?: string[];
+}
+
+/**
+ * Declares configuration requirements for the server.
+ *
+ * Servers can use this to communicate what environment variables,
+ * command-line arguments, or other configuration they need to function properly.
+ *
+ * This enables clients to:
+ * - Detect missing configuration before attempting connection
+ * - Prompt users interactively for required values
+ * - Validate configuration before startup
+ * - Provide helpful error messages
+ *
+ * @category initialize
+ */
+export interface ConfigurationSchema {
+  /**
+   * Environment variables required by the server
+   */
+  environmentVariables?: ConfigurationParameter[];
+
+  /**
+   * Command-line arguments required by the server
+   */
+  arguments?: ConfigurationParameter[];
+
+  /**
+   * Other configuration requirements (files, URLs, etc.)
+   */
+  other?: ConfigurationParameter[];
+}
+
+/**
  * After receiving an initialize request from the client, the server sends this response.
  *
  * @category initialize
@@ -201,6 +285,52 @@ export interface InitializeResult extends Result {
    * This can be used by clients to improve the LLM's understanding of available tools, resources, etc. It can be thought of like a "hint" to the model. For example, this information MAY be added to the system prompt.
    */
   instructions?: string;
+
+  /**
+   * Optional schema declaring the server's configuration requirements.
+   *
+   * Servers can use this to communicate what environment variables,
+   * command-line arguments, or other configuration they need.
+   *
+   * Clients can use this information to:
+   * - Validate configuration before attempting connection
+   * - Prompt users for missing required configuration
+   * - Provide better error messages and setup guidance
+   *
+   * This field is optional and backward compatible - servers that don't
+   * provide it continue to work as before.
+   *
+   * @example
+   * ```typescript
+   * // Filesystem server declaring path requirement
+   * {
+   *   "configurationSchema": {
+   *     "arguments": [{
+   *       "name": "allowed-directory",
+   *       "description": "Directory path that the server is allowed to access",
+   *       "type": "path",
+   *       "required": true,
+   *       "multiple": true
+   *     }]
+   *   }
+   * }
+   *
+   * // API server declaring token requirement
+   * {
+   *   "configurationSchema": {
+   *     "environmentVariables": [{
+   *       "name": "GITHUB_TOKEN",
+   *       "description": "GitHub personal access token with repo permissions",
+   *       "type": "string",
+   *       "required": true,
+   *       "sensitive": true,
+   *       "pattern": "^ghp_[a-zA-Z0-9]{36}$"
+   *     }]
+   *   }
+   * }
+   * ```
+   */
+  configurationSchema?: ConfigurationSchema;
 }
 
 /**


### PR DESCRIPTION
This PR extends the MCP specification to allow servers to declare their configuration requirements during initialization, solving a critical usability issue where users must attempt connection failures before discovering missing configuration.

## Problem
- 12% of MCP servers (141 out of 1,215 analyzed) fail due to missing configuration
- No standardized way for servers to declare configuration needs
- Users discover requirements only after cryptic connection failures
- Fragile workarounds required (parsing stderr, documentation hunting)

## Solution
Add optional `configurationSchema` field to `InitializeResult` that allows servers to declare:
- Environment variables needed
- Command-line arguments required
- Other configuration (files, URLs, etc.)

## Key Features
- ✅ **Fully backward compatible** - optional field, existing servers unaffected
- ✅ **Simple** - reuses familiar JSON Schema patterns
- ✅ **Declarative** - clear separation from tool schemas
- ✅ **Client-agnostic** - works for env vars, CLI args, and other methods

## Changes Included

### 1. Schema Changes (\`schema/draft/schema.ts\`)
- Add \`ConfigurationSchema\` interface
- Add \`ConfigurationParameter\` interface
- Extend \`InitializeResult\` with optional \`configurationSchema\` field

### 2. Documentation (\`docs/specification/draft/basic/lifecycle.mdx\`)
- Document configuration schema in initialization phase
- Provide examples for common use cases
- Explain benefits for server and client developers

## Examples

### Filesystem Server (Path Arguments)
\`\`\`typescript
{
  "configurationSchema": {
    "arguments": [{
      "name": "allowed-directory",
      "description": "Directory path that the server is allowed to access",
      "type": "path",
      "required": true,
      "multiple": true
    }]
  }
}
\`\`\`

### GitHub Server (API Token)
\`\`\`typescript
{
  "configurationSchema": {
    "environmentVariables": [{
      "name": "GITHUB_TOKEN",
      "description": "GitHub personal access token with repo permissions",
      "type": "string",
      "required": true,
      "sensitive": true
    }]
  }
}
\`\`\`

## Related Work

This PR builds on and complements:
- [Discussion #863](https://github.com/modelcontextprotocol/specification/discussions/863) - Similar proposal, this adds comprehensive types and real-world data
- [Discussion #1510](https://github.com/modelcontextprotocol/specification/discussions/1510) - Complementary (client sending vs server declaring)
- [Issue #279](https://github.com/modelcontextprotocol/specification/issues/279) - Runtime parameter input
- [Issue #1284](https://github.com/modelcontextprotocol/specification/issues/1284) - Enterprise static metadata

## Implementation Status

Working prototype available in [NCP project](https://github.com/PortelU/ncp):
- Error parser that demonstrates the current fragile workaround
- Interactive repair command that shows desired user experience
- Validates the need with real-world data from 1,215+ MCPs

## Backward Compatibility

✅ No breaking changes
- Optional field - servers can omit it
- Clients that don't understand it simply ignore it
- Existing protocol behavior unchanged

## Benefits

### For Server Developers
- Self-documenting configuration
- Better error messages
- Programmatic validation

### For Client Developers
- Proactive configuration detection
- Build setup wizards
- Better user experience

### For End Users
- Clear guidance upfront
- Interactive setup assistance
- Fewer connection failures