### PR TITLE
Rename 'Node' tab to 'TypeScript' in quickstart docs

### DIFF
--- a/docs/docs/develop/build-client.mdx
+++ b/docs/docs/develop/build-client.mdx
@@ -440,7 +440,7 @@ If you see:
 
 </Tab>
 
-<Tab title="Node">
+<Tab title="TypeScript">
 
 [You can find the complete code for this tutorial here.](https://github.com/modelcontextprotocol/quickstart-resources/tree/main/mcp-client-typescript)
 

--- a/docs/docs/develop/build-server.mdx
+++ b/docs/docs/develop/build-server.mdx
@@ -353,7 +353,7 @@ Save the file, and restart **Claude for Desktop**.
 
 </Tab>
 
-<Tab title='Node'>
+<Tab title='TypeScript'>
 
 Let's get started with building our weather server! [You can find the complete code for what we'll be building here.](https://github.com/modelcontextprotocol/quickstart-resources/tree/main/weather-server-typescript)
 


### PR DESCRIPTION
The TypeScript SDK examples in the build-server and build-client quickstart docs are written in TypeScript, so the tab name should reflect that rather than 'Node'.