### PR TITLE
Fix broken CallToolRequest schema link in tools.mdx

### DIFF
--- a/docs/specification/2025-11-25/server/tools.mdx
+++ b/docs/specification/2025-11-25/server/tools.mdx
@@ -453,7 +453,7 @@ Tools use two error reporting mechanisms:
 
 1. **Protocol Errors**: Standard JSON-RPC errors for issues like:
    - Unknown tools
-   - Malformed requests (requests that fail to satisfy [CallToolRequest schema](specification/2025-11-25/schema#calltoolrequest))
+   - Malformed requests (requests that fail to satisfy [CallToolRequest schema](/specification/2025-11-25/schema#calltoolrequest))
    - Server errors
 
 2. **Tool Execution Errors**: Reported in tool results with `isError: true`:

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -453,7 +453,7 @@ Tools use two error reporting mechanisms:
 
 1. **Protocol Errors**: Standard JSON-RPC errors for issues like:
    - Unknown tools
-   - Malformed requests (requests that fail to satisfy [CallToolRequest schema](specification/draft/schema#calltoolrequest))
+   - Malformed requests (requests that fail to satisfy [CallToolRequest schema](/specification/draft/schema#calltoolrequest))
    - Server errors
 
 2. **Tool Execution Errors**: Reported in tool results with `isError: true`:


### PR DESCRIPTION
## Motivation and Context
  The `CallToolRequest schema` link in `docs/specification/2025-11-25/server/tools.mdx` was broken. It used a relative path `(specification/2025-11-25/schema#calltoolrequest)` which resolved incorrectly when published, producing:
  - **Broken URL**: `https://modelcontextprotocol.io/specification/2025-11-25/server/specification/2025-11-25/schema#calltoolrequest`
  - **Expected URL**: `https://modelcontextprotocol.io/specification/2025-11-25/schema#calltoolrequest`

  ## How Has This Been Tested?
  - Ran `npm run check:docs:links` - no broken links found

  ## Breaking Changes
  None

  ## Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [x] Documentation update

  ## Checklist
  - [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
  - [x] My code follows the repository's style guidelines
  - [ ] New and existing tests pass locally
  - [ ] I have added appropriate error handling
  - [ ] I have added or updated documentation as needed

  ## Additional context
  This PR was assisted by Claude Code for research and planning.