### PR TITLE
Add follow_redirects=True to NWS httpx example

### DIFF
--- a/docs/docs/develop/build-server.mdx
+++ b/docs/docs/develop/build-server.mdx
@@ -167,10 +167,7 @@ async def make_nws_request(url: str) -> dict[str, Any] | None:
         "User-Agent": USER_AGENT,
         "Accept": "application/geo+json"
     }
--    async with httpx.AsyncClient() as client:
-+    # NWS API may return 301 redirects for canonicalized coordinates,
-+    # so we enable follow_redirects to ensure the client follows them.
-+    async with httpx.AsyncClient(follow_redirects=True) as client:
+    async with httpx.AsyncClient(follow_redirects=True) as client:
         try:
             response = await client.get(url, headers=headers, timeout=30.0)
             response.raise_for_status()
@@ -219,8 +216,8 @@ async def get_forecast(latitude: float, longitude: float) -> str:
     """Get weather forecast for a location.
 
     Args:
-        latitude: Latitude of the location
-        longitude: Longitude of the location
+    	latitude: Latitude of the location (recommended: up to 4 decimal places)
+    	longitude: Longitude of the location (recommended: up to 4 decimal places)
     """
     # First get the forecast grid endpoint
     points_url = f"{NWS_API_BASE}/points/{latitude},{longitude}"


### PR DESCRIPTION
## Summary
Enable following redirects in the NWS weather example by adding `follow_redirects=True` to the `httpx.AsyncClient` call and update the argument documentation to recommend up to 4 decimal places for latitude and longitude.  
This ensures the example works correctly with current NWS behavior and behaves more consistently across different LLM clients.

## Motivation and Context
The NWS `/points/{lat},{lon}` endpoint often returns `301 Moved Permanently` responses when canonicalizing coordinates (e.g., trimming latitude/longitude to four decimal places). Some LLM agents (unlike Claude, which already uses 4-decimal precision) may call the `get_forecast()` tool with higher-precision coordinates (e.g., 6–7 decimal places).

Since `httpx` does not follow redirects by default, the existing documentation example fails silently in these cases:
`raise_for_status()` raises on the 301 response, causing `make_nws_request()` to return `None`.

This PR addresses the issue in two ways:

1. Adds `follow_redirects=True` so the HTTP client transparently follows
   NWS canonicalization redirects.
2. Updates the argument documentation for `get_forecast()` to recommend
   using latitude/longitude values with up to 4 decimal places, guiding
   LLM agents and developers toward inputs that avoid redirects in the
   first place.

Together, these changes make the example more robust and less dependent
on the quirks of any particular LLM client.

## How Has This Been Tested?
The behavior was tested across multiple LLM clients using both the original example code and the updated version:

1. Claude Desktop  
   Successfully calls the weather tool using the original example.  
   Claude naturally limits latitude/longitude to 4 decimal places, so no redirect occurs.

2. Gemini CLI  
   The original example fails for certain locations because Gemini tends to provide higher-precision coordinates (e.g., 6+ decimal places), which triggers the NWS canonicalization redirect and causes
   `make_nws_request()` to return `None`.

3. With `follow_redirects=True` added  
   Both Claude Desktop and Gemini CLI successfully retrieve weather data, even for high-precision coordinates.

4. With only the updated argument documentation (4-decimal recommendation)  
   Even without `follow_redirects=True`, Gemini CLI succeeds as long as the LLM adjusts the coordinates based on the updated docstring guidance.

As a result, the combination of:
- enabling `follow_redirects=True`, and
- documenting recommended coordinate precision (up to 4 decimals)

ensures that the example works reliably across a wide range of LLM
clients and avoids silent failures caused by NWS coordinate canonicalization.

## Types of changes
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] I have updated the documentation where necessary

## Additional context
This update aligns the example with current NWS API behavior and improves
interoperability across different LLM agents, making the tutorial example
more reliable for developers integrating MCP servers with weather data.
