### PR TITLE
Add MCP Apps Working Group maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -166,6 +166,11 @@ This document lists current maintainers in the Model Context Protocol project.
 - [Luca Chang](https://github.com/LucaButBoring)
 - [Inna Harper](https://github.com/ihrpr)
 
+### MCP Apps Working Group
+
+- [Liad Yosef](https://github.com/liady)
+- [Ido Salomon](https://github.com/idosal)
+
 ## About This Document
 
 This document is updated by the MCP maintainers and reflects the current


### PR DESCRIPTION
Add MCP Apps Working Group maintainers to MAINTAINERS.md

## Motivation and Context
The MCP Apps Working Group has been driving the standardization of interactive user interfaces within MCP through SEP-1865. Liad Yosef (@liady) and Ido Salomon (@idosal) have been moderating the `#ui-wg` group, which was created before the current WG/IG governance structure was established. This change formally recognizes their maintainer roles.

## How Has This Been Tested?
N/A

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
