### PR TITLE
MCP Apps documentation tweaks

### DIFF
--- a/docs/docs/extensions/apps.mdx
+++ b/docs/docs/extensions/apps.mdx
@@ -147,119 +147,125 @@ The `create-mcp-app` skill includes architecture guidance, best practices, and
 working examples that the agent uses to generate your project.
 
 <Steps>
-  <Step title="Install the skill">
+<Step title="Install the skill">
 
-    If you are using Claude Code, you can install the skill directly with:
+If you are using Claude Code, you can install the skill directly with:
 
-    ```
-    /plugin marketplace add modelcontextprotocol/ext-apps
-    /plugin install mcp-apps@modelcontextprotocol-ext-apps
-    ```
+```
+/plugin marketplace add modelcontextprotocol/ext-apps
+/plugin install mcp-apps@modelcontextprotocol-ext-apps
+```
 
-    You can also use the [Vercel Skills CLI](https://vercel.com/changelog/introducing-skills-the-open-agent-skills-ecosystem) to install skills across different AI coding agents:
+You can also use the [Vercel Skills CLI](https://vercel.com/changelog/introducing-skills-the-open-agent-skills-ecosystem) to install skills across different AI coding agents:
 
-    ```bash
-    npx skills add modelcontextprotocol/ext-apps
-    ```
+```bash
+npx skills add modelcontextprotocol/ext-apps
+```
 
-    Alternatively, you can install the skill manually by cloning the ext-apps repository:
+Alternatively, you can install the skill manually by cloning the ext-apps repository:
 
-    ```bash
-    git clone https://github.com/modelcontextprotocol/ext-apps.git
-    ```
+```bash
+git clone https://github.com/modelcontextprotocol/ext-apps.git
+```
 
-    And then copying the skill to the appropriate location for your agent:
+And then copying the skill to the appropriate location for your agent:
 
-    | Agent                                                                                                                                                                        | Skills directory (macOS/Linux) | Skills directory (Windows)            |
-    | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------- |
-    | [Claude Code](https://docs.anthropic.com/en/docs/claude-code/skills)                                                                                                         | `~/.claude/skills/`            | `%USERPROFILE%\.claude\skills\`       |
-    | [VS Code](https://code.visualstudio.com/docs/copilot/customization/agent-skills) and [GitHub Copilot](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills) | `~/.copilot/skills/`           | `%USERPROFILE%\.copilot\skills\`      |
-    | [Gemini CLI](https://geminicli.com/docs/cli/skills/)                                                                                                                         | `~/.gemini/skills/`            | `%USERPROFILE%\.gemini\skills\`       |
-    | [Cline](https://cline.bot/blog/cline-3-48-0-skills-and-websearch-make-cline-smarter)                                                                                         | `~/.cline/skills/`             | `%USERPROFILE%\.cline\skills\`        |
-    | [Goose](https://block.github.io/goose/docs/guides/context-engineering/using-skills/)                                                                                         | `~/.config/goose/skills/`      | `%USERPROFILE%\.config\goose\skills\` |
+| Agent                                                                                                                                                                        | Skills directory (macOS/Linux) | Skills directory (Windows)            |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------- |
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code/skills)                                                                                                         | `~/.claude/skills/`            | `%USERPROFILE%\.claude\skills\`       |
+| [VS Code](https://code.visualstudio.com/docs/copilot/customization/agent-skills) and [GitHub Copilot](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills) | `~/.copilot/skills/`           | `%USERPROFILE%\.copilot\skills\`      |
+| [Gemini CLI](https://geminicli.com/docs/cli/skills/)                                                                                                                         | `~/.gemini/skills/`            | `%USERPROFILE%\.gemini\skills\`       |
+| [Cline](https://cline.bot/blog/cline-3-48-0-skills-and-websearch-make-cline-smarter)                                                                                         | `~/.cline/skills/`             | `%USERPROFILE%\.cline\skills\`        |
+| [Goose](https://block.github.io/goose/docs/guides/context-engineering/using-skills/)                                                                                         | `~/.config/goose/skills/`      | `%USERPROFILE%\.config\goose\skills\` |
 
-    <Note>
+<Note>
 
-      This list is not comprehensive. Other agents may support skills in different locations; check your agent's documentation.
+This list is not comprehensive. Other agents may support skills in different locations; check your agent's documentation.
 
-    </Note>
+</Note>
 
-    For example, with Claude Code you can install the skill globally (available in all projects):
+For example, with Claude Code you can install the skill globally (available in all projects):
 
-    <CodeGroup>
+<CodeGroup>
 
-    ```bash macOS/Linux
-    cp -r ext-apps/plugins/mcp-apps/skills/create-mcp-app ~/.claude/skills/create-mcp-app
-    ```
+```bash macOS/Linux
+cp -r ext-apps/plugins/mcp-apps/skills/create-mcp-app ~/.claude/skills/create-mcp-app
+```
 
-    ```powershell Windows
-    Copy-Item -Recurse ext-apps\plugins\mcp-apps\skills\create-mcp-app $env:USERPROFILE\.claude\skills\create-mcp-app
-    ```
+```powershell Windows
+Copy-Item -Recurse ext-apps\plugins\mcp-apps\skills\create-mcp-app $env:USERPROFILE\.claude\skills\create-mcp-app
+```
 
-    </CodeGroup>
+</CodeGroup>
 
-    Or install it for a single project only by copying to `.claude/skills/` in your project directory:
+Or install it for a single project only by copying to `.claude/skills/` in your project directory:
 
-    <CodeGroup>
+<CodeGroup>
 
-    ```bash macOS/Linux
-    mkdir -p .claude/skills && cp -r ext-apps/plugins/mcp-apps/skills/create-mcp-app .claude/skills/create-mcp-app
-    ```
+```bash macOS/Linux
+mkdir -p .claude/skills && cp -r ext-apps/plugins/mcp-apps/skills/create-mcp-app .claude/skills/create-mcp-app
+```
 
-    ```powershell Windows
-    New-Item -ItemType Directory -Force -Path .claude\skills | Out-Null; Copy-Item -Recurse ext-apps\plugins\mcp-apps\skills\create-mcp-app .claude\skills\create-mcp-app
-    ```
+```powershell Windows
+New-Item -ItemType Directory -Force -Path .claude\skills | Out-Null; Copy-Item -Recurse ext-apps\plugins\mcp-apps\skills\create-mcp-app .claude\skills\create-mcp-app
+```
 
-    </CodeGroup>
+</CodeGroup>
 
-    To verify the skill is installed, ask your agent "What skills do you have access to?" — you should see `create-mcp-app` as one of the available skills.
+To verify the skill is installed, ask your agent "What skills do you have access to?" — you should see `create-mcp-app` as one of the available skills.
 
-  </Step>
-  <Step title="Create your app">
+</Step>
+<Step title="Create your app">
 
-    Ask your AI coding agent to build it:
+Ask your AI coding agent to build it:
 
-    ```
-    Create an MCP App that displays a color picker
-    ```
+```
+Create an MCP App that displays a color picker
+```
 
-    The agent will recognize the `create-mcp-app` skill is relevant, load its instructions, then scaffold a complete project with server, UI, and configuration files.
+The agent will recognize the `create-mcp-app` skill is relevant, load its instructions, then scaffold a complete project with server, UI, and configuration files.
 
-    <Frame caption="Creating a new MCP App with Claude Code">
-      <img src="../../images/quickstart-apps/create-mcp-app-skill.gif" alt="Creating a new MCP App with Claude Code" />
-    </Frame>
+<Frame caption="Creating a new MCP App with Claude Code">
+  <img
+    src="../../images/quickstart-apps/create-mcp-app-skill.gif"
+    alt="Creating a new MCP App with Claude Code"
+  />
+</Frame>
 
-  </Step>
-  <Step title="Run your app">
+</Step>
+<Step title="Run your app">
 
-    <CodeGroup>
+<CodeGroup>
 
-      ```bash macOS/Linux
-      npm install && npm run build && npm run serve
-      ```
+```bash macOS/Linux
+npm install && npm run build && npm run serve
+```
 
-      ```powershell Windows
-      npm install; npm run build; npm run serve
-      ```
+```powershell Windows
+npm install; npm run build; npm run serve
+```
 
-    </CodeGroup>
+</CodeGroup>
 
-    <Tip>
+<Tip>
 
-      You might need to make sure that you are first in the **app folder** before running the commands above.
+You might need to make sure that you are first in the **app folder** before running the commands above.
 
-    </Tip>
+</Tip>
 
-  </Step>
-  <Step title="Test your app">
+</Step>
+<Step title="Test your app">
 
-    Follow the instructions in [Testing your app](#testing-your-app) below. For the color picker example, start a new chat and ask Claude to provide you a color picker.
+Follow the instructions in [Testing your app](#testing-your-app) below. For the color picker example, start a new chat and ask Claude to provide you a color picker.
 
-    <Frame caption="Testing the color picker in Claude">
-      <img src="../../images/quickstart-apps/test-color-picker.gif" alt="Testing the color picker in Claude" />
-    </Frame>
+<Frame caption="Testing the color picker in Claude">
+  <img
+    src="../../images/quickstart-apps/test-color-picker.gif"
+    alt="Testing the color picker in Claude"
+  />
+</Frame>
 
-  </Step>
+</Step>
 </Steps>
 
 ### Manual setup
@@ -268,100 +274,100 @@ If you're not using an AI coding agent, or prefer to understand the setup
 process, follow these steps.
 
 <Steps>
-  <Step title="Create the project structure">
+<Step title="Create the project structure">
 
-    A typical MCP App project separates the server code from the UI code:
+A typical MCP App project separates the server code from the UI code:
 
-    <Tree>
-      <Tree.Folder name="my-mcp-app" defaultOpen>
-        <Tree.File name="package.json" />
-        <Tree.File name="tsconfig.json" />
-        <Tree.File name="vite.config.ts" />
-        <Tree.File name="server.ts" comment="MCP server with tool + resource" />
-        <Tree.File name="mcp-app.html" comment="UI entry point" />
-        <Tree.Folder name="src" defaultOpen>
-          <Tree.File name="mcp-app.ts" comment="UI logic" />
-        </Tree.Folder>
-      </Tree.Folder>
-    </Tree>
+<Tree>
+  <Tree.Folder name="my-mcp-app" defaultOpen>
+    <Tree.File name="package.json" />
+    <Tree.File name="tsconfig.json" />
+    <Tree.File name="vite.config.ts" />
+    <Tree.File name="server.ts" comment="MCP server with tool + resource" />
+    <Tree.File name="mcp-app.html" comment="UI entry point" />
+    <Tree.Folder name="src" defaultOpen>
+      <Tree.File name="mcp-app.ts" comment="UI logic" />
+    </Tree.Folder>
+  </Tree.Folder>
+</Tree>
 
-    The server registers the tool and serves the UI resource. The UI files get bundled into a single HTML file that the server returns when the host requests the resource.
+The server registers the tool and serves the UI resource. The UI files get bundled into a single HTML file that the server returns when the host requests the resource.
 
-  </Step>
-  <Step title="Install dependencies">
+</Step>
+<Step title="Install dependencies">
 
-    ```bash
-    npm install @modelcontextprotocol/ext-apps @modelcontextprotocol/sdk
-    npm install -D typescript vite vite-plugin-singlefile express cors @types/express @types/cors tsx
-    ```
+```bash
+npm install @modelcontextprotocol/ext-apps @modelcontextprotocol/sdk
+npm install -D typescript vite vite-plugin-singlefile express cors @types/express @types/cors tsx
+```
 
-    The `ext-apps` package provides helpers for both the server side (registering tools and resources) and the client side (the `App` class for UI-to-host communication). Vite with the `vite-plugin-singlefile` plugin bundles your UI into a single HTML file that can be served as a resource.
+The `ext-apps` package provides helpers for both the server side (registering tools and resources) and the client side (the `App` class for UI-to-host communication). Vite with the `vite-plugin-singlefile` plugin bundles your UI into a single HTML file that can be served as a resource.
 
-  </Step>
-  <Step title="Configure the project">
+</Step>
+<Step title="Configure the project">
 
-    <Tabs>
-      <Tab title="package.json">
+<Tabs>
+<Tab title="package.json">
 
-        The `"type": "module"` setting enables ES module syntax. The `build` script uses the `INPUT` environment variable to tell Vite which HTML file to bundle. The `serve` script runs your server using `tsx` for TypeScript execution.
+The `"type": "module"` setting enables ES module syntax. The `build` script uses the `INPUT` environment variable to tell Vite which HTML file to bundle. The `serve` script runs your server using `tsx` for TypeScript execution.
 
-        ```json
-        {
-          "type": "module",
-          "scripts": {
-            "build": "INPUT=mcp-app.html vite build",
-            "serve": "npx tsx server.ts"
-          }
-        }
-        ```
+```json
+{
+  "type": "module",
+  "scripts": {
+    "build": "INPUT=mcp-app.html vite build",
+    "serve": "npx tsx server.ts"
+  }
+}
+```
 
-      </Tab>
-      <Tab title="tsconfig.json">
+</Tab>
+<Tab title="tsconfig.json">
 
-        The TypeScript configuration targets modern JavaScript (`ES2022`) and uses ESNext modules with bundler resolution, which works well with Vite. The `include` array covers both the server code in the root and UI code in `src/`.
+The TypeScript configuration targets modern JavaScript (`ES2022`) and uses ESNext modules with bundler resolution, which works well with Vite. The `include` array covers both the server code in the root and UI code in `src/`.
 
-        ```json
-        {
-          "compilerOptions": {
-            "target": "ES2022",
-            "module": "ESNext",
-            "moduleResolution": "bundler",
-            "strict": true,
-            "esModuleInterop": true,
-            "skipLibCheck": true,
-            "outDir": "dist"
-          },
-          "include": ["*.ts", "src/**/*.ts"]
-        }
-        ```
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["*.ts", "src/**/*.ts"]
+}
+```
 
-      </Tab>
-      <Tab title="vite.config.ts">
+</Tab>
+<Tab title="vite.config.ts">
 
-        ```typescript
-        import { defineConfig } from "vite";
-        import { viteSingleFile } from "vite-plugin-singlefile";
+```typescript
+import { defineConfig } from "vite";
+import { viteSingleFile } from "vite-plugin-singlefile";
 
-        export default defineConfig({
-          plugins: [viteSingleFile()],
-          build: {
-            outDir: "dist",
-            rollupOptions: {
-              input: process.env.INPUT,
-            },
-          },
-        });
-        ```
+export default defineConfig({
+  plugins: [viteSingleFile()],
+  build: {
+    outDir: "dist",
+    rollupOptions: {
+      input: process.env.INPUT,
+    },
+  },
+});
+```
 
-      </Tab>
-    </Tabs>
+</Tab>
+</Tabs>
 
-  </Step>
-  <Step title="Build the project">
+</Step>
+<Step title="Build the project">
 
-    With the project structure and configuration in place, continue to [Building an MCP App](#building-an-mcp-app) below to implement the server and UI.
+With the project structure and configuration in place, continue to [Building an MCP App](#building-an-mcp-app) below to implement the server and UI.
 
-  </Step>
+</Step>
 </Steps>
 
 ## Building an MCP App


### PR DESCRIPTION
Some formatting tweaks, and also reordered the Skill installation instructions to present the easy options first, with manual installation as a fall back.