### PR TITLE
Add weekly SEP review reminder workflow

### DIFF
--- a/.github/workflows/sep-reminder.yml
+++ b/.github/workflows/sep-reminder.yml
@@ -6,6 +6,8 @@ on:
     - cron: "0 18 * * 3"
   workflow_dispatch: # Allow manual triggering
 
+permissions: {}
+
 jobs:
   discord-reminder:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow to post weekly Discord reminders for SEP reviews
- Runs every Wednesday at 10am PST (18:00 UTC) via cron schedule
- Reminds maintainers to add SEPs to the MCP Core Maintainer Meeting agenda

## Test plan
- [ ] Verify the workflow file syntax is valid
- [ ] Manually trigger the workflow via `workflow_dispatch` to test Discord integration
- [ ] Confirm the `DISCORD_MAINTAINER_WEBHOOK` secret is configured in the repository

🤖 Generated with [Claude Code](https://claude.com/claude-code) (0% 2-shotted by claude-opus-4-5)