### PR TITLE
docs: Remove incorrect `Resources` support for Cursor MCP client.

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -39,7 +39,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [CodeGPT][CodeGPT]                               | ❌          | ❌        | ✅      | ❓                     | ❌         | ❌    | ❓            | ❓             |
 | [Continue][Continue]                             | ✅          | ✅        | ✅      | ❓                     | ❌         | ❌    | ❓            | ❓             |
 | [Copilot-MCP][CopilotMCP]                        | ✅          | ❌        | ✅      | ❓                     | ❌         | ❌    | ❓            | ❓             |
-| [Cursor][Cursor]                                 | ✅          | ✅        | ✅      | ❌                     | ❌         | ✅    | ✅            | ❓             |
+| [Cursor][Cursor]                                 | ❌          | ✅        | ✅      | ❌                     | ❌         | ✅    | ✅            | ❓             |
 | [Daydreams Agents][Daydreams]                    | ✅          | ✅        | ✅      | ❌                     | ❌         | ❌    | ❓            | ❓             |
 | [ECA][ECA]                                       | ✅          | ✅        | ✅      | ❌                     | ❌         | ✅    | ❓            | ❓             |
 | [Emacs Mcp][Mcp.el]                              | ❌          | ❌        | ✅      | ❌                     | ❌         | ❌    | ❓            | ❓             |


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
For the past few months, users have been requesting full MCP support in Cursor for the original primitives; despite the Cursor docs and the MCP docs saying otherwise, Cursor has never supported MCP Resources. This PR makes that correction.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Additional context
Forum comment from Cursor internal team member where he said it was in the roadmap but deprioritized: https://forum.cursor.com/t/cursor-mcp-resource-feature-support/50987/7?u=pattobrien
Forum request for MCP resource support: https://forum.cursor.com/t/cursor-mcp-resource-feature-support/50987/13
