### PR TITLE
Remove redirect rule causing 404

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -372,10 +372,6 @@
       "destination": "/docs/learn/architecture"
     },
     {
-      "source": "/docs/tools",
-      "destination": "/legacy/tools/inspector"
-    },
-    {
       "source": "/docs/tutorials/use-remote-mcp-server",
       "destination": "/docs/develop/connect-remote-servers"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12298,9 +12298,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
-      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Fixed 404 error on MCP Inspector documentation page by removing conflicting redirect rule in docs.json

## Motivation and Context
The MCP Inspector documentation page at https://modelcontextprotocol.io/docs/tools/inspector was returning a 404 error. The redirect rule `/docs/tools ->
/legacy/tools/inspector` was intercepting the `/docs/tools/inspector` URL before it could resolve to the correct page.

## How Has This Been Tested?
The redirect rule has been removed. After deployment, the page should be accessible at `/docs/tools/inspector`

## Breaking Changes
None.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Page was moved in a separate PR but old redirect still needed to get updated.
