### PR TITLE
Add Memgraph Lab as an example MCP client

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -73,6 +73,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [MCPHub][MCPHub]                                 | ✅          | ✅        | ✅      | ❓                     | ❌         | ❌    | ❓            | ❓             |
 | [MCPOmni-Connect][MCPOmni-Connect]               | ✅          | ✅        | ✅      | ❓                     | ✅         | ❌    | ❓            | ❓             |
 | [Memex][Memex]                                   | ✅          | ✅        | ✅      | ❓                     | ❌         | ❌    | ❓            | ❓             |
+| [Memgraph Lab][Memgraph Lab]                     | ❌          | ❌        | ✅      | ❌                     | ✅         | ❌    | ✅            | ✅             |
 | [Microsoft Copilot Studio]                       | ✅          | ❌        | ✅      | ✅                     | ❌         | ❌    | ❓            | ❓             |
 | [MindPal][MindPal]                               | ❌          | ❌        | ✅      | ❓                     | ❌         | ❌    | ❓            | ❓             |
 | [Mistral AI: Le Chat][Mistral AI: Le Chat]       | ❌          | ❌        | ✅      | ❌                     | ❌         | ❌    | ❓            | ❓             |
@@ -179,6 +180,7 @@ This page provides an overview of applications that support the Model Context Pr
 [MCPHub]: https://github.com/ravitemer/mcphub.nvim
 [MCPOmni-Connect]: https://github.com/Abiorh001/mcp_omni_connect
 [Memex]: https://memex.tech/
+[Memgraph Lab]: https://memgraph.com/docs/memgraph-lab/features/graphchat
 [Microsoft Copilot Studio]: https://learn.microsoft.com/en-us/microsoft-copilot-studio/agent-extend-action-mcp
 [MindPal]: https://mindpal.io
 [Mistral AI: Le Chat]: https://chat.mistral.ai
@@ -941,6 +943,23 @@ Langflow is an open-source visual builder that lets developers rapidly prototype
 **Learn more:**
 
 - [Memex Launch 2: MCP Teams and Agent API](https://memex.tech/blog/memex-launch-2-mcp-teams-and-agent-api-private-preview-125f)
+
+### Memgraph Lab
+
+[Memgraph Lab](https://memgraph.com/lab) is a visualization and management tool for Memgraph graph databases. Its [GraphChat](https://memgraph.com/docs/memgraph-lab/features/graphchat) feature lets you query graph data using natural language, with MCP server integrations to extend your AI workflows.
+
+**Key features:**
+
+- Build GraphRAG workflows powered by knowledge graphs as the data backbone
+- Connect remote MCP servers via `SSE` or `Streamable HTTP`
+- Support for MCP tools, sampling, elicitation, and instructions
+- Create multiple agents with different configurations for easy comparison and debugging
+- Works with various LLM providers (OpenAI, Azure OpenAI, Anthropic, Gemini, Ollama, DeepSeek)
+- Available as a Desktop app or Docker container
+
+**Learn more:**
+
+- [Memgraph Lab: MCP integration](https://memgraph.com/docs/memgraph-lab/features/graphchat#mcp-servers)
 
 ### Microsoft Copilot Studio
 


### PR DESCRIPTION
I added Memgraph Lab to a list of MCP clients examples with its support, short description, key features, and a link to the documentation on how to use it.

## Motivation and Context

With more MCP features supported (lately elicitation, sampling, and instructions; prompts soon), I think Memgraph Lab should be in the list, especially due to its GraphRAG capabilities, which can be empowered with the MCP ecosystem.

## How Has This Been Tested?

Started the web app and ran lint processes.

## Breaking Changes

No breaking changes. Only documentation update.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
