### PR TITLE
docs: add pagination support to resource templates listing

### DIFF
--- a/docs/specification/2024-11-05/server/resources.mdx
+++ b/docs/specification/2024-11-05/server/resources.mdx
@@ -163,6 +163,8 @@ To retrieve resource contents, clients send a `resources/read` request:
 Resource templates allow servers to expose parameterized resources using
 [URI templates](https://datatracker.ietf.org/doc/html/rfc6570). Arguments may be
 auto-completed through [the completion API](/specification/2024-11-05/server/utilities/completion).
+This operation supports
+[pagination](/specification/2024-11-05/server/utilities/pagination).
 
 **Request:**
 
@@ -170,7 +172,10 @@ auto-completed through [the completion API](/specification/2024-11-05/server/uti
 {
   "jsonrpc": "2.0",
   "id": 3,
-  "method": "resources/templates/list"
+  "method": "resources/templates/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
 }
 ```
 
@@ -188,7 +193,8 @@ auto-completed through [the completion API](/specification/2024-11-05/server/uti
         "description": "Access files in the project directory",
         "mimeType": "application/octet-stream"
       }
-    ]
+    ],
+    "nextCursor": "next-page-cursor"
   }
 }
 ```

--- a/docs/specification/2025-03-26/server/resources.mdx
+++ b/docs/specification/2025-03-26/server/resources.mdx
@@ -160,6 +160,7 @@ To retrieve resource contents, clients send a `resources/read` request:
 Resource templates allow servers to expose parameterized resources using
 [URI templates](https://datatracker.ietf.org/doc/html/rfc6570). Arguments may be
 auto-completed through [the completion API](/specification/2025-03-26/server/utilities/completion).
+This operation supports [pagination](/specification/2025-03-26/server/utilities/pagination).
 
 **Request:**
 
@@ -167,7 +168,10 @@ auto-completed through [the completion API](/specification/2025-03-26/server/uti
 {
   "jsonrpc": "2.0",
   "id": 3,
-  "method": "resources/templates/list"
+  "method": "resources/templates/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
 }
 ```
 
@@ -185,7 +189,8 @@ auto-completed through [the completion API](/specification/2025-03-26/server/uti
         "description": "Access files in the project directory",
         "mimeType": "application/octet-stream"
       }
-    ]
+    ],
+    "nextCursor": "next-page-cursor"
   }
 }
 ```

--- a/docs/specification/2025-06-18/server/resources.mdx
+++ b/docs/specification/2025-06-18/server/resources.mdx
@@ -165,6 +165,7 @@ To retrieve resource contents, clients send a `resources/read` request:
 Resource templates allow servers to expose parameterized resources using
 [URI templates](https://datatracker.ietf.org/doc/html/rfc6570). Arguments may be
 auto-completed through [the completion API](/specification/2025-06-18/server/utilities/completion).
+This operation supports [pagination](/specification/2025-06-18/server/utilities/pagination).
 
 **Request:**
 
@@ -172,7 +173,10 @@ auto-completed through [the completion API](/specification/2025-06-18/server/uti
 {
   "jsonrpc": "2.0",
   "id": 3,
-  "method": "resources/templates/list"
+  "method": "resources/templates/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
 }
 ```
 
@@ -191,7 +195,8 @@ auto-completed through [the completion API](/specification/2025-06-18/server/uti
         "description": "Access files in the project directory",
         "mimeType": "application/octet-stream"
       }
-    ]
+    ],
+    "nextCursor": "next-page-cursor"
   }
 }
 ```

--- a/docs/specification/draft/server/resources.mdx
+++ b/docs/specification/draft/server/resources.mdx
@@ -170,6 +170,7 @@ To retrieve resource contents, clients send a `resources/read` request:
 Resource templates allow servers to expose parameterized resources using
 [URI templates](https://datatracker.ietf.org/doc/html/rfc6570). Arguments may be
 auto-completed through [the completion API](/specification/draft/server/utilities/completion).
+This operation supports [pagination](/specification/draft/server/utilities/pagination).
 
 **Request:**
 
@@ -177,7 +178,10 @@ auto-completed through [the completion API](/specification/draft/server/utilitie
 {
   "jsonrpc": "2.0",
   "id": 3,
-  "method": "resources/templates/list"
+  "method": "resources/templates/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
 }
 ```
 
@@ -203,7 +207,8 @@ auto-completed through [the completion API](/specification/draft/server/utilitie
           }
         ]
       }
-    ]
+    ],
+    "nextCursor": "next-page-cursor"
   }
 }
 ```


### PR DESCRIPTION
## Summary
- Updated resource templates documentation to show that `resources/templates/list` supports pagination
- Matched the format used in the "Listing Resources" section for consistency
- Applied changes across all specification versions (2024-11-05, 2025-03-26, 2025-06-18, and draft)

## Changes
- Added pagination note to Resource Templates section
- Added `cursor` parameter to request examples
- Added `nextCursor` field to response examples

This brings the documentation in line with the spec definition of `ListResourceTemplatesRequest` which allows an optional cursor parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code), but validated by the human @maxisbey.

If we don't want to update the old spec docs as well lemme know.