### PR TITLE
Fix `scroll-margin-top` for schema reference page

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -168,7 +168,7 @@ body:has(#schema-reference) {
       font-family: var(--font-mono);
       font-weight: 700;
 
-      scroll-margin-top: 5rem;
+      scroll-margin-top: 8rem;
     }
 
     & > .tsd-comment,


### PR DESCRIPTION
When navigating to a particular type member on the schema reference page, the sitewide tab bar overlaps the target content.

This commit adjusts the CSS `scroll-margin-top` property so that the target content is positioned just below the tab bar.

For example, when navigating to https://modelcontextprotocol.io/specification/2025-06-18/schema#annotations-audience:

| Before | After |
| --- | --- |
| <img width="1508" height="746" alt="before" src="https://github.com/user-attachments/assets/f2070405-4877-4176-8ba1-2b130940e1fa" /> | <img width="1508" height="746" alt="after" src="https://github.com/user-attachments/assets/656dbac9-8ef2-447c-80b9-bd81438d7a7e" /> |
