### PR TITLE
SEP-2188: Add elicitation timeout coordination via notifications/elicitation/pe…

### DIFF
--- a/docs/community/seps/2188-elicitation-timeout-coordination.mdx
+++ b/docs/community/seps/2188-elicitation-timeout-coordination.mdx
@@ -1,0 +1,236 @@
+---
+title: "SEP-2188: Elicitation Timeout Coordination"
+sidebarTitle: "SEP-2188: Elicitation Timeout Coordination"
+description: "Elicitation Timeout Coordination"
+---
+
+<div className="flex items-center gap-2 mb-4">
+  <Badge color="gray" shape="pill">
+    Draft
+  </Badge>
+  <Badge color="gray" shape="pill">
+    Standards Track
+  </Badge>
+</div>
+
+| Field         | Value                                                                           |
+| ------------- | ------------------------------------------------------------------------------- |
+| **SEP**       | 2188                                                                            |
+| **Title**     | Elicitation Timeout Coordination                                                |
+| **Status**    | Draft                                                                           |
+| **Type**      | Standards Track                                                                 |
+| **Created**   | 2026-02-27                                                                      |
+| **Author(s)** | Arsalan Shakil ([@ArsalanShakil](https://github.com/ArsalanShakil))             |
+| **Sponsor**   | None (seeking sponsor)                                                          |
+| **PR**        | [#2188](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2188) |
+
+---
+
+## Abstract
+
+This SEP introduces a `notifications/elicitation/pending` notification that servers can send to clients before issuing an `elicitation/create` request during in-flight request processing. The notification includes the `requestId` of the original request (e.g., a tool call) so the client can suspend or extend its timeout for that request while waiting for user input. This addresses the problem described in [#2006](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2006), where tool calls timeout because the client has no way to know that a server is waiting for user input via elicitation.
+
+## Motivation
+
+When a server issues a form-mode elicitation during a tool call, the client's configured request timeout may expire before the user has a chance to respond. This creates a poor user experience: the tool call fails with a timeout error even though the server is actively and legitimately waiting for user input.
+
+Consider this scenario:
+
+1. Client sends `tools/call` with a 60-second request timeout
+2. Server processes the tool call and determines it needs user input
+3. Server sends `elicitation/create` (mode: form) to the client
+4. The user sees the form but takes more than 60 seconds to respond
+5. The client's timeout fires and the `tools/call` fails
+
+This is particularly problematic because:
+
+- **The client has no advance notice** that an elicitation is coming. It cannot preemptively extend the timeout.
+- **URL mode has partial coverage** via `notifications/elicitation/complete` and `URLElicitationRequiredError`, but form mode has no such coordination mechanism.
+- **The task system helps but isn't always appropriate**. Task-augmented requests (which return immediately with a task ID) can avoid the timeout issue, but not all tool calls warrant full task lifecycle management. Simple "ask the user a question and continue" patterns shouldn't require task infrastructure.
+- **Progress notifications can reset the timeout clock**, but this is a workaround rather than a proper coordination mechanism. Servers would need to send artificial progress notifications that don't represent actual progress.
+
+The existing protocol lacks a lightweight, purpose-built mechanism for timeout coordination when elicitation is involved.
+
+## Specification
+
+### New Notification: `notifications/elicitation/pending`
+
+A new optional server-to-client notification is introduced:
+
+```typescript
+export interface ElicitationPendingNotification extends JSONRPCNotification {
+  method: "notifications/elicitation/pending";
+  params: {
+    /**
+     * The ID of the original request that triggered this elicitation.
+     * This allows the client to associate the pending elicitation with
+     * the request whose timeout should be adjusted.
+     */
+    requestId: RequestId;
+
+    /**
+     * An optional hint for how long the server expects to wait for
+     * user input, in milliseconds. Clients MAY use this to set an
+     * appropriate timeout for the elicitation itself.
+     */
+    timeout?: number;
+
+    /**
+     * An optional human-readable message explaining why the
+     * elicitation is needed.
+     */
+    message?: string;
+  };
+}
+```
+
+### Server Behavior
+
+- Servers **MAY** send `notifications/elicitation/pending` before issuing an `elicitation/create` request when the elicitation is triggered by another in-flight request (e.g., a tool call).
+- The `requestId` field **MUST** correspond to the ID of a currently in-flight request from the client.
+- Servers **SHOULD** include a `timeout` hint when the expected user interaction time is known.
+- Servers **SHOULD** provide a descriptive `message` to help clients show appropriate context to users.
+
+### Client Behavior
+
+Upon receiving a `notifications/elicitation/pending` notification:
+
+- Clients **SHOULD** suspend or extend the timeout for the request identified by `requestId`.
+- Clients **SHOULD** resume normal timeout behavior after the corresponding elicitation completes (via user response or cancellation).
+- Clients **MAY** use the `timeout` hint to set an appropriate maximum wait time for the elicitation itself.
+- Clients **MAY** display the `message` to users to provide context.
+- Clients **MUST** still enforce a maximum timeout to prevent indefinite waits, even when a pending notification is received.
+- Clients **MUST** ignore notifications referencing unknown request IDs.
+
+### Schema Changes
+
+The `ElicitationPendingNotification` interface is added to the `ServerNotification` union type:
+
+```typescript
+export type ServerNotification =
+  | CancelledNotification
+  | ProgressNotification
+  | LoggingMessageNotification
+  | ResourceUpdatedNotification
+  | ResourceListChangedNotification
+  | ToolListChangedNotification
+  | PromptListChangedNotification
+  | ElicitationPendingNotification // New
+  | ElicitationCompleteNotification
+  | TaskStatusNotification;
+```
+
+### Message Flow
+
+```
+Client                          Server
+  |                                |
+  |  tools/call (id: 42)          |
+  |------------------------------->|
+  |  Start request timeout         |
+  |                                |
+  |                                |  Server needs user input
+  |                                |
+  |  notifications/elicitation/    |
+  |  pending (requestId: 42)      |
+  |<-------------------------------|
+  |  Suspend/extend timeout        |
+  |                                |
+  |  elicitation/create            |
+  |  (mode: form)                  |
+  |<-------------------------------|
+  |                                |
+  |  User fills in form...         |
+  |                                |
+  |  Elicitation response          |
+  |------------------------------->|
+  |  Resume normal timeout         |
+  |                                |
+  |  tools/call result (id: 42)   |
+  |<-------------------------------|
+```
+
+### Example: Basic Pending Notification
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/elicitation/pending",
+  "params": {
+    "requestId": 42,
+    "message": "User input required to continue processing the tool call"
+  }
+}
+```
+
+### Example: Pending Notification with Timeout Hint
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/elicitation/pending",
+  "params": {
+    "requestId": "abc-123",
+    "timeout": 300000,
+    "message": "Please provide your GitHub credentials to access the repository"
+  }
+}
+```
+
+## Rationale
+
+### Design Decisions
+
+**Why a new notification rather than extending progress notifications?**
+
+Progress notifications (`notifications/progress`) are designed to report incremental progress on work being performed. Repurposing them to signal "waiting for user input" would be semantically misleading. A dedicated notification clearly communicates intent and allows clients to implement specific timeout behavior.
+
+**Why not require task-augmented requests?**
+
+The task system (SEP-1686) provides robust lifecycle management for long-running operations, including an `input_required` status. However, requiring task augmentation for every tool call that might trigger an elicitation adds unnecessary complexity. Many tool calls are simple and synchronous — they just occasionally need user input. This proposal provides a lightweight alternative.
+
+**Why include `requestId` instead of a separate elicitation identifier?**
+
+The `requestId` directly ties the notification to the request whose timeout needs adjustment. This is simpler than introducing a new identifier and requiring clients to maintain a mapping between elicitation IDs and request IDs.
+
+**Why is the `timeout` field optional?**
+
+Not all servers can predict how long user input will take. Some elicitations are simple confirmations (seconds), while others involve complex form filling or decision-making (minutes). Making the timeout optional allows servers to provide guidance when they can, without requiring it.
+
+### Alternative Approaches Considered
+
+1. **Extending `elicitation/create` with a `requestId` field**: This was considered but rejected because the elicitation request goes from server to client, while the timeout adjustment needs to reference a client-to-server request. A notification sent before the elicitation request is a cleaner separation.
+
+2. **Adding a timeout extension field to `RequestMetaObject`**: This would let servers specify upfront that a request might need extra time. However, it doesn't solve the core problem — the server doesn't know it needs elicitation until processing has begun.
+
+3. **Client-side heuristic**: Clients could automatically extend timeouts whenever they receive an `elicitation/create` request. However, the client may not always be able to correlate the elicitation with a specific in-flight request, especially if multiple requests are in flight simultaneously.
+
+4. **Using progress notifications as a workaround**: Servers could send periodic progress notifications to keep the timeout clock alive. This works but is semantically incorrect and wastes bandwidth with meaningless progress updates.
+
+## Backward Compatibility
+
+This proposal introduces no breaking changes:
+
+- The new notification is **optional** — servers are not required to send it.
+- Existing clients that do not understand `notifications/elicitation/pending` will simply ignore it (per JSON-RPC notification semantics).
+- No changes to existing message formats, capabilities, or error codes.
+- Servers can adopt this notification incrementally without coordinating with client updates.
+
+## Security Implications
+
+This proposal has minimal security implications:
+
+- **No new data exposure**: The notification only references an existing `requestId` that both parties already know.
+- **No authentication changes**: The notification uses the same transport and session as all other protocol messages.
+- **Denial of service consideration**: A malicious server could send excessive pending notifications. However, clients already must handle arbitrary notifications from servers, and the recommendation to enforce a maximum timeout provides protection against indefinite waits.
+- **No new attack surfaces**: The notification is purely informational and does not change any server or client state beyond timeout management.
+
+## Reference Implementation
+
+A prototype implementation will be provided in the TypeScript SDK demonstrating:
+
+1. Server-side: Sending `notifications/elicitation/pending` before `elicitation/create` during tool call processing
+2. Client-side: Suspending and resuming request timeouts upon receiving the notification
+3. Integration test showing the timeout coordination in action
+
+_Reference implementation to be completed before this SEP can reach "Final" status._

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -37,7 +37,7 @@
               "docs/learn/architecture",
               "docs/learn/server-concepts",
               "docs/learn/client-concepts",
-              "docs/learn/versioning"
+              "specification/versioning"
             ]
           },
           {
@@ -45,15 +45,8 @@
             "pages": [
               "docs/develop/connect-local-servers",
               "docs/develop/connect-remote-servers",
-              "docs/develop/build-with-agent-skills",
               "docs/develop/build-server",
-              {
-                "group": "Clients",
-                "pages": [
-                  "docs/develop/build-client",
-                  "docs/develop/clients/client-best-practices"
-                ]
-              },
+              "docs/develop/build-client",
               "docs/sdk",
               {
                 "group": "Security",
@@ -67,14 +60,7 @@
           {
             "group": "Developer tools",
             "pages": [
-              "docs/tools/inspector",
-              "docs/tools/debugging"
-            ]
-          },
-          {
-            "group": "Examples",
-            "pages": [
-              "examples"
+              "docs/tools/inspector"
             ]
           }
         ]
@@ -97,12 +83,6 @@
               "extensions/auth/overview",
               "extensions/auth/oauth-client-credentials",
               "extensions/auth/enterprise-managed-authorization"
-            ]
-          },
-          {
-            "group": "Tasks",
-            "pages": [
-              "extensions/tasks/overview"
             ]
           }
         ]
@@ -315,38 +295,21 @@
             "pages": [
               "specification/draft/index",
               "specification/draft/changelog",
-              "specification/draft/deprecated",
               "specification/draft/architecture/index",
               {
                 "group": "Base Protocol",
                 "pages": [
                   "specification/draft/basic/index",
-                  "specification/draft/basic/versioning",
+                  "specification/draft/basic/lifecycle",
+                  "specification/draft/basic/transports",
+                  "specification/draft/basic/authorization",
                   {
-                    "group": "Message Patterns",
+                    "group": "Utilities",
                     "pages": [
-                      "specification/draft/basic/patterns/index",
-                      "specification/draft/basic/patterns/mrtr",
-                      "specification/draft/basic/patterns/subscriptions",
-                      "specification/draft/basic/patterns/cancellation",
-                      "specification/draft/basic/patterns/progress"
-                    ]
-                  },
-                  {
-                    "group": "Transports",
-                    "pages": [
-                      "specification/draft/basic/transports/index",
-                      "specification/draft/basic/transports/stdio",
-                      "specification/draft/basic/transports/streamable-http"
-                    ]
-                  },
-                  {
-                    "group": "Authorization",
-                    "pages": [
-                      "specification/draft/basic/authorization/index",
-                      "specification/draft/basic/authorization/authorization-server-discovery",
-                      "specification/draft/basic/authorization/client-registration",
-                      "specification/draft/basic/authorization/security-considerations"
+                      "specification/draft/basic/utilities/cancellation",
+                      "specification/draft/basic/utilities/ping",
+                      "specification/draft/basic/utilities/progress",
+                      "specification/draft/basic/utilities/tasks"
                     ]
                   }
                 ]
@@ -363,14 +326,12 @@
                 "group": "Server Features",
                 "pages": [
                   "specification/draft/server/index",
-                  "specification/draft/server/discover",
                   "specification/draft/server/prompts",
                   "specification/draft/server/resources",
                   "specification/draft/server/tools",
                   {
                     "group": "Utilities",
                     "pages": [
-                      "specification/draft/server/utilities/caching",
                       "specification/draft/server/utilities/completion",
                       "specification/draft/server/utilities/logging",
                       "specification/draft/server/utilities/pagination"
@@ -410,112 +371,73 @@
         ]
       },
       {
-        "tab": "SEPs",
-        "pages": [
-          "seps/index",
-          {
-            "group": "Final",
-            "pages": [
-              "seps/414-request-meta",
-              "seps/932-model-context-protocol-governance",
-              "seps/973-expose-additional-metadata-for-implementations-res",
-              "seps/985-align-oauth-20-protected-resource-metadata-with-rf",
-              "seps/986-specify-format-for-tool-names",
-              "seps/990-enable-enterprise-idp-policy-controls-during-mcp-o",
-              "seps/991-enable-url-based-client-registration-using-oauth-c",
-              "seps/994-shared-communication-practicesguidelines",
-              "seps/1024-mcp-client-security-requirements-for-local-server-",
-              "seps/1034--support-default-values-for-all-primitive-types-in",
-              "seps/1036-url-mode-elicitation-for-secure-out-of-band-intera",
-              "seps/1046-support-oauth-client-credentials-flow-in-authoriza",
-              "seps/1302-formalize-working-groups-and-interest-groups-in-mc",
-              "seps/1303-input-validation-errors-as-tool-execution-errors",
-              "seps/1319-decouple-request-payload-from-rpc-methods-definiti",
-              "seps/1330-elicitation-enum-schema-improvements-and-standards",
-              "seps/1577--sampling-with-tools",
-              "seps/1613-establish-json-schema-2020-12-as-default-dialect-f",
-              "seps/1686-tasks",
-              "seps/1699-support-sse-polling-via-server-side-disconnect",
-              "seps/1730-sdks-tiering-system",
-              "seps/1850-pr-based-sep-workflow",
-              "seps/1865-mcp-apps-interactive-user-interfaces-for-mcp",
-              "seps/2085-governance-succession-and-amendment",
-              "seps/2106-json-schema-2020-12",
-              "seps/2133-extensions",
-              "seps/2148-contributor-ladder",
-              "seps/2149-working-group-charter-template",
-              "seps/2164-resource-not-found-error",
-              "seps/2207-oidc-refresh-token-guidance",
-              "seps/2243-http-standardization",
-              "seps/2260-Require-Server-requests-to-be-associated-with-Client-requests",
-              "seps/2322-MRTR",
-              "seps/2468-recommend-issuer-claim-for-auth",
-              "seps/2484-conformance-tests-required-for-final-seps",
-              "seps/2549-TTL-for-list-results",
-              "seps/2567-sessionless-mcp",
-              "seps/2575-stateless-mcp",
-              "seps/2577-deprecate-roots-sampling-and-logging",
-              "seps/2596-spec-feature-lifecycle-and-deprecation",
-              "seps/2663-tasks-extension"
-            ]
-          }
-        ]
-      },
-      {
         "tab": "Community",
         "pages": [
-          {
-            "group": "Get Involved",
-            "pages": [
-              "community/contributing",
-              "community/communication",
-              "community/working-interest-groups",
-              "community/charter-template"
-            ]
-          },
-          {
-            "group": "Propose Changes",
-            "pages": [
-              "community/design-principles",
-              "community/sep-guidelines"
-            ]
-          },
+          "community/contributing",
+          "community/communication",
           {
             "group": "Governance",
             "pages": [
               "community/governance",
-              "community/contributor-ladder",
-              "community/feature-lifecycle",
+              "community/sep-guidelines",
               "community/sdk-tiers",
+              "community/working-interest-groups",
               "community/antitrust"
             ]
           },
           {
-            "group": "Working Group Charters",
+            "group": "SEPs",
             "pages": [
-              "community/working-groups/file-uploads",
-              "community/working-groups/inspector-v2",
-              "community/working-groups/interceptors",
-              "community/working-groups/registry",
-              "community/working-groups/sdk",
-              "community/working-groups/server-card",
-              "community/working-groups/skills-over-mcp",
-              "community/working-groups/triggers-events"
-            ]
-          },
-          {
-            "group": "Interest Group Charters",
-            "pages": [
-              "community/interest-groups/auth",
-              "community/interest-groups/enterprise-managed-authorization",
-              "community/interest-groups/security",
-              "community/interest-groups/tool-annotations"
+              "community/seps/index",
+              {
+                "group": "Final",
+                "pages": [
+                  "community/seps/414-request-meta",
+                  "community/seps/932-model-context-protocol-governance",
+                  "community/seps/973-expose-additional-metadata-for-implementations-res",
+                  "community/seps/985-align-oauth-20-protected-resource-metadata-with-rf",
+                  "community/seps/986-specify-format-for-tool-names",
+                  "community/seps/990-enable-enterprise-idp-policy-controls-during-mcp-o",
+                  "community/seps/991-enable-url-based-client-registration-using-oauth-c",
+                  "community/seps/994-shared-communication-practicesguidelines",
+                  "community/seps/1024-mcp-client-security-requirements-for-local-server-",
+                  "community/seps/1034--support-default-values-for-all-primitive-types-in",
+                  "community/seps/1036-url-mode-elicitation-for-secure-out-of-band-intera",
+                  "community/seps/1046-support-oauth-client-credentials-flow-in-authoriza",
+                  "community/seps/1302-formalize-working-groups-and-interest-groups-in-mc",
+                  "community/seps/1303-input-validation-errors-as-tool-execution-errors",
+                  "community/seps/1319-decouple-request-payload-from-rpc-methods-definiti",
+                  "community/seps/1330-elicitation-enum-schema-improvements-and-standards",
+                  "community/seps/1577--sampling-with-tools",
+                  "community/seps/1613-establish-json-schema-2020-12-as-default-dialect-f",
+                  "community/seps/1686-tasks",
+                  "community/seps/1699-support-sse-polling-via-server-side-disconnect",
+                  "community/seps/1730-sdks-tiering-system",
+                  "community/seps/1850-pr-based-sep-workflow",
+                  "community/seps/1865-mcp-apps-interactive-user-interfaces-for-mcp",
+                  "community/seps/2085-governance-succession-and-amendment",
+                  "community/seps/2133-extensions"
+                ]
+              },
+              {
+                "group": "Draft",
+                "pages": [
+                  "community/seps/2188-elicitation-timeout-coordination"
+                ]
+              }
             ]
           },
           {
             "group": "Roadmap",
             "pages": [
               "development/roadmap"
+            ]
+          },
+          {
+            "group": "Examples",
+            "pages": [
+              "clients",
+              "examples"
             ]
           }
         ]
@@ -539,58 +461,6 @@
   },
   "redirects": [
     {
-      "source": "/clients",
-      "destination": "/docs/getting-started/intro"
-    },
-    {
-      "source": "/community/auth/charter",
-      "destination": "/community/interest-groups/auth"
-    },
-    {
-      "source": "/community/tool-annotations/charter",
-      "destination": "/community/interest-groups/tool-annotations"
-    },
-    {
-      "source": "/community/file-uploads/charter",
-      "destination": "/community/working-groups/file-uploads"
-    },
-    {
-      "source": "/community/inspector-v2/charter",
-      "destination": "/community/working-groups/inspector-v2"
-    },
-    {
-      "source": "/community/interceptors/charter",
-      "destination": "/community/working-groups/interceptors"
-    },
-    {
-      "source": "/community/registry/charter",
-      "destination": "/community/working-groups/registry"
-    },
-    {
-      "source": "/community/sdk/charter",
-      "destination": "/community/working-groups/sdk"
-    },
-    {
-      "source": "/community/server-card/charter",
-      "destination": "/community/working-groups/server-card"
-    },
-    {
-      "source": "/community/skills-over-mcp/charter",
-      "destination": "/community/working-groups/skills-over-mcp"
-    },
-    {
-      "source": "/community/triggers-events/charter",
-      "destination": "/community/working-groups/triggers-events"
-    },
-    {
-      "source": "/specification/draft/basic/lifecycle",
-      "destination": "/specification/draft/basic/versioning"
-    },
-    {
-      "source": "/specification/versioning",
-      "destination": "/docs/learn/versioning"
-    },
-    {
       "source": "/specification/latest",
       "destination": "/specification/2025-11-25",
       "permanent": false
@@ -603,22 +473,6 @@
     {
       "source": "/tutorials/building-a-client",
       "destination": "/docs/develop/build-client"
-    },
-    {
-      "source": "/tutorials/building-a-client-node",
-      "destination": "/docs/develop/build-client"
-    },
-    {
-      "source": "/tutorials/building-mcp-with-llms",
-      "destination": "/docs/develop/build-with-agent-skills"
-    },
-    {
-      "source": "/faqs",
-      "destination": "/docs/getting-started/intro"
-    },
-    {
-      "source": "/docs/tutorials/use-local-mcp-server",
-      "destination": "/docs/develop/connect-local-servers"
     },
     {
       "source": "/quickstart",
@@ -657,40 +511,8 @@
       "destination": "/specification/2025-06-18/basic/transports"
     },
     {
-      "source": "/legacy/tools/debugging",
-      "destination": "/docs/tools/debugging"
-    },
-    {
-      "source": "/legacy/concepts/architecture",
-      "destination": "/specification/latest/architecture"
-    },
-    {
-      "source": "/legacy/concepts/elicitation",
-      "destination": "/specification/latest/client/elicitation"
-    },
-    {
-      "source": "/legacy/concepts/prompts",
-      "destination": "/specification/latest/server/prompts"
-    },
-    {
-      "source": "/legacy/concepts/resources",
-      "destination": "/specification/latest/server/resources"
-    },
-    {
-      "source": "/legacy/concepts/roots",
-      "destination": "/specification/latest/client/roots"
-    },
-    {
-      "source": "/legacy/concepts/sampling",
-      "destination": "/specification/latest/client/sampling"
-    },
-    {
-      "source": "/legacy/concepts/tools",
-      "destination": "/specification/latest/server/tools"
-    },
-    {
-      "source": "/legacy/concepts/transports",
-      "destination": "/specification/latest/basic/transports"
+      "source": "/docs/tools/debugging",
+      "destination": "/legacy/tools/debugging"
     },
     {
       "source": "/legacy/tools/inspector",
@@ -747,18 +569,6 @@
     {
       "source": "/docs/extensions/apps",
       "destination": "/extensions/apps/overview"
-    },
-    {
-      "source": "/docs/extensions/tasks",
-      "destination": "/extensions/tasks/overview"
-    },
-    {
-      "source": "/community/seps",
-      "destination": "/seps"
-    },
-    {
-      "source": "/community/seps/:slug*",
-      "destination": "/seps/:slug*"
     }
   ],
   "contextual": {

--- a/seps/2188-elicitation-timeout-coordination.md
+++ b/seps/2188-elicitation-timeout-coordination.md
@@ -1,0 +1,219 @@
+# SEP-2188: Elicitation Timeout Coordination
+
+- **Status**: Draft
+- **Type**: Standards Track
+- **Created**: 2026-02-27
+- **Author(s)**: Arsalan Shakil (@ArsalanShakil)
+- **Sponsor**: None (seeking sponsor)
+- **PR**: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2188
+
+> **AI Disclosure**: This SEP was drafted with assistance from Claude Code (Claude Opus 4.5). The author reviewed and understands all proposed changes.
+
+## Abstract
+
+This SEP introduces a `notifications/elicitation/pending` notification that servers can send to clients before issuing an `elicitation/create` request during in-flight request processing. The notification includes the `requestId` of the original request (e.g., a tool call) so the client can suspend or extend its timeout for that request while waiting for user input. This addresses the problem described in [#2006](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2006), where tool calls timeout because the client has no way to know that a server is waiting for user input via elicitation.
+
+## Motivation
+
+When a server issues a form-mode elicitation during a tool call, the client's configured request timeout may expire before the user has a chance to respond. This creates a poor user experience: the tool call fails with a timeout error even though the server is actively and legitimately waiting for user input.
+
+Consider this scenario:
+
+1. Client sends `tools/call` with a 60-second request timeout
+2. Server processes the tool call and determines it needs user input
+3. Server sends `elicitation/create` (mode: form) to the client
+4. The user sees the form but takes more than 60 seconds to respond
+5. The client's timeout fires and the `tools/call` fails
+
+This is particularly problematic because:
+
+- **The client has no advance notice** that an elicitation is coming. It cannot preemptively extend the timeout.
+- **URL mode has partial coverage** via `notifications/elicitation/complete` and `URLElicitationRequiredError`, but form mode has no such coordination mechanism.
+- **The task system helps but isn't always appropriate**. Task-augmented requests (which return immediately with a task ID) can avoid the timeout issue, but not all tool calls warrant full task lifecycle management. Simple "ask the user a question and continue" patterns shouldn't require task infrastructure.
+- **Progress notifications can reset the timeout clock**, but this is a workaround rather than a proper coordination mechanism. Servers would need to send artificial progress notifications that don't represent actual progress.
+
+The existing protocol lacks a lightweight, purpose-built mechanism for timeout coordination when elicitation is involved.
+
+## Specification
+
+### New Notification: `notifications/elicitation/pending`
+
+A new optional server-to-client notification is introduced:
+
+```typescript
+export interface ElicitationPendingNotification extends JSONRPCNotification {
+  method: "notifications/elicitation/pending";
+  params: {
+    /**
+     * The ID of the original request that triggered this elicitation.
+     * This allows the client to associate the pending elicitation with
+     * the request whose timeout should be adjusted.
+     */
+    requestId: RequestId;
+
+    /**
+     * An optional hint for how long the server expects to wait for
+     * user input, in milliseconds. Clients MAY use this to set an
+     * appropriate timeout for the elicitation itself.
+     */
+    timeout?: number;
+
+    /**
+     * An optional human-readable message explaining why the
+     * elicitation is needed.
+     */
+    message?: string;
+  };
+}
+```
+
+### Server Behavior
+
+- Servers **MAY** send `notifications/elicitation/pending` before issuing an `elicitation/create` request when the elicitation is triggered by another in-flight request (e.g., a tool call).
+- The `requestId` field **MUST** correspond to the ID of a currently in-flight request from the client.
+- Servers **SHOULD** include a `timeout` hint when the expected user interaction time is known.
+- Servers **SHOULD** provide a descriptive `message` to help clients show appropriate context to users.
+
+### Client Behavior
+
+Upon receiving a `notifications/elicitation/pending` notification:
+
+- Clients **SHOULD** suspend or extend the timeout for the request identified by `requestId`.
+- Clients **SHOULD** resume normal timeout behavior after the corresponding elicitation completes (via user response or cancellation).
+- Clients **MAY** use the `timeout` hint to set an appropriate maximum wait time for the elicitation itself.
+- Clients **MAY** display the `message` to users to provide context.
+- Clients **MUST** still enforce a maximum timeout to prevent indefinite waits, even when a pending notification is received.
+- Clients **MUST** ignore notifications referencing unknown request IDs.
+
+### Schema Changes
+
+The `ElicitationPendingNotification` interface is added to the `ServerNotification` union type:
+
+```typescript
+export type ServerNotification =
+  | CancelledNotification
+  | ProgressNotification
+  | LoggingMessageNotification
+  | ResourceUpdatedNotification
+  | ResourceListChangedNotification
+  | ToolListChangedNotification
+  | PromptListChangedNotification
+  | ElicitationPendingNotification // New
+  | ElicitationCompleteNotification
+  | TaskStatusNotification;
+```
+
+### Message Flow
+
+```
+Client                          Server
+  |                                |
+  |  tools/call (id: 42)          |
+  |------------------------------->|
+  |  Start request timeout         |
+  |                                |
+  |                                |  Server needs user input
+  |                                |
+  |  notifications/elicitation/    |
+  |  pending (requestId: 42)      |
+  |<-------------------------------|
+  |  Suspend/extend timeout        |
+  |                                |
+  |  elicitation/create            |
+  |  (mode: form)                  |
+  |<-------------------------------|
+  |                                |
+  |  User fills in form...         |
+  |                                |
+  |  Elicitation response          |
+  |------------------------------->|
+  |  Resume normal timeout         |
+  |                                |
+  |  tools/call result (id: 42)   |
+  |<-------------------------------|
+```
+
+### Example: Basic Pending Notification
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/elicitation/pending",
+  "params": {
+    "requestId": 42,
+    "message": "User input required to continue processing the tool call"
+  }
+}
+```
+
+### Example: Pending Notification with Timeout Hint
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/elicitation/pending",
+  "params": {
+    "requestId": "abc-123",
+    "timeout": 300000,
+    "message": "Please provide your GitHub credentials to access the repository"
+  }
+}
+```
+
+## Rationale
+
+### Design Decisions
+
+**Why a new notification rather than extending progress notifications?**
+
+Progress notifications (`notifications/progress`) are designed to report incremental progress on work being performed. Repurposing them to signal "waiting for user input" would be semantically misleading. A dedicated notification clearly communicates intent and allows clients to implement specific timeout behavior.
+
+**Why not require task-augmented requests?**
+
+The task system (SEP-1686) provides robust lifecycle management for long-running operations, including an `input_required` status. However, requiring task augmentation for every tool call that might trigger an elicitation adds unnecessary complexity. Many tool calls are simple and synchronous — they just occasionally need user input. This proposal provides a lightweight alternative.
+
+**Why include `requestId` instead of a separate elicitation identifier?**
+
+The `requestId` directly ties the notification to the request whose timeout needs adjustment. This is simpler than introducing a new identifier and requiring clients to maintain a mapping between elicitation IDs and request IDs.
+
+**Why is the `timeout` field optional?**
+
+Not all servers can predict how long user input will take. Some elicitations are simple confirmations (seconds), while others involve complex form filling or decision-making (minutes). Making the timeout optional allows servers to provide guidance when they can, without requiring it.
+
+### Alternative Approaches Considered
+
+1. **Extending `elicitation/create` with a `requestId` field**: This was considered but rejected because the elicitation request goes from server to client, while the timeout adjustment needs to reference a client-to-server request. A notification sent before the elicitation request is a cleaner separation.
+
+2. **Adding a timeout extension field to `RequestMetaObject`**: This would let servers specify upfront that a request might need extra time. However, it doesn't solve the core problem — the server doesn't know it needs elicitation until processing has begun.
+
+3. **Client-side heuristic**: Clients could automatically extend timeouts whenever they receive an `elicitation/create` request. However, the client may not always be able to correlate the elicitation with a specific in-flight request, especially if multiple requests are in flight simultaneously.
+
+4. **Using progress notifications as a workaround**: Servers could send periodic progress notifications to keep the timeout clock alive. This works but is semantically incorrect and wastes bandwidth with meaningless progress updates.
+
+## Backward Compatibility
+
+This proposal introduces no breaking changes:
+
+- The new notification is **optional** — servers are not required to send it.
+- Existing clients that do not understand `notifications/elicitation/pending` will simply ignore it (per JSON-RPC notification semantics).
+- No changes to existing message formats, capabilities, or error codes.
+- Servers can adopt this notification incrementally without coordinating with client updates.
+
+## Security Implications
+
+This proposal has minimal security implications:
+
+- **No new data exposure**: The notification only references an existing `requestId` that both parties already know.
+- **No authentication changes**: The notification uses the same transport and session as all other protocol messages.
+- **Denial of service consideration**: A malicious server could send excessive pending notifications. However, clients already must handle arbitrary notifications from servers, and the recommendation to enforce a maximum timeout provides protection against indefinite waits.
+- **No new attack surfaces**: The notification is purely informational and does not change any server or client state beyond timeout management.
+
+## Reference Implementation
+
+A prototype implementation will be provided in the TypeScript SDK demonstrating:
+
+1. Server-side: Sending `notifications/elicitation/pending` before `elicitation/create` during tool call processing
+2. Client-side: Suspending and resuming request timeouts upon receiving the notification
+3. Integration test showing the timeout coordination in action
+
+_Reference implementation to be completed before this SEP can reach "Final" status._


### PR DESCRIPTION
This change addresses issue #2006 by adding a mechanism for servers to coordinate client-side timeouts when elicitation is required during request processing.

Changes:
- Add ElicitationPendingNotification to schema/draft/schema.ts
- Add example JSON files for the new notification
- Update elicitation documentation with timeout coordination guidance
- Update lifecycle documentation with elicitation timeout handling section

The new notifications/elicitation/pending notification allows servers to inform clients when an elicitation is about to be issued for an in-flight request. Clients can then suspend or extend the timeout for that request until the elicitation completes.

Closes #2006

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
