### PR TITLE
Fix MCP spec links

### DIFF
--- a/blog/content/posts/2025-12-19-mcp-transport-future.md
+++ b/blog/content/posts/2025-12-19-mcp-transport-future.md
@@ -51,7 +51,7 @@ This direction mirrors standard HTTP, where the protocol itself is stateless whi
 
 ### Elicitations and Sampling
 
-Two MCP features are central to a few of the modern AI workflows: [Elicitations](https://spec.modelcontextprotocol.io/specification/2025-11-25/client/elicitation), which request human input, and [Sampling](https://spec.modelcontextprotocol.io/specification/2025-11-25/client/sampling), which enable agentic LLM interactions.
+Two MCP features are central to a few of the modern AI workflows: [Elicitations](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation), which request human input, and [Sampling](https://modelcontextprotocol.io/specification/2025-11-25/client/sampling), which enable agentic LLM interactions.
 
 Supporting these features at scale requires rethinking the bidirectional communication pattern they rely on. Currently, when a server needs more information to complete a tool call, it suspends execution and waits for a client response, requiring it to track all outstanding requests.
 

--- a/docs/development/roadmap.mdx
+++ b/docs/development/roadmap.mdx
@@ -17,7 +17,7 @@ The ideas presented here are not commitments—we may solve these challenges dif
 
 We value community participation! Each section links to relevant discussions where you can learn more and contribute your thoughts.
 
-For a technical view of our standardization process, visit the [Standards Track](https://github.com/orgs/modelcontextprotocol/projects/2/views/2) on GitHub, which tracks how proposals progress toward inclusion in the official [MCP specification](https://spec.modelcontextprotocol.io).
+For a technical view of our standardization process, visit the [Standards Track](https://github.com/orgs/modelcontextprotocol/projects/2/views/2) on GitHub, which tracks how proposals progress toward inclusion in the official [MCP specification](https://modelcontextprotocol.io/specification/).
 
 ## Priority Areas for the Next Release
 


### PR DESCRIPTION
Fix broken MCP specification links in the transport roadmap blog post and roadmap doc.