### PR TITLE
Rename Client Implementor Interest Group section

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -126,7 +126,7 @@ This document lists current maintainers in the Model Context Protocol project.
 - [Darin McAdams](https://github.com/D-McAdams)
 - [Paul Carleton](https://github.com/pcarleton)
 
-### Client Implementor Interest Group
+### Client Implementor Working Group
 
 **Note:** These individuals serve as MCP protocol representatives for their respective clients. For client-specific issues, use the official support channels provided by each product.
 


### PR DESCRIPTION
Updated the title of the Client Implementor Interest Group to Client Implementor Working Group.

<!-- Provide a brief summary of your changes -->

## Motivation and Context

There is a [proposal being discussed in the `#wg-ig-group-creation` Discord channel](https://discord.com/channels/1358869848138059966/1421635794099109888) to separate the broader Interest Group from a more limited Working Group.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
