### PR TITLE
Add DCR/CIMD filter for Example Clients

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -281,20 +281,20 @@ export const McpClient = ({ name, homepage, supports, sourceCode, instructions, 
 
 This page showcases applications that support the Model Context Protocol (MCP). Each client may support different MCP features:
 
-| Feature                                 | Description                                                                                                 |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| <FeatureBadge feature="Resources" />    | Server-exposed data and content                                                                             |
-| <FeatureBadge feature="Prompts" />      | Pre-defined templates for LLM interactions                                                                  |
-| <FeatureBadge feature="Tools" />        | Executable functions that LLMs can invoke                                                                   |
-| <FeatureBadge feature="Discovery" />    | Support for tools/prompts/resources changed notifications                                                   |
-| <FeatureBadge feature="Instructions" /> | Server-provided guidance for LLMs                                                                           |
-| <FeatureBadge feature="Sampling" />     | Server-initiated LLM completions                                                                            |
-| <FeatureBadge feature="Roots" />        | Filesystem boundary definitions                                                                             |
-| <FeatureBadge feature="Elicitation" />  | User information requests                                                                                   |
+| Feature                                 | Description                                                                                                  |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| <FeatureBadge feature="Resources" />    | Server-exposed data and content                                                                              |
+| <FeatureBadge feature="Prompts" />      | Pre-defined templates for LLM interactions                                                                   |
+| <FeatureBadge feature="Tools" />        | Executable functions that LLMs can invoke                                                                    |
+| <FeatureBadge feature="Discovery" />    | Support for tools/prompts/resources changed notifications                                                    |
+| <FeatureBadge feature="Instructions" /> | Server-provided guidance for LLMs                                                                            |
+| <FeatureBadge feature="Sampling" />     | Server-initiated LLM completions                                                                             |
+| <FeatureBadge feature="Roots" />        | Filesystem boundary definitions                                                                              |
+| <FeatureBadge feature="Elicitation" />  | User information requests                                                                                    |
 | <FeatureBadge feature="CIMD" />         | [Client ID Metadata Document](specification/latest/basic/authorization#client-id-metadata-documents) support |
 | <FeatureBadge feature="DCR" />          | [Dynamic Client Registration](specification/latest/basic/authorization#dynamic-client-registration) support  |
-| <FeatureBadge feature="Tasks" />        | Long-running operation tracking                                                                             |
-| <FeatureBadge feature="Apps" />         | Interactive HTML interfaces                                                                                 |
+| <FeatureBadge feature="Tasks" />        | Long-running operation tracking                                                                              |
+| <FeatureBadge feature="Apps" />         | Interactive HTML interfaces                                                                                  |
 
 <Note>
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
This change introduces two new filters on the [example clients](https://modelcontextprotocol.io/clients) page - allowing users to filter clients that support Dynamic Client Registration (DCR) and Client ID Metadata Documents (CIMD). I also added an MCP client that supports DCR as a part of this PR.

I'm pretty sure this is part of https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1738. 

<img width="675" height="303" alt="Screenshot 2026-01-13 at 1 44 45 PM" src="https://github.com/user-attachments/assets/225c73da-f7b4-4a77-b590-742e5906faeb" />

## Motivation and Context
Currently, there is no source of truth on the internet for which clients support DCR or CIMD. Adding these filters allows developers implementing MCP Auth to understand which clients support what client registration method, if at all. 

## Breaking Changes
Documentation change - no breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
Docs feature added by request of several members of the MCP community :)