### PR TITLE
Clarify actor: MCP servers MUST only accept tokens valid for their protected resources

### DIFF
--- a/docs/specification/draft/basic/authorization.mdx
+++ b/docs/specification/draft/basic/authorization.mdx
@@ -355,7 +355,7 @@ response.
 
 MCP clients **MUST NOT** send tokens to the MCP server other than ones issued by the MCP server's authorization server.
 
-MCP servers **MUST** only accept tokens that are valid for use with their own resources, 
+MCP servers **MUST** only accept tokens that are valid for use with their own resources,
 and **MUST NOT** accept or transit any other tokens.
 
 ### Error Handling


### PR DESCRIPTION
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
In the original specificiation text,

> Authorization servers **MUST** only accept tokens that are valid for use with their own resources.

Here, `authorization server` serves as the actor to accept tokens. However, it is the `MCP server` that MUST validate access tokens as described in [OAuth 2.1 Section 5.2](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-5.2), and having "own resources". This could be a potential typo.

## Modification

To clarify the actor, the specification is corrected as

> MCP servers **MUST** only accept tokens that are valid for use with their own resources,  and **MUST NOT** accept or transit any other tokens.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
