### PR TITLE
fix: grammar correction in resources documentation

### DIFF
--- a/docs/specification/draft/server/resources.mdx
+++ b/docs/specification/draft/server/resources.mdx
@@ -348,7 +348,7 @@ Clients can use these annotations to:
 
 ## Common URI Schemes
 
-The protocol defines several standard URI schemes. This list not
+The protocol defines several standard URI schemes. This list is not
 exhaustive&mdash;implementations are always free to use additional, custom URI schemes.
 
 ### https://


### PR DESCRIPTION
This fix is funny, I asked Claude to check the specification and it got fixated on the grammar.

Now it calls itself The Grammar Vigilante. So here is the work of the vigilante.