### PR TITLE
fix the sequence diagram, client should open the SSE stream first.

### DIFF
--- a/docs/specification/2025-06-18/server/prompts.mdx
+++ b/docs/specification/2025-06-18/server/prompts.mdx
@@ -161,9 +161,8 @@ sequenceDiagram
     Server-->>Client: Prompt content
 
     opt listChanged
-      Client->>+Server: GET /mcp<br>(starts background SSE stream)
       Note over Client,Server: Changes
-      Server--)Client: prompts/list_changed<br>(notification on background SSE stream)
+      Server--)Client: prompts/list_changed
       Client->>Server: prompts/list
       Server-->>Client: Updated prompts
     end

--- a/docs/specification/draft/server/prompts.mdx
+++ b/docs/specification/draft/server/prompts.mdx
@@ -168,8 +168,9 @@ sequenceDiagram
     Server-->>Client: Prompt content
 
     opt listChanged
+      Client->>+Server: GET /mcp<br>(starts background SSE stream)
       Note over Client,Server: Changes
-      Server--)Client: prompts/list_changed
+      Server--)Client: prompts/list_changed<br>(notification on background SSE stream)
       Client->>Server: prompts/list
       Server-->>Client: Updated prompts
     end


### PR DESCRIPTION
Client should open the SSE stream first, then server can send prompts/list_changed notification.

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
the sequence diagram for Prompts feature is not completed.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed
