### PR TITLE
Fix TypeScript server example: remove invalid capabilities option

### DIFF
--- a/docs/docs/develop/build-server.mdx
+++ b/docs/docs/develop/build-server.mdx
@@ -505,10 +505,6 @@ const USER_AGENT = "weather-app/1.0";
 const server = new McpServer({
   name: "weather",
   version: "1.0.0",
-  capabilities: {
-    resources: {},
-    tools: {},
-  },
 });
 ```
 


### PR DESCRIPTION
The McpServer class doesn't accept a capabilities option - capabilities are inferred from registered tools/resources/prompts.

Fixes #1899