### PR TITLE
Clarify relationship between `server.json` and MCP Server Cards

### DIFF
--- a/seps/2127-mcp-server-cards.md
+++ b/seps/2127-mcp-server-cards.md
@@ -56,9 +56,9 @@ Example:
 
 We can develop and iterate on MCP Server Cards largely independently from the broader effort to integrate with AI Cards, as long as we maintain some integration point so it is possible to understand when an entry in an AI Card references an MCP Server Card that is hosted and maintained elsewhere.
 
-### Extended MCP Server Cards
+### Relationship to `server.json`
 
-The focus of MCP Server Cards is on expressing _remote_ MCP servers; however the card is designed to be compatible with an Extended MCP Server Card that includes consideration for locally-run MCP servers (e.g. where to download executable packages, how to run them).
+The focus of MCP Server Cards is on expressing _remote_ MCP servers; however the card is designed to be compatible with the previously established `server.json` standard that includes consideration for locally-run MCP servers (e.g. where to download executable packages, how to run them).
 
 This alignment is useful for the following reasons:
 
@@ -296,14 +296,14 @@ Most fields follow the current MCP Registry `server.json` standard: https://gith
 
 MCP primitives are dynamic in nature and can change. To indicate that a list of primitives is dynamic in nature, authors can provide the reserved string "dynamic" (as an array with a single element) for the resources, tools, or prompts field. This indicates that the full list of primitives must be discovered through the protocol's standard list operations.
 
-### Extended MCP Server Card Schema
+### `server.json` Schema
 
-We rename the MCP Registry's `server.json` to `Extended MCP Server Card`, and define the schema as having this shape:
+Building on the previously established [`server.json` shape](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/generic-server-json.md), we move it to be defined in terms of the new Server Card shape:
 
 ```json
 {
   // ... all the fields above except $schema
-  "$schema": "https://static.modelcontextprotocol.io/schemas/v1/extended-server-card.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/v1/server.schema.json",
   "packages": [ ... ]
 }
 ```
@@ -313,7 +313,7 @@ With example values:
 ```json
 {
   // ... all the fields above except $schema
-  "$schema": "https://static.modelcontextprotocol.io/schemas/v1/extended-server-card.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/v1/server.schema.json",
   "packages": [
     {
       "registryType": "npm",


### PR DESCRIPTION
Incorporating feedback from https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2152 regarding the topic "how do MCP Server Cards relate to server.json". Specifically the comment left open at https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2152#discussion_r2745808122

Builds on https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127

Per @dsp:

> I think we all agree that Server Cards should be a subset of server.json. They should have the same shape. It should be trivial to point a framework to a server.json and let it expose a server card.

Left open was this thread:

> I very much agree with @localden and @maiargu. The Server card should care about exposing HTTP and only that. We should aim for minimal information not maximal information. In fact, den has me believe we don't want any local package installation mechanisms at all. We might be okay to "refer" to a the registry so that clients trusting the registry can refer to that, but not more.

This PR brings the SEP into alignment with that point of view by:
- Removing `packages` from the MCP Server Card
- Renaming the MCP Registry's `server.json` to `Extended MCP Server Card` and reintroducing `packages` there
- Explaining the reasoning behind this design decision

I think the naming of "Extended MCP Server Card" is a little awkward (open to other suggestions). It feels like it would be cleaner to maximally define "MCP Server Card" with all the fields, and then constrain the remote/.well-known URI variant to be a "Remote MCP Server Card" -- but I don't feel strongly on this, so I wrote this PR from the perspective that we want to minimally design the core MCP Server Card and refer to its expansions as something else ("Extended MCP Server Card" in the verbiage of this PR).

