### PR TITLE
Fix Prettier formatting in prompts.mdx

### DIFF
--- a/docs/specification/2025-11-25/server/prompts.mdx
+++ b/docs/specification/2025-11-25/server/prompts.mdx
@@ -195,8 +195,8 @@ Messages in a prompt can contain:
 
 <Note>
   All content types in prompt messages support optional
-  [annotations](./resources#annotations) for
-  metadata about audience, priority, and modification times.
+  [annotations](./resources#annotations) for metadata about audience, priority,
+  and modification times.
 </Note>
 
 #### Text Content


### PR DESCRIPTION
Fixes line wrapping in the prompts.mdx Note block to pass the Markdown Format Check CI.