### PR TITLE
Add icons property to Data Types sections in specification docs

### DIFF
--- a/docs/specification/2025-11-25/server/prompts.mdx
+++ b/docs/specification/2025-11-25/server/prompts.mdx
@@ -184,6 +184,7 @@ A prompt definition includes:
 - `name`: Unique identifier for the prompt
 - `title`: Optional human-readable name of the prompt for display purposes.
 - `description`: Optional human-readable description
+- `icons`: Optional array of icons for display in user interfaces
 - `arguments`: Optional list of arguments for customization
 
 ### PromptMessage

--- a/docs/specification/2025-11-25/server/resources.mdx
+++ b/docs/specification/2025-11-25/server/resources.mdx
@@ -289,6 +289,7 @@ A resource definition includes:
 - `name`: The name of the resource.
 - `title`: Optional human-readable name of the resource for display purposes.
 - `description`: Optional description
+- `icons`: Optional array of icons for display in user interfaces
 - `mimeType`: Optional MIME type
 - `size`: Optional size in bytes
 

--- a/docs/specification/2025-11-25/server/tools.mdx
+++ b/docs/specification/2025-11-25/server/tools.mdx
@@ -193,6 +193,7 @@ A tool definition includes:
 - `name`: Unique identifier for the tool
 - `title`: Optional human-readable name of the tool for display purposes.
 - `description`: Human-readable description of functionality
+- `icons`: Optional array of icons for display in user interfaces
 - `inputSchema`: JSON Schema defining expected parameters
   - Follows the [JSON Schema usage guidelines](/specification/2025-11-25/basic#json-schema-usage)
   - Defaults to 2020-12 if no `$schema` field is present

--- a/docs/specification/draft/server/prompts.mdx
+++ b/docs/specification/draft/server/prompts.mdx
@@ -184,6 +184,7 @@ A prompt definition includes:
 - `name`: Unique identifier for the prompt
 - `title`: Optional human-readable name of the prompt for display purposes.
 - `description`: Optional human-readable description
+- `icons`: Optional array of icons for display in user interfaces
 - `arguments`: Optional list of arguments for customization
 
 ### PromptMessage

--- a/docs/specification/draft/server/resources.mdx
+++ b/docs/specification/draft/server/resources.mdx
@@ -289,6 +289,7 @@ A resource definition includes:
 - `name`: The name of the resource.
 - `title`: Optional human-readable name of the resource for display purposes.
 - `description`: Optional description
+- `icons`: Optional array of icons for display in user interfaces
 - `mimeType`: Optional MIME type
 - `size`: Optional size in bytes
 

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -193,6 +193,7 @@ A tool definition includes:
 - `name`: Unique identifier for the tool
 - `title`: Optional human-readable name of the tool for display purposes.
 - `description`: Human-readable description of functionality
+- `icons`: Optional array of icons for display in user interfaces
 - `inputSchema`: JSON Schema defining expected parameters
   - Follows the [JSON Schema usage guidelines](/specification/draft/basic#json-schema-usage)
   - Defaults to 2020-12 if no `$schema` field is present


### PR DESCRIPTION
The icons property was already shown in JSON examples but was missing from the formal Data Types documentation for Prompt, Resource, and Tool.

Fixes #1967

---

Note: Eventually I want to make these pages point to the Schema Reference instead of duplicating its documentation, but for now, let's fix these pages.
