### PR TITLE
Remove elicitation response from URL Mode Elicitation Required Error Flow sequence diagram

### DIFF
--- a/docs/specification/draft/client/elicitation.mdx
+++ b/docs/specification/draft/client/elicitation.mdx
@@ -513,7 +513,6 @@ sequenceDiagram
     User-->>Client: Provide consent
 
     Client->>UserAgent: Open URL
-    Client->>Server: Accept response
 
     Note over User,UserAgent: User interaction
 


### PR DESCRIPTION
As demonstrated in the client `elicitationUrlExample.ts` sample in the TypeScript SDK, this response is discarded which makes sense because there's no elicitation request in this case to respond to, just a URLElicitationRequiredError.

https://github.com/modelcontextprotocol/typescript-sdk/blob/0c1cbf0d37199ffa1bb6e119bd855cd0add930b3/src/examples/client/elicitationUrlExample.ts#L716

@nbarbettini 