### PR TITLE
Change model from claude-3-5-sonnet-20241022 to claude-sonnet-4-20250514

### DIFF
--- a/docs/docs/develop/build-client.mdx
+++ b/docs/docs/develop/build-client.mdx
@@ -178,7 +178,7 @@ async def process_query(self, query: str) -> str:
 
     # Initial Claude API call
     response = self.anthropic.messages.create(
-        model="claude-3-5-sonnet-20241022",
+        model="claude-sonnet-4-20250514",
         max_tokens=1000,
         messages=messages,
         tools=available_tools
@@ -218,7 +218,7 @@ async def process_query(self, query: str) -> str:
 
             # Get next response from Claude
             response = self.anthropic.messages.create(
-                model="claude-3-5-sonnet-20241022",
+                model="claude-sonnet-4-20250514",
                 max_tokens=1000,
                 messages=messages,
                 tools=available_tools
@@ -647,7 +647,7 @@ async processQuery(query: string) {
   ];
 
   const response = await this.anthropic.messages.create({
-    model: "claude-3-5-sonnet-20241022",
+    model: "claude-sonnet-4-20250514",
     max_tokens: 1000,
     messages,
     tools: this.tools,
@@ -676,7 +676,7 @@ async processQuery(query: string) {
       });
 
       const response = await this.anthropic.messages.create({
-        model: "claude-3-5-sonnet-20241022",
+        model: "claude-sonnet-4-20250514",
         max_tokens: 1000,
         messages,
       });
@@ -1565,7 +1565,7 @@ using var anthropicClient = new AnthropicClient(new APIAuthentication(builder.Co
 var options = new ChatOptions
 {
     MaxOutputTokens = 1000,
-    ModelId = "claude-3-5-sonnet-20241022",
+    ModelId = "claude-sonnet-4-20250514",
     Tools = [.. tools]
 };
 

--- a/docs/tutorials/building-a-client-node.mdx
+++ b/docs/tutorials/building-a-client-node.mdx
@@ -192,7 +192,7 @@ Now add the core functionality for processing queries and handling tool calls:
 
     const finalText: string[] = [];
     let currentResponse = await this.anthropic.messages.create({
-      model: "claude-3-5-sonnet-20241022",
+      model: "claude-sonnet-4-20250514",
       max_tokens: 1000,
       messages,
       tools: availableTools,
@@ -246,7 +246,7 @@ Now add the core functionality for processing queries and handling tool calls:
 
           // Get next response from Claude with tool results
           currentResponse = await this.anthropic.messages.create({
-            model: "claude-3-5-sonnet-20241022",
+            model: "claude-sonnet-4-20250514",
             max_tokens: 1000,
             messages,
             tools: availableTools,


### PR DESCRIPTION
When following the tutorials, you get an error because the model (claude-3-5-sonnet-20241022) is not supported anymore. 

```
 NotFoundError: 404 {"type":"error","error":{"type":"not_found_error","message":"model: claude-3-5-sonnet-20241022"},"request_id":"req_011CUtiLv644LpAmtQLvbyMJ"}
    at APIError.generate (file:///Users/jilles/Cloudflare/mcp-11-11/mcp-io-client/node_modules/.pnpm/@anthropic-ai+sdk@0.68.0_zod@3.25.76/node_modules/@anthropic-ai/sdk/core/error.mjs:46:20)
    at Anthropic.makeStatusError (file:///Users/jilles/Cloudflare/mcp-11-11/mcp-io-client/node_modules/.pnpm/@anthropic-ai+sdk@0.68.0_zod@3.25.76/node_modules/@anthropic-ai/sdk/client.mjs:152:32)
    at Anthropic.makeRequest (file:///Users/jilles/Cloudflare/mcp-11-11/mcp-io-client/node_modules/.pnpm/@anthropic-ai+sdk@0.68.0_zod@3.25.76/node_modules/@anthropic-ai/sdk/client.mjs:306:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async MCPClient.processQuery (file:///Users/jilles/Cloudflare/mcp-11-11/mcp-io-client/build/index.js:65:26)
    at async MCPClient.chatLoop (file:///Users/jilles/Cloudflare/mcp-11-11/mcp-io-client/build/index.js:112:38)
    at async main (file:///Users/jilles/Cloudflare/mcp-11-11/mcp-io-client/build/index.js:136:9) {
  status: 404,
```

## Motivation and Context
This change is needed so that anyone following this tutorial can run the code without issues. I found the next Sonnet model name by doing https://docs.claude.com/en/api/models-list

## How Has This Been Tested?
I replaced the model with claude-sonnet-4-20250514 and ran the MCP Server and Client.

## Breaking Changes
None (that I know of)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
I found this out by adding a `try/catch` around the `this.processQuery` call in https://modelcontextprotocol.io/docs/develop/build-client#interactive-chat-interface-2 

First, I got "insufficient anthropic credits" (so people might also but running into that). Then I topped up $5 and got the model error. 

I'd be happy to update the `try/catch` in the docs to include that change too, but that would increase the scope of this small PR. 
