### PR TITLE
Tailor logging guidance to each language in `build-server` docs

### DIFF
--- a/docs/docs/develop/build-server.mdx
+++ b/docs/docs/develop/build-server.mdx
@@ -45,30 +45,27 @@ This quickstart assumes you have familiarity with:
 
 When implementing MCP servers, be careful about how you handle logging:
 
-**For STDIO-based servers:** Never write to standard output (stdout). This includes:
-
-- `print()` statements in Python
-- `console.log()` in JavaScript
-- `fmt.Println()` in Go
-- Similar stdout functions in other languages
-
-Writing to stdout will corrupt the JSON-RPC messages and break your server.
+**For STDIO-based servers:** Never write to stdout. Writing to stdout will corrupt the JSON-RPC messages and break your server. The `print()` function writes to stdout by default, but can be used safely with `file=sys.stderr`.
 
 **For HTTP-based servers:** Standard output logging is fine since it doesn't interfere with HTTP responses.
 
 ### Best Practices
 
-1. Use a logging library that writes to stderr or files.
-1. For Python, be especially careful - `print()` writes to stdout by default.
+- Use a logging library that writes to stderr or files.
 
 ### Quick Examples
 
 ```python
+import sys
+import logging
+
 # ❌ Bad (STDIO)
 print("Processing request")
 
 # ✅ Good (STDIO)
-import logging
+print("Processing request", file=sys.stderr)
+
+# ✅ Good (STDIO)
 logging.info("Processing request")
 ```
 
@@ -369,21 +366,13 @@ This quickstart assumes you have familiarity with:
 
 When implementing MCP servers, be careful about how you handle logging:
 
-**For STDIO-based servers:** Never write to standard output (stdout). This includes:
-
-- `print()` statements in Python
-- `console.log()` in JavaScript
-- `fmt.Println()` in Go
-- Similar stdout functions in other languages
-
-Writing to stdout will corrupt the JSON-RPC messages and break your server.
+**For STDIO-based servers:** Never use `console.log()`, as it writes to standard output (stdout) by default. Writing to stdout will corrupt the JSON-RPC messages and break your server.
 
 **For HTTP-based servers:** Standard output logging is fine since it doesn't interfere with HTTP responses.
 
 ### Best Practices
 
-1. Use a logging library that writes to stderr or files, such as `logging` in Python.
-2. For JavaScript, be especially careful - `console.log()` writes to stdout by default.
+- Use `console.error()` which writes to stderr, or use a logging library that writes to stderr or files.
 
 ### Quick Examples
 
@@ -842,21 +831,14 @@ For manual MCP Server implementation, refer to the [MCP Server Java SDK document
 
 When implementing MCP servers, be careful about how you handle logging:
 
-**For STDIO-based servers:** Never write to standard output (stdout). This includes:
-
-- `print()` statements in Python
-- `console.log()` in JavaScript
-- `fmt.Println()` in Go
-- Similar stdout functions in other languages
-
-Writing to stdout will corrupt the JSON-RPC messages and break your server.
+**For STDIO-based servers:** Never use `System.out.println()` or `System.out.print()`, as they write to standard output (stdout). Writing to stdout will corrupt the JSON-RPC messages and break your server.
 
 **For HTTP-based servers:** Standard output logging is fine since it doesn't interfere with HTTP responses.
 
 ### Best Practices
 
-1. Use a logging library that writes to stderr or files.
-2. Ensure any configured logging library will not write to STDOUT
+- Use a logging library that writes to stderr or files.
+- Ensure any configured logging library will not write to stdout.
 
 ### System requirements
 
@@ -1150,6 +1132,18 @@ This quickstart assumes you have familiarity with:
 
 - Kotlin
 - LLMs like Claude
+
+### Logging in MCP Servers
+
+When implementing MCP servers, be careful about how you handle logging:
+
+**For STDIO-based servers:** Never use `println()`, as it writes to standard output (stdout) by default. Writing to stdout will corrupt the JSON-RPC messages and break your server.
+
+**For HTTP-based servers:** Standard output logging is fine since it doesn't interfere with HTTP responses.
+
+### Best Practices
+
+- Use a logging library that writes to stderr or files.
 
 ### System requirements
 
@@ -1538,20 +1532,13 @@ This quickstart assumes you have familiarity with:
 
 When implementing MCP servers, be careful about how you handle logging:
 
-**For STDIO-based servers:** Never write to standard output (stdout). This includes:
-
-- `print()` statements in Python
-- `console.log()` in JavaScript
-- `fmt.Println()` in Go
-- Similar stdout functions in other languages
-
-Writing to stdout will corrupt the JSON-RPC messages and break your server.
+**For STDIO-based servers:** Never use `Console.WriteLine()` or `Console.Write()`, as they write to standard output (stdout). Writing to stdout will corrupt the JSON-RPC messages and break your server.
 
 **For HTTP-based servers:** Standard output logging is fine since it doesn't interfere with HTTP responses.
 
 ### Best Practices
 
-1. Use a logging library that writes to stderr or files
+- Use a logging library that writes to stderr or files.
 
 ### System requirements
 
@@ -1811,21 +1798,14 @@ This quickstart assumes you have familiarity with:
 
 When implementing MCP servers, be careful about how you handle logging:
 
-**For STDIO-based servers:** Never write to standard output (stdout). This includes:
-
-- `print()` statements in Python
-- `console.log()` in JavaScript
-- `println!()` in Rust
-- Similar stdout functions in other languages
-
-Writing to stdout will corrupt the JSON-RPC messages and break your server.
+**For STDIO-based servers:** Never use `println!()` or `print!()`, as they write to standard output (stdout). Writing to stdout will corrupt the JSON-RPC messages and break your server.
 
 **For HTTP-based servers:** Standard output logging is fine since it doesn't interfere with HTTP responses.
 
 ### Best Practices
 
-1. Use a logging library that writes to stderr or files, such as `tracing` or `log` in Rust.
-2. Configure your logging framework to avoid stdout output.
+- Use a logging library that writes to stderr or files, such as `tracing` or `log` in Rust.
+- Configure your logging framework to avoid stdout output.
 
 ### Quick Examples
 
@@ -1834,8 +1814,7 @@ Writing to stdout will corrupt the JSON-RPC messages and break your server.
 println!("Processing request");
 
 // ✅ Good (STDIO)
-use tracing::info;
-info!("Processing request"); // writes to stderr
+eprintln!("Processing request"); // writes to stderr
 ```
 
 ### System requirements


### PR DESCRIPTION
The "Logging in MCP Servers" section was copy-pasted across language tabs with examples from Python, JavaScript, and Go regardless of which tab the reader was viewing. Each tab now only references its own language:

- Python: `print()` with `file=sys.stderr` workaround
- TypeScript: `console.log()` / `console.error()`
- Java: `System.out.println()`
- Kotlin: Added missing logging section with `println()`
- C#: `Console.WriteLine()`
- Rust: `println!()` / `print!()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
