### PR TITLE
Remove incorrect properties from ResourceContents

### DIFF
--- a/docs/specification/2025-06-18/server/resources.mdx
+++ b/docs/specification/2025-06-18/server/resources.mdx
@@ -312,6 +312,8 @@ Example resource with annotations:
 ```json
 {
   "uri": "file:///project/README.md",
+  "name": "README.md",
+  "title": "Project Documentation",
   "mimeType": "text/markdown",
   "annotations": {
     "audience": ["user"],


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Remove `name` and `title` fields from ResourceContents examples in the resources/read response documentation. These fields are part of the Resource type (used in resources/list) but not ResourceContents (used in resources/read), as defined in the schema.

## Motivation and Context
Extra fields in the documentation are confusing.

## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [n/a] My code follows the repository's style guidelines
- [n/a] New and existing tests pass locally
- [n/a] I have added appropriate error handling
- [n/a] I have added or updated documentation as needed

## Additional context
N/A
