### PR TITLE
add description of authorization extensions to main authorization spec page

### DIFF
--- a/docs/specification/draft/basic/authorization.mdx
+++ b/docs/specification/draft/basic/authorization.mdx
@@ -714,4 +714,3 @@ There are several authorization extensions to the core protocol that define addi
 - **Versioned independently** - Extensions follow the core MCP versioning cycle but may adopt independent versioning as needed
 
 A list of supported extensions can be found in the [MCP Authorization Extensions](https://github.com/modelcontextprotocol/ext-auth) repository.
-


### PR DESCRIPTION
## Motivation and Context
Authorization extensions were adopted in #1502. This PR adds a description of authorization extensions and link to the new github from the main authorization page.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
