### PR TITLE
fix: update LATEST_PROTOCOL_VERSION to 2025-11-25

### DIFF
--- a/schema/2025-11-25/schema.ts
+++ b/schema/2025-11-25/schema.ts
@@ -11,7 +11,7 @@ export type JSONRPCMessage =
   | JSONRPCResponse;
 
 /** @internal */
-export const LATEST_PROTOCOL_VERSION = "DRAFT-2025-v3";
+export const LATEST_PROTOCOL_VERSION = "2025-11-25";
 /** @internal */
 export const JSONRPC_VERSION = "2.0";
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Now that 2025-11-25 is the latest official MCP protocol version, the `LATEST_PROTOCOL_VERSION` constant in [schema/2025-11-25/schema.ts](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/)  should correctly reflect that.
 
 
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Currently, it is still set to `DRAFT-2025-v3`, which could cause issues for tools that rely on the `LATEST_PROTOCOL_VERSION` constant in the official schema.   for example, my [rust-mcp-schema](https://crates.io/crates/rust-mcp-schema) crate that generates Rust structs from the official schema is detecting multiple DRAFT-2025-v3 entries in the repository that leads to ambiguity during schema resolution.


## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
```
npm run check:schema:ts
```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
