### PR TITLE
Format tool name examples as inline code

### DIFF
--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -219,9 +219,9 @@ A tool definition includes:
 - Tool names **SHOULD NOT** contain spaces, commas, or other special characters.
 - Tool names **SHOULD** be unique within a server.
 - Example valid tool names:
-  - getUser
-  - DATA_EXPORT_v2
-  - admin.tools.list
+  - `getUser`
+  - `DATA_EXPORT_v2`
+  - `admin.tools.list`
 
 ### Tool Result
 


### PR DESCRIPTION
Add backticks around example tool names in the Tool Names section for consistent code formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
