### PR TITLE
Add rust example in Build an MCP server page

### DIFF
--- a/docs/docs/develop/build-server.mdx
+++ b/docs/docs/develop/build-server.mdx
@@ -1881,7 +1881,7 @@ Update your `Cargo.toml` to add the required dependencies:
 [package]
 name = "weather"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 rmcp = { version = "0.3", features = ["server", "macros", "transport-io"] }


### PR DESCRIPTION
Add rust mcp server example in `Build an MCP server` page.
The rust mcp implementation is already merged in the [quickstart-resources ](https://github.com/modelcontextprotocol/quickstart-resources) repo. See https://github.com/modelcontextprotocol/quickstart-resources/pull/43

## How Has This Been Tested?
Run the following commands to ensure everything looks good: 
```
npm run check:docs
npm run format
```

This is the page after running:
```
npm run serve:docs
```

NOTE: The screenshot is too long, causing it to appear distorted. Click into it to see the details.

<img width="1618" height="29432" alt="rust-mcp-server" src="https://github.com/user-attachments/assets/31c01118-deda-4762-8200-2569a705c7ff" />




## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

