### PR TITLE
fix: update primary-cta for visible text in lightmode

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -578,7 +578,7 @@ body:has(#schema-reference) {
     border-radius: 9999px;
 
     border: 6px solid var(--highlight-color);
-    color: white;
+    color: light-dark(#111827, #e5e7eb);
 
     font-size: 1.5rem;
     font-weight: 700;
@@ -586,6 +586,7 @@ body:has(#schema-reference) {
     transition: all 0.3s;
 
     &:hover {
+      color: white;
       background: var(--highlight-color);
     }
   }


### PR DESCRIPTION
Fixing white-text on white-background bug on `cta-primary` style.

<!-- Provide a brief summary of your changes -->

## Motivation and Context

The button text is not visible in lightmode

## How Has This Been Tested?

Made the changes via console, as it's very straightforward.

## Breaking Changes

None

## Additional context

Minor style change