### PR TITLE
Fix protocolVersion values in initialize messages

### DIFF
--- a/docs/specification/2025-06-18/basic/lifecycle.mdx
+++ b/docs/specification/2025-06-18/basic/lifecycle.mdx
@@ -58,7 +58,7 @@ The client **MUST** initiate this phase by sending an `initialize` request conta
   "id": 1,
   "method": "initialize",
   "params": {
-    "protocolVersion": "2024-11-05",
+    "protocolVersion": "2025-06-18",
     "capabilities": {
       "roots": {
         "listChanged": true
@@ -82,7 +82,7 @@ The server **MUST** respond with its own capabilities and information:
   "jsonrpc": "2.0",
   "id": 1,
   "result": {
-    "protocolVersion": "2024-11-05",
+    "protocolVersion": "2025-06-18",
     "capabilities": {
       "logging": {},
       "prompts": {

--- a/docs/specification/2025-11-25/basic/lifecycle.mdx
+++ b/docs/specification/2025-11-25/basic/lifecycle.mdx
@@ -58,7 +58,7 @@ The client **MUST** initiate this phase by sending an `initialize` request conta
   "id": 1,
   "method": "initialize",
   "params": {
-    "protocolVersion": "2024-11-05",
+    "protocolVersion": "2025-11-25",
     "capabilities": {
       "roots": {
         "listChanged": true
@@ -104,7 +104,7 @@ The server **MUST** respond with its own capabilities and information:
   "jsonrpc": "2.0",
   "id": 1,
   "result": {
-    "protocolVersion": "2024-11-05",
+    "protocolVersion": "2025-11-25",
     "capabilities": {
       "logging": {},
       "prompts": {

--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -58,7 +58,7 @@ The client **MUST** initiate this phase by sending an `initialize` request conta
   "id": 1,
   "method": "initialize",
   "params": {
-    "protocolVersion": "2024-11-05",
+    "protocolVersion": "2025-11-25",
     "capabilities": {
       "roots": {
         "listChanged": true
@@ -104,7 +104,7 @@ The server **MUST** respond with its own capabilities and information:
   "jsonrpc": "2.0",
   "id": 1,
   "result": {
-    "protocolVersion": "2024-11-05",
+    "protocolVersion": "2025-11-25",
     "capabilities": {
       "logging": {},
       "prompts": {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Some versions of the spec have a down-level value for the `protocolVersion` in the example messages in the Lifecycle section. While down-level versions are valid, they don't make sense in these examples since the examples contain other features that require the latest protocolVersion.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

I discovered this problem when I tried to use the example message with a real server and it threw an error.
The request worked after I fixed the protocolVersion as in this PR.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

Just a doc change.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
