### PR TITLE
Community feedback iteration (rev 1) on SEP-1649 (MCP Server Cards)

### DIFF
--- a/seps/2127-mcp-server-cards.md
+++ b/seps/2127-mcp-server-cards.md
@@ -409,7 +409,9 @@ The `.well-known` URI pattern is an established IETF standard (RFC 8615) used by
 
 ### Why Mirror `server.json`'s shape?
 
-The MCP Registry team has iterated on a shape that properly enables MCP server configuration and connection across hundreds of industry stakeholders over the past year, so we have reasonably high confidence that this shape will work for most use cases.
+MCP Server Cards aim to provide a static representation of server metadata and capabilities so that clients can discover and connect to them without prior knowledge of their existence.
+
+The MCP Registry and conformant internal Sub-Registry implementations share the same goal, just distributed via a centralized rather than decentralized manner.
 
 By avoiding inducing breaking changes to the `server.json` shape, we also leave intact dozens, perhaps hundreds of systems that are already in production across the MCP Registry-related ecosystem.
 


### PR DESCRIPTION
Proposed iteration on https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127

I've taken into account all the feedback from:
- The [discussion](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1649) on the original SEP Issue
- Ensuing discussion on a [Google Doc](https://docs.google.com/document/d/13fVsxAeRWgHzG6XXcH_Ouh-0sMsk0t93AgUkOctap7g/edit?tab=t.0#heading=h.jcx25kx4jn97) bikeshedding the shape
- @maiargu and @Fannon's [recent PR](https://github.com/maiargu/registry/pull/1)
- Some consideration of the direction [AI Cards](https://github.com/Agent-Card/ai-card) are going

...in pursuit of taking an iterative step towards bringing us all into alignment on this SEP.

Big thank you to @ggoodman, @PederHP, @sdatspun2, @connor4312, @SamMorrowDrums, @fannon, @maiargu, @electrocucaracha, @ibuildthecloud, @yoannarz, @pcarleton, @domdomegg and everyone else commenting and contributing so far; the feedback is all helping progress this forward.

I have avoided iterating on some of the more controversial topics, like `dynamic` as a value option for primitives, so we can hopefully land this quickly and have separate longer-running discussions on those sticky points.

---

Some highlights worth pulling out

### Relationship to AI Card

The [AI Card](https://github.com/Agent-Card/ai-card) standard is paving a path to providing a protocol-agnostic `.well-known` path and file format for discovering services. They are planning to serve a list of AI Cards at `.well-known/ai-catalog.json`.

MCP Server Cards will provide a richer, MCP-specific definition that can be used by MCP clients to actually connect and start performing MCP operations. We will store these values at `.well-known/mcp/server-cards.json`.

Example:
- "Restaurant A" works with platform "Restaurant Reservations SaaS" to provide MCP-powered bookings for their restaurant
- Restaurant A also works with platform "Jobs SaaS" to provide MCP-powered job listings to prospective job seekers
- Restaurant A would advertise the two relevant AI Cards at `restaurant-a.com/.well-known/ai-catalog.json`
- Restaurant Reservations SaaS would have many Server Cards at `restaurant-reservations-saas.com/.well-known/mcp/server-cards.json`, including entries for each of Restaurant A, Restaurant B, etc.
- Jobs Saas would have many Server Cards at `jobs-saas.com/.well-known/mcp/server-cards.json`, including entries for each of Restaurant A, Coffee Shop B, etc.

We can develop and iterate on MCP Server Cards largely independently from the broader effort to integrate with AI Cards, as long as we maintain some integration point so it is possible to understand when an entry in an AI Card references an MCP Server Card that is hosted and maintained elsewhere.

## Instructions as a field in the Server Card

@PederHP had a good point [here](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1649#issuecomment-3452901403).

I think it's reasonable to consider, but we don't have it in `server.json` right now and it doesn't seem particularly critical to have blocking discussions on; I think we should leave it out for now. I've removed it in this PR.

## supportedProtocolVersion

I've moved this field _inside_ the `remotes` field, per discussion with @ggoodman [here](https://docs.google.com/document/d/13fVsxAeRWgHzG6XXcH_Ouh-0sMsk0t93AgUkOctap7g/edit?disco=AAABtXZxA1Y).

I think it would be reasonable to consider removing this from the SEP to simplify, as we don't currently have it in `server.json` so we'd be trying to collect feedback on use cases as we try to land this higher level piece of work in Server Card.

## authentication

I've also moved this field _inside_ the `remotes` field. My firsthand experience is that it is very common for different `remotes` entries to have different valid auth methods, so I think it would be a big shift for the ecosystem to consider authentication a top level Server Card concern.

---

Some topics I think we should continue discussing (but out of scope for landing this PR) into the SEP --

## Removing $schema from server.json and not including it in Server Card

I've removed the explicit $schema field in this PR. We were planning to do this for the MCP Registry in the next iteration of server.json (rationale [here](https://discord.com/channels/1358869848138059966/1369487942862504016/1463653488012824812), cc @rdimitrov). Basically, hardcoding the $schema field there introduces an unnecessary breaking change across versions, when we don't have intention to make breaking changes to these shapes. 

A better solution here would probably be to use something like @vyshnavigadamsetti's suggestion of `mcpCard: "1.0"` that wouldn't needlessly create breaks with every (non-breaking) change.

## Removing `dynamic` as an option in tools/primitive values

There is pretty significant community opposition to including `dynamic` as a possible value. @connor4312, @SamMorrowDrums, @fannon, @sdatspun2 have all expressed their reasoning against it ([link](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1649#issuecomment-3470669197), [link](https://docs.google.com/document/d/13fVsxAeRWgHzG6XXcH_Ouh-0sMsk0t93AgUkOctap7g/edit?disco=AAABtWWWz-U)).

## Removing the spec language around serving Server Cards as a resource

I left it as-written in the SEP for now, but there is [motivation to have this removed](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1649#issuecomment-3470715155)

## Placement of .well-known path

I didn't flesh this out further in this PR, but we should probably incorporate the thinking from @pcarleton and @simonrussell ([link](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1649#issuecomment-3450673046), [link](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1649#issuecomment-3453683897)) explicitly into our language.
