### PR TITLE
fix jsonrpc id in ping doc to int

### DIFF
--- a/docs/specification/draft/basic/utilities/ping.mdx
+++ b/docs/specification/draft/basic/utilities/ping.mdx
@@ -21,7 +21,7 @@ A ping request is a standard JSON-RPC request with no parameters:
 ```json
 {
   "jsonrpc": "2.0",
-  "id": "123",
+  "id": 123,
   "method": "ping"
 }
 ```
@@ -33,7 +33,7 @@ A ping request is a standard JSON-RPC request with no parameters:
 ```json
 {
   "jsonrpc": "2.0",
-  "id": "123",
+  "id": 123,
   "result": {}
 }
 ```


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The type of "id" in jsonrpc should be int.  but the case in the ping part of documentation is string "123".

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
a simeple fix of documentation.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
