### PR TITLE
Add recommendation for `X-Accel-Buffering: no` header on SSE streams

### DIFF
--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -264,7 +264,7 @@ If the server receives a request with an invalid or unsupported
 
 When initiating SSE streams, servers **SHOULD** include the `X-Accel-Buffering: no`
 header in HTTP responses that return `Content-Type: text/event-stream`. This header
-instructs reverse proxies (such as Nginx) to disable response buffering, ensuring that
+instructs reverse proxies (such as nginx) to disable response buffering, ensuring that
 SSE events are delivered to clients immediately rather than being held in a buffer.
 Without this header, proxies may accumulate messages before sending them to the client,
 introducing unwanted latency and potentially breaking the real-time nature of SSE


### PR DESCRIPTION
Add guidance that servers SHOULD include the `X-Accel-Buffering: no` header in HTTP responses that initiate SSE streams. This ensures reverse proxies do not buffer SSE events, maintaining real-time delivery to clients.

🤖 Generated with Claude Code

## Motivation and Context
Without this header, some proxies (such as Nginx) will buffer responses, preventing real-time delivery of updates.

This has been asked for in our SDKs:
* https://github.com/modelcontextprotocol/java-sdk/issues/293

And is also an extremely common issue across other server frameworks that use SSE e.g.:
* https://github.com/pocketbase/pocketbase/issues/488
* https://github.com/ChilliCream/graphql-platform/issues/7084
* https://github.com/apollographql/router/issues/3683

Everyone fixes this independently: https://github.com/search?q=X-Accel-Buffering%3A+no&type=commits

The header is documented [here](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering).

Rather than waiting for users of all our SDKs to independently discover and report this issue, I'm proposing we explicit call out this guidance in the spec. It's a common failure scenario, so worth highlighting.

## How Has This Been Tested?
Not tested explicitly in MCP, but it's well understood.

## Breaking Changes
Not breaking. The header is harmless for proxies that don't understand it.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed
