### PR TITLE
Fix CTA button color on landing page

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -578,6 +578,7 @@ body:has(#schema-reference) {
     border-radius: 9999px;
 
     border: 6px solid var(--highlight-color);
+    background: #0e0e10;
     color: white;
 
     font-size: 1.5rem;


### PR DESCRIPTION
This commit fixes white-on-white text in the landing page's CTA button when using light mode.

The background color of the button was removed in 3d9d8fba75a88a8050d640495169730e975298b9, but the white-on-white text was prevented due to a typo (a missing semi-colon).  The typo was subsequently fixed in fdac46e61c77d403607ac2a0a23940800974a929.

| Before | After |
| --- | --- |
| <img width="252" height="89" alt="before-1" src="https://github.com/user-attachments/assets/5bac5ff1-75fb-45cf-83b9-cb32f66d802b" /> |<img width="252" height="89" alt="after-1" src="https://github.com/user-attachments/assets/f92eee7a-0b54-47c7-b6db-6a73dbcdc068" /> |
| <img width="252" height="89" alt="before-2" src="https://github.com/user-attachments/assets/9cff24a1-9cc8-45d9-8f4d-b20defa23912" /> | <img width="252" height="89" alt="after-2" src="https://github.com/user-attachments/assets/b62499a3-b300-45ce-9464-0307c3e2fee9" /> |
