### PR TITLE
Fix typo in CODEOWNERS documentation ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CODEOWNERS file for MCP Specification repository
 
 # General documentation ownership - @modelcontextprotocol/docs-maintaners and core-maintainers own all of /docs
-/docs/ @modelcontextprotocol/docs-maintaners @modelcontextprotocol/core-maintainers
+/docs/ @modelcontextprotocol/docs-maintainers @modelcontextprotocol/core-maintainers
 
 # Specific ownership - @core-maintainer team owns docs/specification and schema/ directories
 /docs/specification/ @modelcontextprotocol/core-maintainers


### PR DESCRIPTION
## Motivation and Context

Somehow added a typo to the docs approver rules for the existing docs-maintainers group.

## How Has This Been Tested?

Copied and pasted real group name.

## Breaking Changes

No

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

