### PR TITLE
SEP-1699: Support SSE polling via server-side disconnect

### DIFF
--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -103,16 +103,26 @@ MCP endpoint.
    `Content-Type: application/json`, to return one JSON object. The client **MUST**
    support both these cases.
 6. If the server initiates an SSE stream:
-   - The SSE stream **SHOULD** eventually include JSON-RPC _response_ for the
+   - The server **SHOULD** immediately send an SSE event consisting of an event
+     ID and an empty `data` field in order to prime the client to reconnect
+     (using that event ID as `Last-Event-ID`).
+   - After the server has sent an SSE event with an event ID to the client, the
+     server **MAY** close the _connection_ (without terminating the _SSE stream_)
+     at any time in order to avoid holding a long-lived connection. The client
+     **SHOULD** then "poll" the SSE stream by attempting to reconnect.
+   - If the server does close the _connection_ prior to terminating the _SSE stream_,
+     it **SHOULD** send an SSE event with a standard `retry` field before
+     closing the connection. The client **MUST** respect the `retry` field,
+     waiting the given number of milliseconds before attempting to reconnect.
+   - The SSE stream **SHOULD** eventually include a JSON-RPC _response_ for the
      JSON-RPC _request_ sent in the POST body.
    - The server **MAY** send JSON-RPC _requests_ and _notifications_ before sending the
      JSON-RPC _response_. These messages **SHOULD** relate to the originating client
      _request_.
-   - The server **SHOULD NOT** close the SSE stream before sending the JSON-RPC _response_
-     for the received JSON-RPC _request_, unless the [session](#session-management)
+   - The server **MAY** terminate the SSE stream if the [session](#session-management)
      expires.
-   - After the JSON-RPC _response_ has been sent, the server **SHOULD** close the SSE
-     stream.
+   - After the JSON-RPC _response_ has been sent, the server **SHOULD** terminate the
+     SSE stream.
    - Disconnection **MAY** occur at any time (e.g., due to network conditions).
      Therefore:
      - Disconnection **SHOULD NOT** be interpreted as the client cancelling its request.

--- a/docs/specification/draft/changelog.mdx
+++ b/docs/specification/draft/changelog.mdx
@@ -19,6 +19,7 @@ the previous revision, [2025-06-18](/specification/2025-06-18).
 1. Clarify that servers must respond with HTTP 403 Forbidden for invalid Origin headers in Streamable HTTP transport. (PR [#1439](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1439))
 2. Updated the [Security Best Practices guidance](https://modelcontextprotocol.io/specification/draft/basic/security_best_practices).
 3. Clarify that input validation errors should be returned as Tool Execution Errors rather than Protocol Errors to enable model self-correction ([SEP-1303](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1303)).
+4. Support polling SSE streams by allowing servers to disconnect at will ([SEP-1699](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1699)).
 
 ## Other schema changes
 


### PR DESCRIPTION
This implements the specification changes for [SEP-1699](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1699):

* When a server starts an SSE stream, it MUST immediately send an SSE event consisting of an [`id`][SSE `id`] and an empty [`data`][SSE `data`] string in order to prime the client to reconnect with that event ID as the `Last-Event-ID`.

  Note that the SSE standard explicitly [permits setting `data` to an empty string][SSE empty `data`], and says that the appropriate client-side handling is to record the `id` for `Last-Event-ID` but otherwise ignore the event (i.e., not call the event handler callback).

* At any point after the server has sent an event ID to the client, the server MAY disconnect at will.

* If a server disconnects, the client will interpret the disconnection the same as a network failure, and will attempt to reconnect.  In order to prevent clients from reconnecting / polling excessively, the server SHOULD send an SSE event with a [`retry`][SSE `retry`] field indicating how long the client should wait before reconnecting. Clients MUST respect the `retry` field.

[SSE `id`]: https://html.spec.whatwg.org/multipage/server-sent-events.html#:~:text=field%20name%20is%20%22id%22
[SSE `data`]: https://html.spec.whatwg.org/multipage/server-sent-events.html#:~:text=field%20name%20is%20%22data%22
[SSE empty `data`]: https://html.spec.whatwg.org/multipage/server-sent-events.html#:~:text=data%20buffer%20is%20an%20empty%20string
[SSE `retry`]: https://html.spec.whatwg.org/multipage/server-sent-events.html#:~:text=field%20name%20is%20%22retry%22
