### PR TITLE
Add Firebender to clients list

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -808,6 +808,24 @@ fast-agent is a Python Agent framework, with simple declarative support for crea
 </McpClient>
 
 <McpClient
+  name="Firebender"
+  homepage="https://firebender.com"
+  supports="Tools"
+  instructions="https://docs.firebender.com/context/mcp"
+>
+
+Firebender is an IntelliJ plugin that offers a world-class coding agent with MCP integration for tool calling.
+
+**Key features:**
+
+- Tool integration for executing commands and scripts via STDIO, SSE indirectly supported via mcp-remote npm package.
+- Local server connections for enhanced privacy and security
+- MCPs can be installed via project rules or local workstation rules files.
+- Individual tools within MCPs can be turned off.
+
+</McpClient>
+
+<McpClient
   name="FlowDown"
   homepage="https://github.com/Lakr233/FlowDown"
   supports="Tools"


### PR DESCRIPTION
This ports #745 to the new `clients.mdx` format established in f32ca837b519e639ccc7c1ef7b3332ae976d6551.
