### PR TITLE
docs: Add Meeting Calendar information for Interest and Working Groups

### DIFF
--- a/docs/community/working-interest-groups.mdx
+++ b/docs/community/working-interest-groups.mdx
@@ -22,6 +22,12 @@ These groups exist to:
 
 ## Mechanisms
 
+## Meeting Calendar
+
+All Interest Group and Working Group meetings are published on the public MCP community calendar at [mcp.meetable.org](https://mcp.meetable.org/).
+
+Facilitators are responsible for posting their meeting schedules to this calendar in advance to ensure discoverability and enable broader community participation.
+
 ### Interest Groups (IGs)
 
 **Goal:** Facilitate discussion and knowledge-sharing among MCP contributors who share interests in a specific MCP sub-topic or context. The primary focus is on identifying and gathering problems that may be worth addressing through SEPs or other community artifacts, while encouraging open exploration of protocol issues and opportunities.
@@ -30,6 +36,7 @@ These groups exist to:
 
 - Regular conversations in the Interest Group Discord channel
 - **AND/OR** a recurring live meeting regularly attended by Interest Group members
+- Meeting dates and times published in advance on the [MCP community calendar](https://mcp.meetable.org/)
 
 **Examples**:
 
@@ -68,6 +75,7 @@ Participation in an Interest Group (IG) is not required to start a Working Group
 
 - Meaningful progress towards at least one SEP or spec-related implementation **OR** hold maintenance responsibilities for a project (e.g., Inspector, Registry, SDKs)
 - Facilitators are responsible for keeping track of progress and communicating status when appropriate
+- Meeting dates and times published in advance on the [MCP community calendar](https://mcp.meetable.org/) when applicable
 
 **Examples**:
 


### PR DESCRIPTION
Addresses https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1401

Set to Draft since we're still confirming which groups plan to have meetings, and who can add them (and what the finalized domain will be).

## Motivation and Context

Currently, there's no centralized way for community members to discover when Working Group and Interest Group meetings are happening. This makes it difficult for contributors to participate in the groups they're interested in, reducing engagement and making the collaborative process less accessible.

This PR introduces documentation for a public community calendar at https://mcp.meetable.org/ that will provide a single source of truth for all WG and IG meetings, making it easy to discover and participate in community discussions.

## How Has This Been Tested?

- Calendar site (mcp.meetable.org) set up and ready to publish meeting schedules (thank you @aaronpk !)

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally (N/A for docs-only change)
- [x] I have added appropriate error handling (N/A for docs-only change)
- [x] I have added or updated documentation as needed

## Additional context

This change adds:
1. A new "Meeting Calendar" section explaining the public calendar at mcp.meetable.org
2. Updated expectations for both Interest Groups and Working Groups to include publishing meeting schedules to the calendar
3. Clear responsibility assignment to Facilitators for maintaining calendar entries
