### PR TITLE
Specify HTTP status codes for SSE downgrade

### DIFF
--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -291,8 +291,8 @@ protocol version 2024-11-05) as follows:
    defined above:
    - If it succeeds, the client can assume this is a server supporting the new Streamable
      HTTP transport.
-   - If it fails with an HTTP 4xx status code (e.g., 405 Method Not Allowed or 404 Not
-     Found):
+   - If it fails with the following HTTP status codes "400 Bad Request", "404 Not
+     Found" or "405 Method Not Allowed":
      - Issue a GET request to the server URL, expecting that this will open an SSE stream
        and return an `endpoint` event as the first event.
      - When the `endpoint` event arrives, the client can assume this is a server running


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

The current backwards compatibility guidelines for Streamable HTTP suggest that any 4XX status code indicates transport incompatibility and should trigger a downgrade to SSE. This is too broad: not all 4XX codes represent incompatibility issues.

For example, a 401 Unauthorized response should prompt OAuth recovery actions, not attempt to initiate a GET stream fallback. Treating all 4XX codes as transport failures leads to incorrect error handling for authentication and other recoverable scenarios.

## How Has This Been Tested?
Documentation-only change; no code testing required.


## Breaking Changes
N/A
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
