### PR TITLE
Fix blog theme toggle button

### DIFF
--- a/blog/layouts/partials/footer.html
+++ b/blog/layouts/partials/footer.html
@@ -74,12 +74,11 @@
 {{- if (not site.Params.disableThemeToggle) }}
 <script>
     document.getElementById("theme-toggle").addEventListener("click", () => {
-        const html = document.querySelector("html");
-        if (html.dataset.theme === "dark") {
-            html.dataset.theme = 'light';
+        if (document.body.className.includes("dark")) {
+            document.body.classList.remove('dark');
             localStorage.setItem("pref-theme", 'light');
         } else {
-            html.dataset.theme = 'dark';
+            document.body.classList.add('dark');
             localStorage.setItem("pref-theme", 'dark');
         }
     })


### PR DESCRIPTION
The light/dark theme toggle button was not working because the JavaScript was setting `html.dataset.theme` but PaperMod's CSS uses a `dark` class on the `body` element.

Updated the toggle script to match the original PaperMod implementation:
- Toggle `document.body.classList` instead of `html.dataset.theme`


https://github.com/user-attachments/assets/a95073d7-500f-4322-bbe3-e1f298d3a3a2

