### PR TITLE
Update _meta prefix reservation to recommend reverse DNS

### DIFF
--- a/docs/specification/draft/basic/index.mdx
+++ b/docs/specification/draft/basic/index.mdx
@@ -139,9 +139,10 @@ may reserve particular names for purpose-specific metadata, as declared in those
 
 - If specified, MUST be a series of labels separated by dots (`.`), followed by a slash (`/`).
   - Labels MUST start with a letter and end with a letter or digit; interior characters can be letters, digits, or hyphens (`-`).
-- Any prefix beginning with zero or more valid labels, followed by `modelcontextprotocol` or `mcp`, followed by any valid label,
-  is **reserved** for MCP use.
-  - For example: `modelcontextprotocol.io/`, `mcp.dev/`, `api.modelcontextprotocol.org/`, and `tools.mcp.com/` are all reserved.
+  - Implementations SHOULD use reverse DNS notation (e.g., `com.example/` rather than `example.com/`).
+- Any prefix where the second label is `modelcontextprotocol` or `mcp` is **reserved** for MCP use.
+  - For example: `io.modelcontextprotocol/`, `dev.mcp/`, `org.modelcontextprotocol.api/`, and `com.mcp.tools/` are all reserved.
+  - However, `com.example.mcp/` is NOT reserved, as the second label is `example`.
 
 **Name:**
 


### PR DESCRIPTION
Update the _meta specification to recommend reverse DNS to align with what the registry does. Additionally has benefits of not being confused with actual working URLs and allows for grouping via lexicographic sorting.

Additionally updates reserved names to assume reverse DNS (so we reserve second labels that are `modelcontextprotocol` or `mcp`).

**Unclear**: should we also continue to reserve names that are in forward DNS? It's a bit tricky because I might legitimately have a service that is `dev.mcp.example.com` in forward DNS but in reverse DNS this is `com.example.mcp.dev` which was reserved by the old rules!

## Motivation and Context
See https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1686#issuecomment-3479007568

## How Has This Been Tested?
N/A

## Breaking Changes
_Probably_ not breaking since it is just a SHOULD, however if someone has a service that was (using forward DNS) `dev.mcp.example.com` and was using that in a _meta field, technically they are now using a reserved name.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [~] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
N/A
