### PR TITLE
Add MCPBundles to MCP client list

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -1274,7 +1274,7 @@ MCPBundles provides MCPBundle Studio, a browser-based MCP client for testing and
 - Discover and inspect available tools with parameter schemas and descriptions
 - Supports OAuth and API key authentication for secure provider connections
 - Execute MCP tools with form-based and chat based input
-- Implements MCP Apps (SEP-1865) for rendering interactive UI responses from tools
+- Implements MCP Apps for rendering interactive UI responses from tools
 - Streamable HTTP transport for remote MCP server connections
 
 </McpClient>


### PR DESCRIPTION
Added MCPBundles to the MCP client list with feature matrix entry and description of our product and services.

## Motivation and Context

MCPBundles is a cloud-hosted platform that connects AI assistants to real-world tools through curated bundles. It supports Resources, Prompts, Tools, and Discovery, making it a fully-featured MCP client. Adding it to the client list helps users discover this option for managing their MCP integrations.

## How Has This Been Tested?

N/A - Documentation update only. All URLs have been verified to return successful responses.

## Breaking Changes

None - This is purely additive documentation.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

MCPBundles is added alphabetically in the feature matrix table between "MCP Bundler for MacOS" and "mcp-agent". The entry includes support for Resources, Prompts, Tools, and Discovery features. The detailed description follows the same format as other clients in the list, highlighting key features like cloud hosting, bundle collections, credential management, and multi-client support for agencies.