### PR TITLE
Fix dark mode diagram visibility and CSS syntax error

### DIFF
--- a/docs/docs/learn/architecture.mdx
+++ b/docs/docs/learn/architecture.mdx
@@ -55,13 +55,6 @@ graph TB
     Client1 ---|"One-to-one<br/>connection"| Server1
     Client2 ---|"One-to-one<br/>connection"| Server2
     Client3 ---|"One-to-one<br/>connection"| Server3
-
-    style Client1 fill:#e1f5fe
-    style Client2 fill:#e1f5fe
-    style Client3 fill:#e1f5fe
-    style Server1 fill:#f3e5f5
-    style Server2 fill:#f3e5f5
-    style Server3 fill:#f3e5f5
 ```
 
 Note that **MCP server** refers to the program that serves context data, regardless of

--- a/docs/style.css
+++ b/docs/style.css
@@ -578,7 +578,7 @@ body:has(#schema-reference) {
     border-radius: 9999px;
 
     border: 6px solid var(--highlight-color);
-    color: white
+    color: white;
 
     font-size: 1.5rem;
     font-weight: 700;


### PR DESCRIPTION
## Summary

This PR fixes two bugs in the documentation:

1. **Dark mode architecture diagram visibility** – Diagram text was invisible in dark mode due to hardcoded color fills.
2. **CSS syntax error** – Missing semicolon in `.cta-primary` style.

### Bug Fixes

**Dark Mode Architecture Diagram**

* **Issue**: Architecture diagram colors were hardcoded with light theme colors, making text invisible in dark mode.
* **Fix**: Removed color style overrides to allow theme colors to apply properly.
* **Impact**: Diagram is now properly visible in both light and dark modes.

**Missing CSS Semicolon**

* **Issue**: `.cta-primary` style had a missing semicolon after the `color: white` property.
* **Fix**: Added the missing semicolon to prevent potential CSS parsing issues.
* **Impact**: Ensures proper CSS parsing and style application.

---

## How Has This Been Tested?

* ✅ Ran `npm run check:docs` – all checks passed.
* ✅ Ran `npm run format` – all files formatted correctly.
* ✅ Verified diagram visibility in both light and dark modes.
* ✅ Verified CSS parses correctly.

---

## Breaking Changes

None.

---

## Types of Changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

---

## Checklist

* [x] I have read the [[MCP Documentation](https://modelcontextprotocol.io/)](https://modelcontextprotocol.io).
* [x] My code follows the repository’s style guidelines.
* [x] New and existing tests pass locally.
* [x] I have added appropriate error handling.
* [x] I have added or updated documentation as needed.


## Additional context

Screenshots showing before/after comparisons for bug fixes.

### Screenshots 

**Before:**

<img width="1136" height="613" alt="Screenshot 2025-10-02 at 19 00 44" src="https://github.com/user-attachments/assets/7c3386e9-8d05-4e87-8b29-2a2b453ade32" />


**After:**

<img width="1102" height="619" alt="Screenshot 2025-10-03 at 20 30 31" src="https://github.com/user-attachments/assets/d15d0f07-313d-4807-8e07-ad3336cbbb19" />