### PR TITLE
Clarify request lifetimes in task diagrams

### DIFF
--- a/docs/specification/draft/basic/utilities/tasks.mdx
+++ b/docs/specification/draft/basic/utilities/tasks.mdx
@@ -545,7 +545,7 @@ sequenceDiagram
     S->>C: input_required
     deactivate S
 
-    Note over C,S: Client receives input requests
+    Note over C,S: Client opens result stream
     C->>S: tasks/result (task-123)
     activate S
     S->>C: elicitation/create (related-task: task-123)
@@ -554,11 +554,28 @@ sequenceDiagram
     U->>C: Provide information
     C->>S: elicitation response (related-task: task-123)
     deactivate C
+    deactivate S
+
+    Note over C,S: Client closes result stream and resumes polling
 
     Note over S: Task continues processing...<br/>Task moves back to working
 
-    Note over S: Task completes and server sends final results
+    C->>S: tasks/get (task-123)
+    activate S
+    S->>C: working
+    deactivate S
 
+    Note over S: Task completes
+
+    Note over C,S: Client polls and discovers completion
+    C->>S: tasks/get (task-123)
+    activate S
+    S->>C: completed
+    deactivate S
+
+    Note over C,S: Client retrieves final results
+    C->>S: tasks/result (task-123)
+    activate S
     S->>C: Result content
     deactivate S
     C->>LLM: Process result


### PR DESCRIPTION
Simplifies result retrieval to show single `tasks/result` call with marked request lifetimes, to reduce confusion around how the `input_required` transition works.

## Motivation and Context
#1824

## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

<img width="936" height="1227" alt="image" src="https://github.com/user-attachments/assets/fcc43e88-efa3-47c4-8206-e1a261974361" />

<img width="951" height="1263" alt="image" src="https://github.com/user-attachments/assets/a192a5ac-2d06-4a52-96ae-ff47dfbc09b4" />

<img width="943" height="1220" alt="image" src="https://github.com/user-attachments/assets/be010b99-de21-44e4-868f-00a16b3ca15a" />

<img width="875" height="1030" alt="image" src="https://github.com/user-attachments/assets/61a2ca34-b5e0-4986-bb84-4f368d068881" />

