### PR TITLE
chore: Add CreateTaskResult to ServerResult

### DIFF
--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -3154,6 +3154,9 @@
                     "$ref": "#/$defs/CallToolResult"
                 },
                 {
+                    "$ref": "#/$defs/CreateTaskResult"
+                },
+                {
                     "$ref": "#/$defs/GetTaskResult",
                     "description": "The response to a tasks/get request."
                 },

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -2571,6 +2571,7 @@ export type ServerResult =
   | ListResourcesResult
   | ReadResourceResult
   | CallToolResult
+  | CreateTaskResult
   | ListToolsResult
   | GetTaskResult
   | GetTaskPayloadResult


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

The `CreateTaskResult` is missing from the `ServerResult` type.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
