### PR TITLE
Display MCP features as color-coded badges on clients page

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -20,6 +20,11 @@ export const FEATURE_COLORS = {
   Apps: "orange",
 };
 
+export const FeatureBadge = ({ feature }) => {
+  const color = FEATURE_COLORS[feature.split(" (")[0]] || "gray";
+  return <Badge shape="pill" stroke color={color}>{feature}</Badge>;
+};
+
 export const filterStore = {
   state: {
     selectedFeatures: [],
@@ -217,9 +222,7 @@ export const McpClient = ({ name, homepage, supports, sourceCode, instructions, 
               <strong>Supports:</strong>
               <span className="flex flex-wrap gap-1">
                 {features.map(feature => (
-                  <Badge key={feature} shape="pill" stroke color={FEATURE_COLORS[feature.split(" (")[0]] || "gray"}>
-                    {feature}
-                  </Badge>
+                  <FeatureBadge key={feature} feature={feature} />
                 ))}
               </span>
             </div>
@@ -274,7 +277,20 @@ export const McpClient = ({ name, homepage, supports, sourceCode, instructions, 
 
 {/* prettier-ignore-end */}
 
-This page provides an overview of applications that support the Model Context Protocol (MCP). Each client may support different MCP features, allowing for varying levels of integration with MCP servers.
+This page showcases applications that support the Model Context Protocol (MCP). Each client may support different MCP features:
+
+| Feature                                 | Description                                               |
+| --------------------------------------- | --------------------------------------------------------- |
+| <FeatureBadge feature="Resources" />    | Server-exposed data and content                           |
+| <FeatureBadge feature="Prompts" />      | Pre-defined templates for LLM interactions                |
+| <FeatureBadge feature="Tools" />        | Executable functions that LLMs can invoke                 |
+| <FeatureBadge feature="Discovery" />    | Support for tools/prompts/resources changed notifications |
+| <FeatureBadge feature="Instructions" /> | Server-provided guidance for LLMs                         |
+| <FeatureBadge feature="Sampling" />     | Server-initiated LLM completions                          |
+| <FeatureBadge feature="Roots" />        | Filesystem boundary definitions                           |
+| <FeatureBadge feature="Elicitation" />  | User information requests                                 |
+| <FeatureBadge feature="Tasks" />        | Long-running operation tracking                           |
+| <FeatureBadge feature="Apps" />         | Interactive HTML interfaces                               |
 
 <Note>
 


### PR DESCRIPTION
Replace plain text feature list with `Badge` components. Features are grouped by color: blue for primitives (Resources, Prompts, Tools), green for host capabilities (Sampling, Roots, Elicitation), purple for Instructions and Discovery, and orange for Tasks and Apps.

| Before | After |
| --- | --- |
| <img width="1848" height="964" alt="before-1" src="https://github.com/user-attachments/assets/42132bc4-cc4e-42e8-a5c8-0511a0336a7e" /> | <img width="1848" height="964" alt="after-1" src="https://github.com/user-attachments/assets/0d8a0514-c6d8-41ba-ba6f-414072394863" /> |
| <img width="1848" height="964" alt="before-2" src="https://github.com/user-attachments/assets/903e56c4-ef90-455d-973b-c9da21f2249f" /> | <img width="1848" height="964" alt="after-2" src="https://github.com/user-attachments/assets/50af5be0-ad2b-414d-a034-4d4fa67cafde" /> |
| <img width="1848" height="964" alt="before-3" src="https://github.com/user-attachments/assets/aafb7099-eee5-41a2-8a51-f1c857922882" /> | <img width="1848" height="964" alt="after-3" src="https://github.com/user-attachments/assets/52982175-b7ca-4dfc-a139-03ea607662a3" /> |
