### PR TITLE
[SEP-1575] changes to introduce Tool Versions

### DIFF
--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -84,6 +84,7 @@ To discover available tools, clients send a `tools/list` request. This operation
         "name": "get_weather",
         "title": "Weather Information Provider",
         "description": "Get current weather information for a location",
+        "version": "2.1.0",
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -123,6 +124,9 @@ To invoke a tool, clients send a `tools/call` request:
     "name": "get_weather",
     "arguments": {
       "location": "New York"
+    },
+    "tool_requirements": {
+      "get_weather": "^2.0.0"
     }
   }
 }
@@ -184,6 +188,60 @@ sequenceDiagram
     Server-->>Client: Updated tools
 ```
 
+## Tool Versioning
+
+MCP supports semantic versioning for tools to prevent breakages caused by un-versioned, dynamic tool updates. This allows clients to specify version constraints for the tools they are designed to work with.
+
+### Tool Version Declaration
+
+Tools can declare their version using the optional `version` field in their definition. The version string MUST adhere to the **Semantic Versioning 2.0.0** standard (e.g., MAJOR.MINOR.PATCH). Examples: "1.2.3", "2.0.0", "0.1.0-alpha.1".
+
+### Client Version Requirements
+
+Clients can specify version requirements for tools using the optional `tool_requirements` field in tool call requests. This field is a key-value map where:
+- **Key**: Tool name (string)
+- **Value**: Version specifier (string)
+
+The version specifier SHOULD follow conventions from modern package managers and supports the following operators:
+
+- **Caret (`^`)**: Allows non-breaking updates. `^1.2.3` is equivalent to `>=1.2.3 <2.0.0`
+- **Tilde (`~`)**: Allows patch-level updates. `~1.2.3` is equivalent to `>=1.2.3 <1.3.0`
+- **Comparison Operators**: `>`, `>=`, `<`, `<=`
+- **Exact Version**: A version number without any operator (e.g., `"1.2.3"`)
+
+### Version Validation Flow
+
+1. **Tool Discovery**: The client fetches the list of available tools from the server (e.g., via tools/list). The server response SHOULD include the version field for each tool that has one.
+2. **Client-Side Pre-validation (Recommended)**: Before making a tool call, the client SHOULD evaluate the available tool versions against its tool_requirements. This allows the client to identify potential mismatches early.
+3. **Tool Call with Requirements**: The client sends the tool call request, including the tool_requirements object.
+4. **Server-Side Validation (Mandatory)**: Upon receiving a request with tool_requirements, the server MUST perform validation before execution:
+   - For each key (tool name) in the tool_requirements object, the server MUST check if it has a version of that tool that satisfies the specified version constraint.
+   - If multiple versions satisfy a constraint, the server MUST select the **latest, stable** version that satisfies it.
+   - If all constraints are satisfied, the server proceeds with execution using the selected tool versions.
+   - If any constraint cannot be satisfied, the server MUST NOT execute the tool call and MUST return an error.
+
+### Error Handling
+
+If server-side validation fails, the server MUST return an error response with the error code `UNSATISFIED_TOOL_VERSION`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "error": {
+    "code": -32602,
+    "message": "Tool requirement for 'data_analyzer' (~1.4.1) could not be satisfied. Available versions: [1.3.2, 2.0.0]"
+  }
+}
+```
+
+### Backwards Compatibility
+
+This versioning system is designed to be fully backwards compatible:
+
+- **Un-versioned Tools**: If a tool definition does not include a version field, it will only satisfy a request that does not specify a version for that tool (or uses a wildcard `*` specifier).
+- **Legacy Clients**: If a client request does not include the tool_requirements field, the server MUST default to providing the latest stable version of the requested tools, preserving existing behavior.
+
 ## Data Types
 
 ### Tool
@@ -193,6 +251,7 @@ A tool definition includes:
 - `name`: Unique identifier for the tool
 - `title`: Optional human-readable name of the tool for display purposes.
 - `description`: Human-readable description of functionality
+- `version`: Optional semantic version of the tool (SemVer 2.0.0)
 - `inputSchema`: JSON Schema defining expected parameters
 - `outputSchema`: Optional JSON Schema defining expected output structure
 - `annotations`: optional properties describing tool behavior

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -145,6 +145,13 @@
                         },
                         "name": {
                             "type": "string"
+                        },
+                        "tool_requirements": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "A key-value map where the key is the tool name (string) and the value is a version specifier (string). Version specifiers follow conventions from modern package managers and support operators like ^, ~, >, >=, <, <=, and exact versions.",
+                            "type": "object"
                         }
                     },
                     "required": [
@@ -2715,6 +2722,10 @@
                 },
                 "title": {
                     "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "The semantic version of this tool. Must follow Semantic Versioning 2.0.0 standard (e.g., MAJOR.MINOR.PATCH). Examples: \"1.2.3\", \"2.0.0\", \"0.1.0-alpha.1\".",
                     "type": "string"
                 }
             },


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
  This PR adds tool versioning support to the MCP specification as defined in [SEP-1575](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1575), enabling servers to declare
  semantic versions for their tools and allowing clients to specify version constraints when making tool calls.
  ## Motivation and Context
  <!-- Why is this change needed? What problem does it solve? -->
  Currently, MCP tools lack versioning support, which can lead to breaking changes when tools are updated. This creates instability for clients that depend on specific tool behaviors. The tool
  versioning specification addresses this by:
  - **Preventing Breaking Changes**: Clients can specify version constraints to ensure compatibility
  - **Semantic Versioning**: Tools can declare versions following SemVer 2.0.0 standard
  - **Backwards Compatibility**: Existing un-versioned tools continue to work normally
  - **Clear Error Handling**: Provides standardized error responses when version requirements cannot be satisfied
  This specification change enables the ecosystem to evolve safely while maintaining stability for existing implementations.
  ## How Has This Been Tested?
  <!-- Have you tested this in a real application? Which scenarios were tested? -->
  The specification changes have been validated through:
  - **Schema Validation**: JSON Schema validates the new optional fields correctly
  - **Implementation Testing**: Companion Python SDK implementation demonstrates full functionality [Draft PR](https://github.com/modelcontextprotocol/python-sdk/pull/1427)
  - **Documentation Review**: Comprehensive examples and usage patterns documented
  - **Backwards Compatibility**: Verified that existing implementations continue to work without modification
  The companion implementation in the Python SDK includes comprehensive tests covering version parsing, constraint satisfaction, and error handling scenarios.
  ## Breaking Changes
  <!-- Will users need to update their code or configurations? -->
  **No breaking changes** - This specification update is fully backwards compatible:
  - All new fields are optional
  - Existing tools without version fields continue to work normally
  - Legacy clients without version requirements use the latest available version
  - Existing implementations require no modifications
  - New functionality is purely additive
  ## Types of changes
  <!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [x] Documentation update
  ## Checklist
  <!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
  - [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
  - [x] My code follows the repository's style guidelines
  - [x] New and existing tests pass locally
  - [x] I have added appropriate error handling
  - [x] I have added or updated documentation as needed
  ## Additional context
  <!-- Add any other context, implementation notes, or design decisions -->
  ### Schema Changes
  **Tool Definition Updates:**
  - Added optional `version` field to Tool schema
  - Field follows Semantic Versioning 2.0.0 standard
  - Supports pre-release versions (e.g., "1.0.0-alpha.1")
  **Tool Call Request Updates:**
  - Added optional `tool_requirements` field to tool call requests
  - Supports version constraint operators: `^`, `~`, `>`, `>=`, `<`, `<=`, exact versions
  - Follows conventions from modern package managers (npm, pip, etc.)
  ### Version Constraint Syntax
  The specification supports familiar version constraint operators:
  - **Caret (`^`)**: Allows non-breaking updates (`^1.2.3` ≡ `>=1.2.3 <2.0.0`)
  - **Tilde (`~`)**: Allows patch-level updates (`~1.2.3` ≡ `>=1.2.3 <1.3.0`)
  - **Comparison Operators**: `>`, `>=`, `<`, `<=`
  - **Exact Version**: `"1.2.3"` (no operator)
  ### Files Modified
  - `schema/draft/schema.json` - Added version fields to Tool and tool call request schemas
  - `docs/specification/draft/server/tools.mdx` - Updated documentation with versioning examples and usage patterns
  ### Implementation Status
  This specification change is accompanied by a complete implementation in the Python SDK that demonstrates:
  - Server-side tool version registration
  - Client-side version constraint handling
  - Error handling for unsatisfied version requirements
  - Comprehensive test coverage
  The specification provides the foundation for tool versioning across all MCP implementations while maintaining full backwards compatibility with existing deployments.
