### PR TITLE
[Docs] Add `theme` to `icons` in Base Protocol Overview

### DIFF
--- a/docs/specification/2025-11-25/basic/index.mdx
+++ b/docs/specification/2025-11-25/basic/index.mdx
@@ -227,6 +227,7 @@ Icons are represented as an array of `Icon` objects, where each icon includes:
   - A data URI with base64-encoded image data
 - `mimeType`: Optional MIME type if the server's type is missing or generic
 - `sizes`: Optional array of size specifications (e.g., `["48x48"]`, `["any"]` for scalable formats like SVG, or `["48x48", "96x96"]` for multiple sizes)
+- `theme`: Optional theme preference (`light` or `dark`) for the icon background
 
 **Required MIME type support:**
 

--- a/docs/specification/draft/basic/index.mdx
+++ b/docs/specification/draft/basic/index.mdx
@@ -227,6 +227,7 @@ Icons are represented as an array of `Icon` objects, where each icon includes:
   - A data URI with base64-encoded image data
 - `mimeType`: Optional MIME type if the server's type is missing or generic
 - `sizes`: Optional array of size specifications (e.g., `["48x48"]`, `["any"]` for scalable formats like SVG, or `["48x48", "96x96"]` for multiple sizes)
+- `theme`: Optional theme preference (`light` or `dark`) for the icon background
 
 **Required MIME type support:**
 


### PR DESCRIPTION
## Motivation and Context

This PR adds `theme` to `icons` in Base Protocol Overview. This keeps the wording consistent with the Schema Reference.
https://modelcontextprotocol.io/specification/2025-11-25/schema#icon

Resolves #1964.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
