### PR TITLE
Clarify HTTP POST vs JSON-RPC request terminology

### DIFF
--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -93,7 +93,7 @@ MCP endpoint.
 1. The client **MUST** use HTTP POST to send JSON-RPC messages to the MCP endpoint.
 2. The client **MUST** include an `Accept` header, listing both `application/json` and
    `text/event-stream` as supported content types.
-3. The body of the POST request **MUST** be a single JSON-RPC _request_, _notification_, or _response_.
+3. The body of the HTTP POST request **MUST** be a single JSON-RPC _request_, _notification_, or _response_.
 4. If the input is a JSON-RPC _response_ or _notification_:
    - If the server accepts the input, the server **MUST** return HTTP status code 202
      Accepted with no body.


### PR DESCRIPTION
Change "POST request" to "HTTP POST" to avoid terminology collision with JSON-RPC `_request_` in the same sentence.

## Motivation and Context

In the Streamable HTTP section, line 96 previously read:

> "The body of the POST request **MUST** be a single JSON-RPC _request_, _notification_, or _response_."

This uses "request" in two different contexts (HTTP transport vs JSON-RPC message type), which can be confusing. Adding "HTTP" makes it clearer that we're referring to the transport layer, consistent with line 90 which uses "HTTP POST request":

> "The body of the HTTP POST request **MUST** be a single JSON-RPC _request_, _notification_, or _response_."

## How Has This Been Tested?

`bun run check:docs:format` passes  

## Breaking Changes

No 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

None 
