### PR TITLE
(chore): Revise MCP Apps extension proposal blog post

### DIFF
--- a/blog/content/posts/2025-11-21-mcp-apps.md
+++ b/blog/content/posts/2025-11-21-mcp-apps.md
@@ -1,45 +1,46 @@
 +++
 date = '2025-11-21T22:00:00+00:00'
 publishDate = '2025-11-21T22:00:00+00:00'
-draft = false
 title = 'MCP Apps: Extending servers with interactive user interfaces'
 author = 'Anton Pidkuiko (Maintainer), Olivier Chafik (Maintainer), Ido Salomon (MCP-UI), Liad Yosef (MCP-UI), Nick Cooper (Core Maintainer), Sean Strong (Anthropic), Jerome Swannack (Anthropic), Alexi Christakis (OpenAI), Bryan Ashley (OpenAI)'
 tags = ['apps', 'ui', 'user interfaces']
 +++
 
-Today we're proposing an MCP extension to standardize support for interactive user interfaces in the Model Context Protocol. This addresses one of the most requested features from the MCP community and builds on proven work from [MCP-UI](https://github.com/idosal/mcp-ui) and [OpenAI Apps SDK](https://developers.openai.com/apps-sdk/).
+Today we're introducing the proposal for the [MCP Apps Extension](https://github.com/modelcontextprotocol/ext-apps) ([SEP-1865](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1865)) to standardize support for interactive user interfaces in the Model Context Protocol.
 
-MCP Apps is an optional extension that enables servers to deliver interactive user interfaces to hosts. It introduces a standardized pattern for declaring UI resources, linking them to tools, and enabling bidirectional communication between embedded interfaces and the host application.
+This extension addresses one of the most requested features from the MCP community and builds on proven work from [MCP-UI](https://github.com/idosal/mcp-ui) and [OpenAI Apps SDK](https://developers.openai.com/apps-sdk/) - the **ability for MCP servers to deliver interactive user interfaces to hosts**.
+
+MCP Apps Extension introduces a standardized pattern for declaring UI resources, linking them to tools, and enabling bidirectional communication between embedded interfaces and the host application.
 
 ![Example of an inline chat app with interactive UI for permission management](/posts/images/inline-chat-app.png)
 
-The SEP was authored by MCP core maintainers at OpenAI and Anthropic, together with the MCP-UI creators and lead maintainers of the MCP UI Community Working Group.
+The SEP was authored by MCP Core Maintainers at OpenAI and Anthropic, together with the MCP-UI creators and lead maintainers of the MCP UI Community Working Group.
 
 ## Standardization for interactive interfaces
 
 Currently, MCP servers are limited to exchanging text and structured data with hosts. While this works well for many use cases, it creates friction when tools need to present visual information or gather complex user input.
 
-Consider a data visualization server that returns chart data as JSON. The host application must interpret that data and render it, a burden that falls on every client implementation. Or imagine a configuration tool that needs to collect multiple related settings from users. Without UI support, these interactions become awkward exchanges of text prompts and responses.
+For example, consider a data visualization MCP server that returns chart data as JSON. The host application must interpret that data and render it. Handling all kinds of specialized data in this scenario translates to a significant burden for client developers, who would need to build their own logic to render the UI. As more UI requirements come up, like the need to collect multiple related settings from users, the complexity balloons. Alternatively, without UI support, these interactions become awkward exchanges of text prompts and responses.
 
-The community has been creative in working around these limitations, but different implementations use different approaches, making it harder for servers to work consistently across hosts. With lack of standardization, there’s a real risk of fragmentation in the ecosystem.
+The MCP community has been creative in working around these limitations, but different implementations using varying conventions and architectures make it harder for servers to work consistently across clients. This lack of standardization creates a real risk of ecosystem fragmentation - something we're working to proactively prevent.
 
 ## Building together
 
-The [MCP-UI project](https://github.com/idosal/mcp-ui), created by Ido Salomon and Liad Yosef and maintained by a dedicated community, spearheaded the vision of agentic apps with interactive interfaces. The project developed patterns for delivering rich user interfaces as first-class MCP resources, proving that agentic apps fit naturally within MCP’s architecture. Backed by a large community and providing rich SDKs, it drove adoption at leading companies and projects such as Postman, Shopify, HuggingFace, Goose, and ElevenLabs.
+The [MCP-UI project](https://github.com/MCP-UI-Org/mcp-ui), created by [Ido Salomon](https://github.com/idosal) and [Liad Yosef](https://github.com/liady) and maintained by a dedicated community, spearheaded the vision of agentic apps with interactive interfaces. The project developed patterns for delivering rich user interfaces as first-class MCP resources, proving that agentic apps fit naturally within the MCP architecture. The project is backed by a large community and provides [rich SDKs](https://mcpui.dev/guide/client/overview), adopted at leading companies and projects such as Postman, Shopify, Hugging Face, Goose, and ElevenLabs.
 
-The [OpenAI Apps SDK](https://developers.openai.com/apps-sdk/) further validated the demand for rich UI experiences within conversational AI interfaces. The Apps SDK enables developers to build rich, interactive applications inside ChatGPT using MCP as its backbone. To ensure interoperability and establish consistent security and usage patterns across the ecosystem, we (Anthropic, OpenAI and MCP-UI) are collaborating to create an official MCP extension for interactive interfaces.
+The [OpenAI Apps SDK](https://developers.openai.com/apps-sdk/) further validated the demand for rich UI experiences within conversational AI interfaces. The SDK enables developers to build rich, interactive applications inside ChatGPT using MCP as its backbone. To ensure interoperability and establish consistent security and usage patterns across the ecosystem, Anthropic, OpenAI, and MCP-UI are collaborating to create an official MCP extension for interactive interfaces.
 
 ![Example of a fullscreen app with a rich data table interface](/posts/images/fullscreen-chat-app.png)
 
-## MCP Apps specification
+## MCP Apps Extension specification
 
-We're proposing a specification for UI resources in MCP, but the implications go further. MCP Apps is starting to look like an agentic app runtime: a foundation for novel interactions between AI models, users, and applications. The proposal is intentionally lean, starting with core patterns that we plan on expanding over time.
+We're proposing a specification for UI resources in MCP, but the implications go further than just a set of schema changes. The MCP Apps Extension is starting to look like an agentic app runtime: a foundation for novel interactions between AI models, users, and applications. The proposal is intentionally lean, starting with core patterns that we plan on expanding over time.
 
 ### Key design decisions
 
-**Predeclared resources**
+#### Pre-declared resources
 
-UI templates are resources with the `ui://` URI scheme, then referenced in tool metadata.
+UI templates are resources with the `ui://` URI scheme, referenced in tool metadata.
 
 ```ts
 // Server registers UI resource
@@ -67,26 +68,26 @@ UI templates are resources with the `ui://` URI scheme, then referenced in tool 
 
 This approach enables hosts to prefetch and review templates before tool execution, improving both performance and security. It also separates static presentation (the template) from dynamic data (tool results), enabling better caching.
 
-**MCP transport for communication**
+#### MCP transport for communication
 
-Instead of inventing a custom message protocol, UI components communicate with hosts using MCP's existing JSON-RPC base protocol over `postMessage`. This means:
+Instead of inventing a custom message protocol, UI components communicate with hosts using existing MCP JSON-RPC base protocol over `postMessage`. This means that:
 
-- UI developers can use the standard `@modelcontextprotocol/sdk`
+- UI developers can use the standard `@modelcontextprotocol/sdk` to build their applications
 - All communication is structured and auditable
 - Future MCP features automatically work with the UI extension
 
-**Starting with HTML**
+#### Starting with HTML
 
-The initial specification supports only `text/html` content, rendered in sandboxed iframes. This provides:
+The initial extension specification supports only `text/html` content, rendered in sandboxed [iframes](https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/iframe). This provides:
 
 - Universal browser support
 - Well-understood security model
 - Screenshot and preview generation capabilities
 - A clear baseline for future extensions
 
-Other content types such as external URLs, remote DOM and native widgets are explicitly deferred to future iterations.
+Other content types such as external URLs, remote DOM, and native widgets are explicitly deferred to future iterations.
 
-**Security first**
+#### Security-first
 
 Hosting interactive content from MCP servers requires careful security consideration. The proposal addresses this through multiple layers:
 
@@ -97,25 +98,29 @@ Hosting interactive content from MCP servers requires careful security considera
 
 These mitigations create defense in depth against malicious servers while preserving the flexibility developers need.
 
-**Backward compatibility**
+#### Backward compatibility
 
 MCP Apps is an optional extension. Existing implementations continue working without changes, and hosts can gradually adopt UI support at their own pace. Servers should provide text-only fallback for all UI-enabled tools and return meaningful content even when UI is unavailable, so they can serve both UI-capable and text-only hosts.
 
 ## What's next
 
-The [UI Community Working Group](https://github.com/modelcontextprotocol-community/working-groups/issues/35) has been instrumental in shaping this proposal through extensive feedback and discussion. We have built an [early access sdk](https://github.com/modelcontextprotocol/ext-apps) to demonstrate the patterns & types described in the SEP. The [MCP-UI](https://mcpui.dev/) client and server SDKs support these patterns.
+The [UI Community Working Group](https://github.com/modelcontextprotocol-community/working-groups/issues/35) has been instrumental in shaping this proposal through extensive feedback and discussion. We have built an [early access SDK](https://github.com/modelcontextprotocol/ext-apps) to demonstrate the patterns and types described in the specification proposal. The [MCP-UI](https://mcpui.dev/) client and server SDKs support these patterns.
 
-We invite you to:
+If you are interested in contributing to this effort, we invite you to:
 
 - Review the full specification in [SEP-1865](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1865)
-- Share feedback and concerns in the GitHub issue
-- Join the discussion in the `#ui-cwg` channel on [MCP Discord](https://discord.gg/modelcontextprotocol)
+- Share feedback and concerns in [GitHub Issues](https://github.com/MCP-UI-Org/mcp-ui/issues)
+- Join the discussion in the `#ui-wg` channel in the [MCP Contributors Discord](https://modelcontextprotocol.io/community/communication#discord)
 - Test prototype implementations and share your experience
 
 ## Acknowledgements
 
-This proposal wouldn't exist without the work of the maintainers at MCP-UI, OpenAI and Anthropic.
+This proposal wouldn't exist without the work of the maintainers at MCP-UI, OpenAI, and Anthropic.
 
-Ido Salomon and Liad Yosef, through MCP-UI and moderation of `#ui-cwg`, incubated and championed many of the patterns that MCP Apps now standardizes, and together with contributors demonstrated that UI resources can be a natural part of MCP. Sean Strong, Olivier Chafik, Anton Pidkuiko and Jerome Swannack from Anthropic helped steer the initiative and drive the collaboration. Nick Cooper, Alexei Christakis, and Bryan Ashley from OpenAI have provided valuable direction from their experience building the Apps SDK.
+**Ido Salomon** and **Liad Yosef**, through MCP-UI and moderation of `#ui-wg`, incubated and championed many of the patterns that MCP Apps now standardizes, and together with contributors demonstrated that UI resources can be a natural part of MCP.
 
-Special thanks to the UI Community Working Group members and everyone who contributed to the discussions that shaped this proposal.
+**Sean Strong**, **Olivier Chafik**, **Anton Pidkuiko**, and **Jerome Swannack** from Anthropic helped steer the initiative and drive the collaboration.
+
+**Nick Cooper**, **Alexei Christakis**, and **Bryan Ashley** from OpenAI have provided valuable direction from their experience building the Apps SDK.
+
+Special thanks to the **UI Community Working Group** members and everyone who contributed to the discussions that shaped this proposal.


### PR DESCRIPTION
Updated the blog post to clarify the MCP Apps Extension proposal, add links to relevant resources, and refine explanations of design decisions and community involvement.

Also, fixes some of the contributor pointers that (likely) went to the wrong locations.