### PR TITLE
Update client filter UI layout

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -5,13 +5,18 @@ description: "A list of applications that support MCP integrations"
 
 {/* prettier-ignore-start */}
 
-export const CAPABILITIES = ['Resources', 'Prompts', 'Tools', 'Discovery', 'Sampling', 'Roots', 'Elicitation', 'Instructions'];
+export const CAPABILITIES = ["Resources", "Prompts", "Tools", "Discovery", "Sampling", "Roots", "Elicitation", "Instructions"];
 
 export const filterStore = {
-  state: { selectedCapabilities: [], searchText: '', visibleCount: 0, totalCount: 0 },
+  state: {
+    selectedCapabilities: [],
+    searchText: "",
+    visibleCount: 0,
+    totalCount: 0
+  },
   listeners: new Set(),
   setState(updater) {
-    if (typeof updater === 'function') {
+    if (typeof updater === "function") {
       this.state = { ...this.state, ...updater(this.state) };
     } else {
       this.state = { ...this.state, ...updater };
@@ -30,8 +35,38 @@ export const useFilterStore = () => {
   return state;
 };
 
+export const useFilter = ({ name, supports }) => {
+  const { selectedCapabilities, searchText } = useFilterStore();
+
+  // Check if client matches filters
+  const isVisible = (
+    name.toLowerCase().includes(searchText.toLowerCase()) &&
+    selectedCapabilities.every(cap => supports?.includes(cap))
+  );
+
+  // Track total/visible counts
+  useEffect(() => {
+    filterStore.setState(s => ({ totalCount: s.totalCount + 1 }));
+    return () => filterStore.setState(s => ({ totalCount: s.totalCount - 1 }));
+  }, []);
+
+  useEffect(() => {
+    if (isVisible) {
+      filterStore.setState(s => ({ visibleCount: s.visibleCount + 1 }));
+      return () => filterStore.setState(s => ({ visibleCount: s.visibleCount - 1 }));
+    }
+  }, [isVisible]);
+
+  return isVisible;
+};
+
+
 export const ClientFilter = () => {
   const { selectedCapabilities, searchText, visibleCount, totalCount } = useFilterStore();
+
+  useEffect(() => {
+    filterStore.setState({ selectedCapabilities: [], searchText: "" });
+  }, []);
 
   const toggleCapability = (cap) => {
     const newCaps = selectedCapabilities.includes(cap)
@@ -41,32 +76,27 @@ export const ClientFilter = () => {
   };
 
   const clearFilters = () => {
-    filterStore.setState({ selectedCapabilities: [], searchText: '' });
+    filterStore.setState({ selectedCapabilities: [], searchText: "" });
   };
 
   const hasFilters = selectedCapabilities.length > 0 || searchText.length > 0;
 
   return (
-    <div className="mb-8 p-4 border border-gray-200 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-800/50">
-      <div className="mb-3">
-        <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Filter by capabilities:</div>
-        <div className="flex flex-wrap gap-2">
-          {CAPABILITIES.map(cap => (
-            <button
-              key={cap}
-              onClick={() => toggleCapability(cap)}
-              className={`px-3 py-1 rounded-full text-sm font-medium transition-colors cursor-pointer ${
-                selectedCapabilities.includes(cap)
-                  ? 'bg-primary text-white'
-                  : 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600'
-              }`}
-            >
-              {cap}
-            </button>
-          ))}
-        </div>
+    <div className="p-4 border border-gray-200 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-800/50">
+      <div className="flex items-center justify-between">
+        <span className="font-bold text-gray-700 dark:text-gray-300">
+          Showing {visibleCount} of {totalCount} clients
+        </span>
+        {hasFilters && (
+          <button
+            onClick={clearFilters}
+            className="text-sm cursor-pointer px-3 py-1 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+          >
+            <Icon icon="xmark" iconType="solid" size={16} /> Clear filters
+          </button>
+        )}
       </div>
-      <div className="mb-3">
+      <div className="mt-3">
         <input
           type="text"
           placeholder="Search clients by name..."
@@ -75,40 +105,41 @@ export const ClientFilter = () => {
           className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
         />
       </div>
-      <div className="flex items-center justify-between text-sm text-gray-600 dark:text-gray-400">
-        <span>Showing {visibleCount} of {totalCount} clients</span>
-        {hasFilters && (
-          <button
-            onClick={clearFilters}
-            className="text-primary hover:underline cursor-pointer"
-          >
-            Clear filters
-          </button>
-        )}
+      <div className="mt-4">
+        <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+          Filter by capabilities:
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {CAPABILITIES.map(cap => (
+            <button
+              key={cap}
+              onClick={() => toggleCapability(cap)}
+              className={`flex items-center gap-1.5 px-2 py-1 rounded text-sm transition-colors cursor-pointer ${
+                selectedCapabilities.includes(cap)
+                  ? 'bg-primary/10 text-primary dark:bg-gray-700 dark:text-gray-100'
+                  : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'
+              }`}
+            >
+              <Icon
+                icon={selectedCapabilities.includes(cap) ? "square-check" : "square"}
+                iconType={selectedCapabilities.includes(cap) ? "solid" : "regular"}
+                size={16}
+              />
+              {cap}
+            </button>
+          ))}
+        </div>
       </div>
     </div>
   );
 };
 
-export const ClientsSection = ({ children }) => {
-  useEffect(() => {
-    // Only reset filters, not counts (counts are managed by McpClient components)
-    filterStore.setState({ selectedCapabilities: [], searchText: '' });
-  }, []);
-
-  return (
-    <>
-      <ClientFilter />
-      {children}
-    </>
-  );
-};
 
 export const McpClient = ({ name, homepage, supports, sourceCode, instructions, children }) => {
   const slug = name
     .toLowerCase()
-    .replace(/[().\s-]+/g, '-')
-    .replace(/^-|-$/g, '');
+    .replace(/[().\s-]+/g, "-")
+    .replace(/^-|-$/g, "");
 
   if (homepage?.match(/^https:\/\/github\.com\/[^/]+\/[^/]+/)) {
     sourceCode ??= homepage;
@@ -129,29 +160,7 @@ export const McpClient = ({ name, homepage, supports, sourceCode, instructions, 
   const [expanded, setExpanded] = useState(false);
   const [hasOverflow, setHasOverflow] = useState(false);
   const contentRef = useRef(null);
-  const { selectedCapabilities, searchText } = useFilterStore();
-
-  // Parse client capabilities (strip "(partial)" suffix)
-  const clientCapabilities = (supports || '').split(',').map(s => s.trim().replace(/\s*\(partial\)/, ''));
-
-  // Check if client matches filters
-  const matchesCapabilities = selectedCapabilities.length === 0 ||
-    selectedCapabilities.every(cap => clientCapabilities.includes(cap));
-  const matchesSearch = !searchText || name.toLowerCase().includes(searchText.toLowerCase());
-  const isVisible = matchesCapabilities && matchesSearch;
-
-  // Track visible/total counts
-  useEffect(() => {
-    filterStore.setState(s => ({ totalCount: s.totalCount + 1 }));
-    return () => filterStore.setState(s => ({ totalCount: s.totalCount - 1 }));
-  }, []);
-
-  useEffect(() => {
-    if (isVisible) {
-      filterStore.setState(s => ({ visibleCount: s.visibleCount + 1 }));
-      return () => filterStore.setState(s => ({ visibleCount: s.visibleCount - 1 }));
-    }
-  }, [isVisible]);
+  const isVisible = useFilter({ name, supports });
 
   useEffect(() => {
     const el = contentRef.current;
@@ -217,7 +226,7 @@ export const McpClient = ({ name, homepage, supports, sourceCode, instructions, 
         <div className="relative">
           <div
             ref={contentRef}
-            className={`px-4 py-4 prose ${!expanded ? 'max-h-[7rem] overflow-hidden' : 'pb-8'}`}
+            className={`px-4 py-4 prose ${!expanded ? "max-h-[7rem] overflow-hidden" : "pb-8"}`}
           >
             {children}
           </div>
@@ -225,10 +234,10 @@ export const McpClient = ({ name, homepage, supports, sourceCode, instructions, 
             <button
               onClick={() => setExpanded(!expanded)}
               className={`absolute bottom-0 left-0 right-0 flex justify-center items-end pb-1 cursor-pointer text-gray-400 hover:text-gray-600 ${
-                !expanded ? 'h-16 bg-gradient-to-t from-white dark:from-gray-900 to-transparent' : 'h-8'
+                !expanded ? "h-16 bg-gradient-to-t from-white dark:from-gray-900 to-transparent" : "h-8"
               }`}
             >
-              <span className={`${expanded ? 'rotate-180' : ''} bg-white/60 dark:bg-gray-900/60 rounded-full`}>
+              <span className={`${expanded ? "rotate-180" : ""} bg-white/60 dark:bg-gray-900/60 rounded-full`}>
                 <Icon icon="chevron-down" iconType="solid" size={18} />
               </span>
             </button>
@@ -251,7 +260,7 @@ This list is maintained by the community. If you notice any inaccuracies or woul
 
 ## Client details
 
-<ClientsSection>
+<ClientFilter />
 
 <McpClient
   name="5ire"
@@ -2042,8 +2051,6 @@ Zencoder is a coding agent that's available as an extension for VS Code and JetB
 - [Zencoder Documentation](https://docs.zencoder.ai)
 
 </McpClient>
-
-</ClientsSection>
 
 ## Adding MCP support to your application
 


### PR DESCRIPTION
Move "Showing X of Y" count to top with bold styling, reorder search input above capability filters, and use checkbox icons for capability toggle buttons. Also extract filtering logic into `useFilter` hook and remove unnecessary `ClientsSection` wrapper component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

| Before | After |
| --- | --- |
| <img width="792" height="237" alt="before-1-light" src="https://github.com/user-attachments/assets/75879d44-3001-42d8-b331-8ad9b0f871e2" /> | <img width="792" height="250" alt="after-1-light" src="https://github.com/user-attachments/assets/bd845c17-a038-490a-aab7-c9fc178d7365" /> |
| <img width="792" height="237" alt="before-2-light" src="https://github.com/user-attachments/assets/e872f274-899f-4fc0-bf9f-7fea5085b76d" /> | <img width="792" height="250" alt="after-2-light" src="https://github.com/user-attachments/assets/47cc8229-5eda-4f48-a791-3146fa0aff5e" /> |
| <img width="792" height="237" alt="before-1-dark" src="https://github.com/user-attachments/assets/40ebdc60-f745-4e52-91c8-ba7cc4baf9e8" /> | <img width="792" height="250" alt="after-1-dark" src="https://github.com/user-attachments/assets/81111b82-1c8b-4dc2-b501-26bdd22b6bdf" /> |
| <img width="792" height="237" alt="before-2-dark" src="https://github.com/user-attachments/assets/bccea578-ac28-47e0-8c3b-168833008ad2" /> | <img width="792" height="250" alt="after-2-dark" src="https://github.com/user-attachments/assets/46156327-ab7e-4e48-b51c-3f8a658bcac6" /> |
