### PR TITLE
Fix documentation format error

### DIFF
--- a/docs/docs/develop/build-client.mdx
+++ b/docs/docs/develop/build-client.mdx
@@ -319,11 +319,13 @@ You can find the complete `client.py` file [here](https://github.com/modelcontex
 ## Common Customization Points
 
 1. **Tool Handling**
+
    - Modify `process_query()` to handle specific tool types
    - Add custom error handling for tool calls
    - Implement tool-specific response formatting
 
 2. **Response Processing**
+
    - Customize how tool results are formatted
    - Add response filtering or transformation
    - Implement custom logging
@@ -378,16 +380,19 @@ When you submit a query:
 ## Best practices
 
 1. **Error Handling**
+
    - Always wrap tool calls in try-catch blocks
    - Provide meaningful error messages
    - Gracefully handle connection issues
 
 2. **Resource Management**
+
    - Use `AsyncExitStack` for proper cleanup
    - Close connections when done
    - Handle server disconnections
 
 3. **Security**
+
    - Store API keys securely in `.env`
    - Validate server responses
    - Be cautious with tool permissions
@@ -790,6 +795,7 @@ When you submit a query:
 ## Best practices
 
 1. **Error Handling**
+
    - Use TypeScript's type system for better error detection
    - Wrap tool calls in try-catch blocks
    - Provide meaningful error messages
@@ -1397,6 +1403,7 @@ When you submit a query:
 ## Best practices
 
 1. **Error Handling**
+
    - Leverage Kotlin's type system to model errors explicitly
    - Wrap external tool and API calls in `try-catch` blocks when exceptions are possible
    - Provide clear and meaningful error messages

--- a/docs/docs/learn/architecture.mdx
+++ b/docs/docs/learn/architecture.mdx
@@ -366,6 +366,7 @@ The request structure includes several important components:
 1. **`name`**: Must match exactly the tool name from the discovery response (`weather_current`). This ensures the server can correctly identify which tool to execute.
 
 2. **`arguments`**: Contains the input parameters as defined by the tool's `inputSchema`. In this example:
+
    - `location`: "San Francisco" (required parameter)
    - `units`: "imperial" (optional parameter, defaults to "metric" if not specified)
 

--- a/docs/docs/learn/server-concepts.mdx
+++ b/docs/docs/learn/server-concepts.mdx
@@ -260,6 +260,7 @@ Consider a personalized AI travel planner application, with three connected serv
    ```
 
 2. **User selects resources to include:**
+
    - `calendar://my-calendar/June-2024` (from Calendar Server)
    - `travel://preferences/europe` (from Travel Server)
    - `travel://past-trips/Spain-2023` (from Travel Server)
@@ -269,10 +270,12 @@ Consider a personalized AI travel planner application, with three connected serv
    The AI first reads all selected resources to gather context - identifying available dates from the calendar, learning preferred airlines and hotel types from travel preferences, and discovering previously enjoyed locations from past trips.
 
    Using this context, the AI then executes a series of Tools:
+
    - `searchFlights()` - Queries airlines for NYC to Barcelona flights
    - `checkWeather()` - Retrieves climate forecasts for travel dates
 
    The AI then uses this information to create the booking and following steps, requesting approval from the user where necessary:
+
    - `bookHotel()` - Finds hotels within the specified budget
    - `createCalendarEvent()` - Adds the trip to the user's calendar
    - `sendEmail()` - Sends confirmation with trip details

--- a/docs/docs/tools/inspector.mdx
+++ b/docs/docs/tools/inspector.mdx
@@ -119,11 +119,13 @@ The Inspector provides several features for interacting with your MCP server:
 ### Development workflow
 
 1. Start Development
+
    - Launch Inspector with your server
    - Verify basic connectivity
    - Check capability negotiation
 
 2. Iterative testing
+
    - Make server changes
    - Rebuild the server
    - Reconnect the Inspector

--- a/docs/legacy/concepts/architecture.mdx
+++ b/docs/legacy/concepts/architecture.mdx
@@ -105,6 +105,7 @@ Key classes include:
 The transport layer handles the actual communication between clients and servers. MCP supports multiple transport mechanisms:
 
 1. **Stdio transport**
+
    - Uses standard input/output for communication
    - Ideal for local processes
 
@@ -287,6 +288,7 @@ if __name__ == "__main__":
 ### Transport selection
 
 1. **Local communication**
+
    - Use stdio transport for local processes
    - Efficient for same-machine communication
    - Simple process management
@@ -298,12 +300,14 @@ if __name__ == "__main__":
 ### Message handling
 
 1. **Request processing**
+
    - Validate inputs thoroughly
    - Use type-safe schemas
    - Handle errors gracefully
    - Implement timeouts
 
 2. **Progress reporting**
+
    - Use progress tokens for long operations
    - Report progress incrementally
    - Include total progress when known
@@ -316,17 +320,20 @@ if __name__ == "__main__":
 ## Security considerations
 
 1. **Transport security**
+
    - Use TLS for remote connections
    - Validate connection origins
    - Implement authentication when needed
 
 2. **Message validation**
+
    - Validate all incoming messages
    - Sanitize inputs
    - Check message size limits
    - Verify JSON-RPC format
 
 3. **Resource protection**
+
    - Implement access controls
    - Validate resource paths
    - Monitor resource usage
@@ -341,12 +348,14 @@ if __name__ == "__main__":
 ## Debugging and monitoring
 
 1. **Logging**
+
    - Log protocol events
    - Track message flow
    - Monitor performance
    - Record errors
 
 2. **Diagnostics**
+
    - Implement health checks
    - Monitor connection state
    - Track resource usage

--- a/docs/legacy/concepts/sampling.mdx
+++ b/docs/legacy/concepts/sampling.mdx
@@ -77,6 +77,7 @@ The `messages` array contains the conversation history to send to the LLM. Each 
 The `modelPreferences` object allows servers to specify their model selection preferences:
 
 - `hints`: Array of model name suggestions that clients can use to select an appropriate model:
+
   - `name`: String that can match full or partial model names (e.g. "claude-3", "sonnet")
   - Clients may map hints to equivalent models from different providers
   - Multiple hints are evaluated in preference order

--- a/docs/legacy/tools/debugging.mdx
+++ b/docs/legacy/tools/debugging.mdx
@@ -16,11 +16,13 @@ This guide is for macOS. Guides for other platforms are coming soon.
 MCP provides several tools for debugging at different levels:
 
 1. **MCP Inspector**
+
    - Interactive debugging interface
    - Direct server testing
    - See the [Inspector guide](/docs/tools/inspector) for details
 
 2. **Claude Desktop Developer Tools**
+
    - Integration testing
    - Log collection
    - Chrome DevTools integration
@@ -37,6 +39,7 @@ MCP provides several tools for debugging at different levels:
 The Claude.app interface provides basic server status information:
 
 1. Click the <img src="/images/claude-desktop-mcp-plug-icon.svg" style={{display: 'inline', margin: 0, height: '1.3em'}} /> icon to view:
+
    - Connected servers
    - Available prompts and resources
 
@@ -130,12 +133,14 @@ To override the default variables or provide your own, you can specify an `env` 
 Common initialization problems:
 
 1. **Path Issues**
+
    - Incorrect server executable path
    - Missing required files
    - Permission problems
    - Try using an absolute path for `command`
 
 2. **Configuration Errors**
+
    - Invalid JSON syntax
    - Missing required fields
    - Type mismatches
@@ -208,6 +213,7 @@ In client applications:
 ### Development cycle
 
 1. Initial Development
+
    - Use [Inspector](/legacy/tools/inspector) for basic testing
    - Implement core functionality
    - Add logging points
@@ -230,12 +236,14 @@ To test changes efficiently:
 ### Logging strategy
 
 1. **Structured Logging**
+
    - Use consistent formats
    - Include context
    - Add timestamps
    - Track request IDs
 
 2. **Error Handling**
+
    - Log stack traces
    - Include error context
    - Track error patterns
@@ -252,6 +260,7 @@ To test changes efficiently:
 When debugging:
 
 1. **Sensitive Data**
+
    - Sanitize logs
    - Protect credentials
    - Mask personal information
@@ -266,12 +275,14 @@ When debugging:
 When encountering issues:
 
 1. **First Steps**
+
    - Check server logs
    - Test with [Inspector](/legacy/tools/inspector)
    - Review configuration
    - Verify environment
 
 2. **Support Channels**
+
    - GitHub issues
    - GitHub discussions
 

--- a/docs/specification/2024-11-05/architecture/index.mdx
+++ b/docs/specification/2024-11-05/architecture/index.mdx
@@ -83,12 +83,14 @@ MCP is built on several key design principles that inform its architecture and
 implementation:
 
 1. **Servers should be extremely easy to build**
+
    - Host applications handle complex orchestration responsibilities
    - Servers focus on specific, well-defined capabilities
    - Simple interfaces minimize implementation overhead
    - Clear separation enables maintainable code
 
 2. **Servers should be highly composable**
+
    - Each server provides focused functionality in isolation
    - Multiple servers can be combined seamlessly
    - Shared protocol enables interoperability
@@ -96,6 +98,7 @@ implementation:
 
 3. **Servers should not be able to read the whole conversation, nor "see into" other
    servers**
+
    - Servers receive only necessary contextual information
    - Full conversation history stays with the host
    - Each server connection maintains isolation

--- a/docs/specification/2024-11-05/basic/utilities/progress.mdx
+++ b/docs/specification/2024-11-05/basic/utilities/progress.mdx
@@ -56,6 +56,7 @@ The receiver **MAY** then send progress notifications containing:
 ## Behavior Requirements
 
 1. Progress notifications **MUST** only reference tokens that:
+
    - Were provided in an active request
    - Are associated with an in-progress operation
 

--- a/docs/specification/2024-11-05/client/roots.mdx
+++ b/docs/specification/2024-11-05/client/roots.mdx
@@ -165,6 +165,7 @@ Example error:
 ## Security Considerations
 
 1. Clients **MUST**:
+
    - Only expose roots with appropriate permissions
    - Validate all root URIs to prevent path traversal
    - Implement proper access controls
@@ -178,6 +179,7 @@ Example error:
 ## Implementation Guidelines
 
 1. Clients **SHOULD**:
+
    - Prompt users for consent before exposing roots to servers
    - Provide clear user interfaces for root management
    - Validate root accessibility before exposing

--- a/docs/specification/2024-11-05/index.mdx
+++ b/docs/specification/2024-11-05/index.mdx
@@ -80,16 +80,19 @@ considerations that all implementors must carefully address.
 ### Key Principles
 
 1. **User Consent and Control**
+
    - Users must explicitly consent to and understand all data access and operations
    - Users must retain control over what data is shared and what actions are taken
    - Implementors should provide clear UIs for reviewing and authorizing activities
 
 2. **Data Privacy**
+
    - Hosts must obtain explicit user consent before exposing user data to servers
    - Hosts must not transmit resource data elsewhere without user consent
    - User data should be protected with appropriate access controls
 
 3. **Tool Safety**
+
    - Tools represent arbitrary code execution and must be treated with appropriate
      caution
    - Hosts must obtain explicit user consent before invoking any tool

--- a/docs/specification/2024-11-05/server/tools.mdx
+++ b/docs/specification/2024-11-05/server/tools.mdx
@@ -231,6 +231,7 @@ or fetched again by the client later:
 Tools use two error reporting mechanisms:
 
 1. **Protocol Errors**: Standard JSON-RPC errors for issues like:
+
    - Unknown tools
    - Invalid arguments
    - Server errors
@@ -274,6 +275,7 @@ Example tool execution error:
 ## Security Considerations
 
 1. Servers **MUST**:
+
    - Validate all tool inputs
    - Implement proper access controls
    - Rate limit tool invocations

--- a/docs/specification/2024-11-05/server/utilities/completion.mdx
+++ b/docs/specification/2024-11-05/server/utilities/completion.mdx
@@ -116,6 +116,7 @@ sequenceDiagram
 ## Implementation Considerations
 
 1. Servers **SHOULD**:
+
    - Return suggestions sorted by relevance
    - Implement fuzzy matching where appropriate
    - Rate limit completion requests

--- a/docs/specification/2024-11-05/server/utilities/logging.mdx
+++ b/docs/specification/2024-11-05/server/utilities/logging.mdx
@@ -115,6 +115,7 @@ Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
 ## Implementation Considerations
 
 1. Servers **SHOULD**:
+
    - Rate limit log messages
    - Include relevant context in data field
    - Use consistent logger names
@@ -129,6 +130,7 @@ Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
 ## Security
 
 1. Log messages **MUST NOT** contain:
+
    - Credentials or secrets
    - Personal identifying information
    - Internal system details that could aid attacks

--- a/docs/specification/2024-11-05/server/utilities/pagination.mdx
+++ b/docs/specification/2024-11-05/server/utilities/pagination.mdx
@@ -79,10 +79,12 @@ The following MCP operations support pagination:
 ## Implementation Guidelines
 
 1. Servers **SHOULD**:
+
    - Provide stable cursors
    - Handle invalid cursors gracefully
 
 2. Clients **SHOULD**:
+
    - Treat a missing `nextCursor` as the end of results
    - Support both paginated and non-paginated flows
 

--- a/docs/specification/2025-03-26/architecture/index.mdx
+++ b/docs/specification/2025-03-26/architecture/index.mdx
@@ -83,12 +83,14 @@ MCP is built on several key design principles that inform its architecture and
 implementation:
 
 1. **Servers should be extremely easy to build**
+
    - Host applications handle complex orchestration responsibilities
    - Servers focus on specific, well-defined capabilities
    - Simple interfaces minimize implementation overhead
    - Clear separation enables maintainable code
 
 2. **Servers should be highly composable**
+
    - Each server provides focused functionality in isolation
    - Multiple servers can be combined seamlessly
    - Shared protocol enables interoperability
@@ -96,6 +98,7 @@ implementation:
 
 3. **Servers should not be able to read the whole conversation, nor "see into" other
    servers**
+
    - Servers receive only necessary contextual information
    - Full conversation history stays with the host
    - Each server connection maintains isolation

--- a/docs/specification/2025-03-26/basic/utilities/progress.mdx
+++ b/docs/specification/2025-03-26/basic/utilities/progress.mdx
@@ -58,6 +58,7 @@ The receiver **MAY** then send progress notifications containing:
 ## Behavior Requirements
 
 1. Progress notifications **MUST** only reference tokens that:
+
    - Were provided in an active request
    - Are associated with an in-progress operation
 

--- a/docs/specification/2025-03-26/client/roots.mdx
+++ b/docs/specification/2025-03-26/client/roots.mdx
@@ -163,6 +163,7 @@ Example error:
 ## Security Considerations
 
 1. Clients **MUST**:
+
    - Only expose roots with appropriate permissions
    - Validate all root URIs to prevent path traversal
    - Implement proper access controls
@@ -176,6 +177,7 @@ Example error:
 ## Implementation Guidelines
 
 1. Clients **SHOULD**:
+
    - Prompt users for consent before exposing roots to servers
    - Provide clear user interfaces for root management
    - Validate root accessibility before exposing

--- a/docs/specification/2025-03-26/index.mdx
+++ b/docs/specification/2025-03-26/index.mdx
@@ -80,16 +80,19 @@ considerations that all implementors must carefully address.
 ### Key Principles
 
 1. **User Consent and Control**
+
    - Users must explicitly consent to and understand all data access and operations
    - Users must retain control over what data is shared and what actions are taken
    - Implementors should provide clear UIs for reviewing and authorizing activities
 
 2. **Data Privacy**
+
    - Hosts must obtain explicit user consent before exposing user data to servers
    - Hosts must not transmit resource data elsewhere without user consent
    - User data should be protected with appropriate access controls
 
 3. **Tool Safety**
+
    - Tools represent arbitrary code execution and must be treated with appropriate
      caution.
      - In particular, descriptions of tool behavior such as annotations should be

--- a/docs/specification/2025-03-26/server/tools.mdx
+++ b/docs/specification/2025-03-26/server/tools.mdx
@@ -246,6 +246,7 @@ or data, behind a URI that can be subscribed to or fetched again by the client l
 Tools use two error reporting mechanisms:
 
 1. **Protocol Errors**: Standard JSON-RPC errors for issues like:
+
    - Unknown tools
    - Invalid arguments
    - Server errors
@@ -289,6 +290,7 @@ Example tool execution error:
 ## Security Considerations
 
 1. Servers **MUST**:
+
    - Validate all tool inputs
    - Implement proper access controls
    - Rate limit tool invocations

--- a/docs/specification/2025-03-26/server/utilities/completion.mdx
+++ b/docs/specification/2025-03-26/server/utilities/completion.mdx
@@ -137,6 +137,7 @@ Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
 ## Implementation Considerations
 
 1. Servers **SHOULD**:
+
    - Return suggestions sorted by relevance
    - Implement fuzzy matching where appropriate
    - Rate limit completion requests

--- a/docs/specification/2025-03-26/server/utilities/logging.mdx
+++ b/docs/specification/2025-03-26/server/utilities/logging.mdx
@@ -115,6 +115,7 @@ Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
 ## Implementation Considerations
 
 1. Servers **SHOULD**:
+
    - Rate limit log messages
    - Include relevant context in data field
    - Use consistent logger names
@@ -129,6 +130,7 @@ Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
 ## Security
 
 1. Log messages **MUST NOT** contain:
+
    - Credentials or secrets
    - Personal identifying information
    - Internal system details that could aid attacks

--- a/docs/specification/2025-03-26/server/utilities/pagination.mdx
+++ b/docs/specification/2025-03-26/server/utilities/pagination.mdx
@@ -79,10 +79,12 @@ The following MCP operations support pagination:
 ## Implementation Guidelines
 
 1. Servers **SHOULD**:
+
    - Provide stable cursors
    - Handle invalid cursors gracefully
 
 2. Clients **SHOULD**:
+
    - Treat a missing `nextCursor` as the end of results
    - Support both paginated and non-paginated flows
 

--- a/docs/specification/2025-06-18/architecture/index.mdx
+++ b/docs/specification/2025-06-18/architecture/index.mdx
@@ -85,12 +85,14 @@ MCP is built on several key design principles that inform its architecture and
 implementation:
 
 1. **Servers should be extremely easy to build**
+
    - Host applications handle complex orchestration responsibilities
    - Servers focus on specific, well-defined capabilities
    - Simple interfaces minimize implementation overhead
    - Clear separation enables maintainable code
 
 2. **Servers should be highly composable**
+
    - Each server provides focused functionality in isolation
    - Multiple servers can be combined seamlessly
    - Shared protocol enables interoperability
@@ -98,6 +100,7 @@ implementation:
 
 3. **Servers should not be able to read the whole conversation, nor "see into" other
    servers**
+
    - Servers receive only necessary contextual information
    - Full conversation history stays with the host
    - Each server connection maintains isolation

--- a/docs/specification/2025-06-18/basic/security_best_practices.mdx
+++ b/docs/specification/2025-06-18/basic/security_best_practices.mdx
@@ -198,6 +198,7 @@ When you have multiple stateful HTTP servers that handle MCP requests, the follo
 
 1. The client connects to **Server A** and receives a session ID.
 1. The attacker obtains an existing session ID and sends a malicious event to **Server B** with said session ID.
+
    - When a server supports [redelivery/resumable streams](/specification/2025-06-18/basic/transports#resumability-and-redelivery), deliberately terminating the request before receiving the response could lead to it being resumed by the original client via the GET request for server sent events.
    - If a particular server initiates server sent events as a consequence of a tool call such as a `notifications/tools/list_changed`, where it is possible to affect the tools that are offered by the server, a client could end up with tools that they were not aware were enabled.
 

--- a/docs/specification/2025-06-18/basic/utilities/progress.mdx
+++ b/docs/specification/2025-06-18/basic/utilities/progress.mdx
@@ -60,6 +60,7 @@ The receiver **MAY** then send progress notifications containing:
 ## Behavior Requirements
 
 1. Progress notifications **MUST** only reference tokens that:
+
    - Were provided in an active request
    - Are associated with an in-progress operation
 

--- a/docs/specification/2025-06-18/client/elicitation.mdx
+++ b/docs/specification/2025-06-18/client/elicitation.mdx
@@ -301,10 +301,12 @@ Elicitation responses use a three-action model to clearly distinguish between di
 The three response actions are:
 
 1. **Accept** (`action: "accept"`): User explicitly approved and submitted with data
+
    - The `content` field contains the submitted data matching the requested schema
    - Example: User clicked "Submit", "OK", "Confirm", etc.
 
 2. **Decline** (`action: "decline"`): User explicitly declined the request
+
    - The `content` field is typically omitted
    - Example: User clicked "Reject", "Decline", "No", etc.
 

--- a/docs/specification/2025-06-18/client/roots.mdx
+++ b/docs/specification/2025-06-18/client/roots.mdx
@@ -165,6 +165,7 @@ Example error:
 ## Security Considerations
 
 1. Clients **MUST**:
+
    - Only expose roots with appropriate permissions
    - Validate all root URIs to prevent path traversal
    - Implement proper access controls
@@ -178,6 +179,7 @@ Example error:
 ## Implementation Guidelines
 
 1. Clients **SHOULD**:
+
    - Prompt users for consent before exposing roots to servers
    - Provide clear user interfaces for root management
    - Validate root accessibility before exposing

--- a/docs/specification/2025-06-18/index.mdx
+++ b/docs/specification/2025-06-18/index.mdx
@@ -84,16 +84,19 @@ considerations that all implementors must carefully address.
 ### Key Principles
 
 1. **User Consent and Control**
+
    - Users must explicitly consent to and understand all data access and operations
    - Users must retain control over what data is shared and what actions are taken
    - Implementors should provide clear UIs for reviewing and authorizing activities
 
 2. **Data Privacy**
+
    - Hosts must obtain explicit user consent before exposing user data to servers
    - Hosts must not transmit resource data elsewhere without user consent
    - User data should be protected with appropriate access controls
 
 3. **Tool Safety**
+
    - Tools represent arbitrary code execution and must be treated with appropriate
      caution.
      - In particular, descriptions of tool behavior such as annotations should be

--- a/docs/specification/2025-06-18/server/tools.mdx
+++ b/docs/specification/2025-06-18/server/tools.mdx
@@ -382,6 +382,7 @@ Providing an output schema helps clients and LLMs understand and properly handle
 Tools use two error reporting mechanisms:
 
 1. **Protocol Errors**: Standard JSON-RPC errors for issues like:
+
    - Unknown tools
    - Invalid arguments
    - Server errors
@@ -425,6 +426,7 @@ Example tool execution error:
 ## Security Considerations
 
 1. Servers **MUST**:
+
    - Validate all tool inputs
    - Implement proper access controls
    - Rate limit tool invocations

--- a/docs/specification/2025-06-18/server/utilities/completion.mdx
+++ b/docs/specification/2025-06-18/server/utilities/completion.mdx
@@ -184,6 +184,7 @@ Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
 ## Implementation Considerations
 
 1. Servers **SHOULD**:
+
    - Return suggestions sorted by relevance
    - Implement fuzzy matching where appropriate
    - Rate limit completion requests

--- a/docs/specification/2025-06-18/server/utilities/logging.mdx
+++ b/docs/specification/2025-06-18/server/utilities/logging.mdx
@@ -117,6 +117,7 @@ Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
 ## Implementation Considerations
 
 1. Servers **SHOULD**:
+
    - Rate limit log messages
    - Include relevant context in data field
    - Use consistent logger names
@@ -131,6 +132,7 @@ Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
 ## Security
 
 1. Log messages **MUST NOT** contain:
+
    - Credentials or secrets
    - Personal identifying information
    - Internal system details that could aid attacks

--- a/docs/specification/2025-06-18/server/utilities/pagination.mdx
+++ b/docs/specification/2025-06-18/server/utilities/pagination.mdx
@@ -82,10 +82,12 @@ The following MCP operations support pagination:
 ## Implementation Guidelines
 
 1. Servers **SHOULD**:
+
    - Provide stable cursors
    - Handle invalid cursors gracefully
 
 2. Clients **SHOULD**:
+
    - Treat a missing `nextCursor` as the end of results
    - Support both paginated and non-paginated flows
 

--- a/docs/specification/draft/architecture/index.mdx
+++ b/docs/specification/draft/architecture/index.mdx
@@ -85,12 +85,14 @@ MCP is built on several key design principles that inform its architecture and
 implementation:
 
 1. **Servers should be extremely easy to build**
+
    - Host applications handle complex orchestration responsibilities
    - Servers focus on specific, well-defined capabilities
    - Simple interfaces minimize implementation overhead
    - Clear separation enables maintainable code
 
 2. **Servers should be highly composable**
+
    - Each server provides focused functionality in isolation
    - Multiple servers can be combined seamlessly
    - Shared protocol enables interoperability
@@ -98,6 +100,7 @@ implementation:
 
 3. **Servers should not be able to read the whole conversation, nor "see into" other
    servers**
+
    - Servers receive only necessary contextual information
    - Full conversation history stays with the host
    - Each server connection maintains isolation

--- a/docs/specification/draft/basic/authorization.mdx
+++ b/docs/specification/draft/basic/authorization.mdx
@@ -64,6 +64,7 @@ specifies how an MCP server indicates the location of its corresponding authoriz
    MCP clients **MUST** use OAuth 2.0 Protected Resource Metadata for authorization server discovery.
 
 1. MCP authorization servers **MUST** provide at least one of the following discovery mechanisms:
+
    - OAuth 2.0 Authorization Server Metadata ([RFC8414](https://datatracker.ietf.org/doc/html/rfc8414))
    - [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html)
 

--- a/docs/specification/draft/basic/security_best_practices.mdx
+++ b/docs/specification/draft/basic/security_best_practices.mdx
@@ -299,6 +299,7 @@ When you have multiple stateful HTTP servers that handle MCP requests, the follo
 
 1. The client connects to **Server A** and receives a session ID.
 1. The attacker obtains an existing session ID and sends a malicious event to **Server B** with said session ID.
+
    - When a server supports [redelivery/resumable streams](/specification/draft/basic/transports#resumability-and-redelivery), deliberately terminating the request before receiving the response could lead to it being resumed by the original client via the GET request for server sent events.
    - If a particular server initiates server sent events as a consequence of a tool call such as a `notifications/tools/list_changed`, where it is possible to affect the tools that are offered by the server, a client could end up with tools that they were not aware were enabled.
 

--- a/docs/specification/draft/basic/utilities/progress.mdx
+++ b/docs/specification/draft/basic/utilities/progress.mdx
@@ -60,6 +60,7 @@ The receiver **MAY** then send progress notifications containing:
 ## Behavior Requirements
 
 1. Progress notifications **MUST** only reference tokens that:
+
    - Were provided in an active request
    - Are associated with an in-progress operation
 

--- a/docs/specification/draft/client/elicitation.mdx
+++ b/docs/specification/draft/client/elicitation.mdx
@@ -362,10 +362,12 @@ Elicitation responses use a three-action model to clearly distinguish between di
 The three response actions are:
 
 1. **Accept** (`action: "accept"`): User explicitly approved and submitted with data
+
    - The `content` field contains the submitted data matching the requested schema
    - Example: User clicked "Submit", "OK", "Confirm", etc.
 
 2. **Decline** (`action: "decline"`): User explicitly declined the request
+
    - The `content` field is typically omitted
    - Example: User clicked "Reject", "Decline", "No", etc.
 

--- a/docs/specification/draft/client/roots.mdx
+++ b/docs/specification/draft/client/roots.mdx
@@ -165,6 +165,7 @@ Example error:
 ## Security Considerations
 
 1. Clients **MUST**:
+
    - Only expose roots with appropriate permissions
    - Validate all root URIs to prevent path traversal
    - Implement proper access controls
@@ -178,6 +179,7 @@ Example error:
 ## Implementation Guidelines
 
 1. Clients **SHOULD**:
+
    - Prompt users for consent before exposing roots to servers
    - Provide clear user interfaces for root management
    - Validate root accessibility before exposing

--- a/docs/specification/draft/index.mdx
+++ b/docs/specification/draft/index.mdx
@@ -84,16 +84,19 @@ considerations that all implementors must carefully address.
 ### Key Principles
 
 1. **User Consent and Control**
+
    - Users must explicitly consent to and understand all data access and operations
    - Users must retain control over what data is shared and what actions are taken
    - Implementors should provide clear UIs for reviewing and authorizing activities
 
 2. **Data Privacy**
+
    - Hosts must obtain explicit user consent before exposing user data to servers
    - Hosts must not transmit resource data elsewhere without user consent
    - User data should be protected with appropriate access controls
 
 3. **Tool Safety**
+
    - Tools represent arbitrary code execution and must be treated with appropriate
      caution.
      - In particular, descriptions of tool behavior such as annotations should be

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -395,6 +395,7 @@ Providing an output schema helps clients and LLMs understand and properly handle
 Tools use two error reporting mechanisms:
 
 1. **Protocol Errors**: Standard JSON-RPC errors for issues like:
+
    - Unknown tools
    - Malformed requests (requests that fail to satisfy [CallToolRequest schema](specification/draft/schema#calltoolrequest))
    - Server errors
@@ -443,6 +444,7 @@ Example tool execution error (input validation):
 ## Security Considerations
 
 1. Servers **MUST**:
+
    - Validate all tool inputs
    - Implement proper access controls
    - Rate limit tool invocations

--- a/docs/specification/draft/server/utilities/completion.mdx
+++ b/docs/specification/draft/server/utilities/completion.mdx
@@ -184,6 +184,7 @@ Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
 ## Implementation Considerations
 
 1. Servers **SHOULD**:
+
    - Return suggestions sorted by relevance
    - Implement fuzzy matching where appropriate
    - Rate limit completion requests

--- a/docs/specification/draft/server/utilities/logging.mdx
+++ b/docs/specification/draft/server/utilities/logging.mdx
@@ -117,6 +117,7 @@ Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
 ## Implementation Considerations
 
 1. Servers **SHOULD**:
+
    - Rate limit log messages
    - Include relevant context in data field
    - Use consistent logger names
@@ -131,6 +132,7 @@ Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
 ## Security
 
 1. Log messages **MUST NOT** contain:
+
    - Credentials or secrets
    - Personal identifying information
    - Internal system details that could aid attacks

--- a/docs/specification/draft/server/utilities/pagination.mdx
+++ b/docs/specification/draft/server/utilities/pagination.mdx
@@ -82,10 +82,12 @@ The following MCP operations support pagination:
 ## Implementation Guidelines
 
 1. Servers **SHOULD**:
+
    - Provide stable cursors
    - Handle invalid cursors gracefully
 
 2. Clients **SHOULD**:
+
    - Treat a missing `nextCursor` as the end of results
    - Support both paginated and non-paginated flows
 

--- a/docs/tutorials/building-a-client-node.mdx
+++ b/docs/tutorials/building-a-client-node.mdx
@@ -406,11 +406,13 @@ The client will:
 ### Common Customization Points
 
 1. **Tool Handling**
+
    - Modify `processQuery()` to handle specific tool types
    - Add custom error handling for tool calls
    - Implement tool-specific response formatting
 
 2. **Response Processing**
+
    - Customize how tool results are formatted
    - Add response filtering or transformation
    - Implement custom logging
@@ -423,11 +425,13 @@ The client will:
 ### Best Practices
 
 1. **Error Handling**
+
    - Always wrap tool calls in try-catch blocks
    - Provide meaningful error messages
    - Gracefully handle connection issues
 
 2. **Resource Management**
+
    - Use proper cleanup methods
    - Close connections when done
    - Handle server disconnections


### PR DESCRIPTION
## Motivation and Context

This PR fixes the following documentation format error:

```console
Run npm run check:docs:format

> @modelcontextprotocol/specification@0.1.0 check:docs:format
> prettier --check "**/*.{md,mdx}"

Checking formatting...
[warn] blog/content/posts/draft-mcp-ui-and-more.md
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
Error: Process completed with exit code 1.
```

https://github.com/modelcontextprotocol/modelcontextprotocol/actions/runs/19285294430/job/55144792455?pr=1799

This documentation format error was resolved by running `npx prettier --check "**/*.{md,mdx}" --write`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
