### PR TITLE
Add Peder Holdgaard Pedersen to Financial Services Interest Group

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -148,6 +148,7 @@ This document lists current maintainers in the Model Context Protocol project.
 ### Financial Services Interest Group
 
 - [Sambhav Kothari](https://github.com/sambhav)
+- [Peder Holdgaard Pedersen](https://github.com/PederHP)
 
 ### Transports Interest Group
 


### PR DESCRIPTION
Adds Peder Holdgaard Pedersen to Financial Services Interest Group maintainers (already added to other access group).