### PR TITLE
Update SDK maintainers list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -26,6 +26,7 @@ This document lists current maintainers in the Model Context Protocol project.
 - [Christian Tzolov](https://github.com/tzolov)
 - [Dariusz Jędrzejczyk](https://github.com/chemicL)
 - [Daniel Garnier-Moiroux](https://github.com/Kehrlann)
+- [Mark Pollack](https://github.com/markpollack)
 
 ### Ruby SDK
 
@@ -51,12 +52,19 @@ This document lists current maintainers in the Model Context Protocol project.
 
 - [Stephan Halter](https://github.com/halter73)
 - [Mike Kistler](https://github.com/mikekistler)
+- [Den Delimarsky](https://github.com/dend)
+- [Eirik Tsarpalis](https://github.com/eiriktsarpalis)
+- [Stephen Toub](https://github.com/stephentoub)
 
 ### Kotlin SDK
 
 - [Leonid Stashevsky](https://github.com/e5l)
 - [Sergey Ignatov](https://github.com/ignatov)
 - [Konstantin Pavlov](https://github.com/kpavlov)
+- [Pavel Gorgulov](https://github.com/devcrocod)
+- [Briliantov Vadim](https://github.com/Ololoshechkin)
+- [Sergei Dubov](https://github.com/sdubov)
+- [Maria Tigina](https://github.com/tiginamaria)
 
 ### Python SDK
 
@@ -64,6 +72,7 @@ This document lists current maintainers in the Model Context Protocol project.
 - [Jerome Swannack](https://github.com/jerome3o)
 - [Marcelo Trylesinski](https://github.com/Kludex)
 - [Max Isbey](https://github.com/maxisbey)
+- [Felix Weinberger](https://github.com/felixweinberger)
 
 ### TypeScript SDK
 
@@ -77,11 +86,18 @@ This document lists current maintainers in the Model Context Protocol project.
 
 - [Alex Hancock](https://github.com/alexhancock)
 - [Michael Bolin](https://github.com/bolinfest)
+- [Bradley Axen](https://github.com/baxen)
+- [Jack Amadeo](https://github.com/jamadeo)
+- [Michael Neale](https://github.com/michaelneale)
 
 ### PHP SDK
 
 - [Kyrian Obikwelu](https://github.com/CodeWithKyrian)
 - [Christopher Hertel](https://github.com/chr-hertel)
+- [Fabien Potencier](https://github.com/fabpot)
+- [Nicolas Grekas](https://github.com/nicolas-grekas)
+- [Tobias Nyholm](https://github.com/Nyholm)
+- [Roman Pronskiy](https://github.com/pronskiy)
 
 ## Project Maintainers
 


### PR DESCRIPTION
Updates the MAINTAINERS.md file to sync with team memberships in modelcontextprotocol/access.

## Changes

### Swift SDK
- Add Maksym Mova (@movetz)
- Add Stephen Tallent (@stallent)

### TypeScript SDK
- Add Konstantin Konstantinov (@KKonstantinov)
- Add Matt Carey (@mattzcarey)

### Python SDK
- Add Felix Weinberger (@felixweinberger)

### C# SDK
- Add Den Delimarsky (@dend)
- Add Eirik Tsarpalis (@eiriktsarpalis)
- Add Stephen Toub (@stephentoub)

### Kotlin SDK
- Add Pavel Gorgulov (@devcrocod)
- Add Briliantov Vadim (@Ololoshechkin)
- Add Sergei Dubov (@sdubov)
- Add Maria Tigina (@tiginamaria)

### Rust SDK
- Add Bradley Axen (@baxen)
- Add Jack Amadeo (@jamadeo)
- Add Michael Neale (@michaelneale)

### PHP SDK
- Add Fabien Potencier (@fabpot)
- Add Nicolas Grekas (@nicolas-grekas)
- Add Tobias Nyholm (@Nyholm)
- Add Roman Pronskiy (@pronskiy)

### Java SDK
- Add Mark Pollack (@markpollack)

Related: modelcontextprotocol/access#21 (grants Swift SDK repo access)