### PR TITLE
docs(extensions): Fix MCP server endpoint path in apps guide

### DIFF
--- a/docs/docs/extensions/apps.mdx
+++ b/docs/docs/extensions/apps.mdx
@@ -629,11 +629,11 @@ pass the `SERVERS` environment variable inline:
 <CodeGroup>
 
 ```bash macOS/Linux
-SERVERS='["http://localhost:3001"]' npm start
+SERVERS='["http://localhost:3001/mcp"]' npm start
 ```
 
 ```powershell Windows
-$env:SERVERS='["http://localhost:3001"]'; npm start
+$env:SERVERS='["http://localhost:3001/mcp"]'; npm start
 ```
 
 </CodeGroup>


### PR DESCRIPTION
Fixed the `SERVERS` environment variable examples in the MCP apps testing guide to include the required `/mcp` endpoint path.

## Motivation and Context
The `/mcp` path is required when testing MCP apps, as documented in the [official MCP apps testing guide](https://modelcontextprotocol.github.io/ext-apps/api/documents/Testing_MCP_Apps.html). The current examples showed `http://localhost:3001`, which would fail without the `/mcp` path.

## How Has This Been Tested?
Verified that the examples now match the official MCP apps testing documentation which explicitly specifies the `/mcp` path as a required endpoint.

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
