### PR TITLE
Clarify that empty cursors are valid cursors

### DIFF
--- a/docs/specification/draft/server/utilities/pagination.mdx
+++ b/docs/specification/draft/server/utilities/pagination.mdx
@@ -92,6 +92,9 @@ The following MCP operations support pagination:
 3. Clients **MUST** treat cursors as opaque tokens:
    - Don't make assumptions about cursor format
    - Don't attempt to parse or modify cursors
+   - Don't make any determination based on cursor value other than whether a
+     non-null value was provided (e.g. an empty string is a valid cursor and
+     thus **MUST NOT** be treated as the end of results)
    - Don't persist cursors across sessions
 
 ## Error Handling


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

The C# SDK has client APIs that automatically follow cursors, and we've received several reports of folks complaining that it's following an empty string cursor when it should instead treat it as end of results. Our understanding of the spec is clients should not be parsing cursors in any way, and thus an empty string is as valid a cursor as any. This PR is simply attempting to further clarify in order to remove any ambiguity around this case.

## How Has This Been Tested?

n/a

## Breaking Changes

No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
