### PR TITLE
docs(spec): clarify Allow header requirement for 405 responses

### DIFF
--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -141,7 +141,7 @@ MCP endpoint.
    supported content type.
 3. The server **MUST** either return `Content-Type: text/event-stream` in response to
    this HTTP GET, or else return HTTP 405 Method Not Allowed, indicating that the server
-   does not offer an SSE stream at this endpoint. If the server returns HTTP 405, it
+   does not offer an SSE stream at this endpoint. Per [RFC 9110 §15.5.6](https://httpwg.org/specs/rfc9110.html#status.405), if the server returns HTTP 405, it
    **MUST** include an `Allow` header listing the methods it does support (e.g.,
    `Allow: POST`).
 4. If the server initiates an SSE stream:


### PR DESCRIPTION
## Summary

This change makes explicit what is already implicitly required by HTTP compliance: per [RFC 9110 §15.5.6](https://httpwg.org/specs/rfc9110.html#status.405), 405 Method Not Allowed responses **MUST** include an `Allow` header listing the target resource's currently supported methods.

## Motivation

HTTP gateways (such as Apigee) enforce strict RFC compliance and may reject 405 responses that lack an `Allow` header, returning 502 Bad Gateway errors to clients. Making this requirement explicit in the MCP specification ensures SDK implementers include the header and avoid interoperability issues with enterprise infrastructure.

## Changes

- **Listening for Messages from the Server**: Clarified that if the server returns HTTP 405 when it does not offer SSE streams, it **MUST** include an `Allow` header (e.g., `Allow: POST`).
- **Session Management**: Clarified that if the server returns HTTP 405 when it does not allow clients to terminate sessions, it **MUST** include an `Allow` header.

## Reference

- Go SDK implementation: https://github.com/modelcontextprotocol/go-sdk/pull/757

## AI Disclosure

This PR was authored with assistance from GitHub Copilot CLI.