### PR TITLE
Fix broken PR links in SEP documents

### DIFF
--- a/docs/community/seps/1024-mcp-client-security-requirements-for-local-server-.mdx
+++ b/docs/community/seps/1024-mcp-client-security-requirements-for-local-server-.mdx
@@ -11,16 +11,16 @@ import { Badge } from "/snippets/badge.mdx";
   <Badge color="gray">Standards Track</Badge>
 </div>
 
-| Field         | Value                                                                    |
-| ------------- | ------------------------------------------------------------------------ |
-| **SEP**       | 1024                                                                     |
-| **Title**     | MCP Client Security Requirements for Local Server Installation           |
-| **Status**    | Final                                                                    |
-| **Type**      | Standards Track                                                          |
-| **Created**   | 2025-07-22                                                               |
-| **Author(s)** | Den Delimarsky                                                           |
-| **Sponsor**   | None                                                                     |
-| **PR**        | [#1024](https://github.com/modelcontextprotocol/specification/pull/1024) |
+| Field         | Value                                                                           |
+| ------------- | ------------------------------------------------------------------------------- |
+| **SEP**       | 1024                                                                            |
+| **Title**     | MCP Client Security Requirements for Local Server Installation                  |
+| **Status**    | Final                                                                           |
+| **Type**      | Standards Track                                                                 |
+| **Created**   | 2025-07-22                                                                      |
+| **Author(s)** | Den Delimarsky                                                                  |
+| **Sponsor**   | None                                                                            |
+| **PR**        | [#1024](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1024) |
 
 ---
 

--- a/docs/community/seps/1034--support-default-values-for-all-primitive-types-in.mdx
+++ b/docs/community/seps/1034--support-default-values-for-all-primitive-types-in.mdx
@@ -11,16 +11,16 @@ import { Badge } from "/snippets/badge.mdx";
   <Badge color="gray">Standards Track</Badge>
 </div>
 
-| Field         | Value                                                                    |
-| ------------- | ------------------------------------------------------------------------ |
-| **SEP**       | 1034                                                                     |
-| **Title**     | Support default values for all primitive types in elicitation schemas    |
-| **Status**    | Final                                                                    |
-| **Type**      | Standards Track                                                          |
-| **Created**   | 2025-07-22                                                               |
-| **Author(s)** | Tapan Chugh (chugh.tapan[@gmail](https://github.com/gmail).com)          |
-| **Sponsor**   | None                                                                     |
-| **PR**        | [#1034](https://github.com/modelcontextprotocol/specification/pull/1034) |
+| Field         | Value                                                                           |
+| ------------- | ------------------------------------------------------------------------------- |
+| **SEP**       | 1034                                                                            |
+| **Title**     | Support default values for all primitive types in elicitation schemas           |
+| **Status**    | Final                                                                           |
+| **Type**      | Standards Track                                                                 |
+| **Created**   | 2025-07-22                                                                      |
+| **Author(s)** | Tapan Chugh (chugh.tapan[@gmail](https://github.com/gmail).com)                 |
+| **Sponsor**   | None                                                                            |
+| **PR**        | [#1034](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1034) |
 
 ---
 

--- a/docs/community/seps/1036-url-mode-elicitation-for-secure-out-of-band-intera.mdx
+++ b/docs/community/seps/1036-url-mode-elicitation-for-secure-out-of-band-intera.mdx
@@ -20,7 +20,7 @@ import { Badge } from "/snippets/badge.mdx";
 | **Created**   | 2025-07-22                                                                                                                |
 | **Author(s)** | Nate Barbettini ([@nbarbettini](https://github.com/nbarbettini)) and Wils Dawson ([@wdawson](https://github.com/wdawson)) |
 | **Sponsor**   | None                                                                                                                      |
-| **PR**        | [#1036](https://github.com/modelcontextprotocol/specification/pull/1036)                                                  |
+| **PR**        | [#1036](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1036)                                           |
 
 ---
 

--- a/docs/community/seps/1046-support-oauth-client-credentials-flow-in-authoriza.mdx
+++ b/docs/community/seps/1046-support-oauth-client-credentials-flow-in-authoriza.mdx
@@ -11,16 +11,16 @@ import { Badge } from "/snippets/badge.mdx";
   <Badge color="gray">Standards Track</Badge>
 </div>
 
-| Field         | Value                                                                    |
-| ------------- | ------------------------------------------------------------------------ |
-| **SEP**       | 1046                                                                     |
-| **Title**     | Support OAuth client credentials flow in authorization                   |
-| **Status**    | Final                                                                    |
-| **Type**      | Standards Track                                                          |
-| **Created**   | 2025-07-23                                                               |
-| **Author(s)** | Darin McAdams ([@D-McAdams](https://github.com/D-McAdams) )              |
-| **Sponsor**   | None                                                                     |
-| **PR**        | [#1046](https://github.com/modelcontextprotocol/specification/pull/1046) |
+| Field         | Value                                                                           |
+| ------------- | ------------------------------------------------------------------------------- |
+| **SEP**       | 1046                                                                            |
+| **Title**     | Support OAuth client credentials flow in authorization                          |
+| **Status**    | Final                                                                           |
+| **Type**      | Standards Track                                                                 |
+| **Created**   | 2025-07-23                                                                      |
+| **Author(s)** | Darin McAdams ([@D-McAdams](https://github.com/D-McAdams) )                     |
+| **Sponsor**   | None                                                                            |
+| **PR**        | [#1046](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1046) |
 
 ---
 

--- a/docs/community/seps/1302-formalize-working-groups-and-interest-groups-in-mc.mdx
+++ b/docs/community/seps/1302-formalize-working-groups-and-interest-groups-in-mc.mdx
@@ -11,16 +11,16 @@ import { Badge } from "/snippets/badge.mdx";
   <Badge color="gray">Standards Track</Badge>
 </div>
 
-| Field         | Value                                                                    |
-| ------------- | ------------------------------------------------------------------------ |
-| **SEP**       | 1302                                                                     |
-| **Title**     | Formalize Working Groups and Interest Groups in MCP Governance           |
-| **Status**    | Final                                                                    |
-| **Type**      | Standards Track                                                          |
-| **Created**   | 2025-08-05                                                               |
-| **Author(s)** | tadasant                                                                 |
-| **Sponsor**   | None                                                                     |
-| **PR**        | [#1302](https://github.com/modelcontextprotocol/specification/pull/1302) |
+| Field         | Value                                                                           |
+| ------------- | ------------------------------------------------------------------------------- |
+| **SEP**       | 1302                                                                            |
+| **Title**     | Formalize Working Groups and Interest Groups in MCP Governance                  |
+| **Status**    | Final                                                                           |
+| **Type**      | Standards Track                                                                 |
+| **Created**   | 2025-08-05                                                                      |
+| **Author(s)** | tadasant                                                                        |
+| **Sponsor**   | None                                                                            |
+| **PR**        | [#1302](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1302) |
 
 ---
 

--- a/docs/community/seps/1303-input-validation-errors-as-tool-execution-errors.mdx
+++ b/docs/community/seps/1303-input-validation-errors-as-tool-execution-errors.mdx
@@ -11,16 +11,16 @@ import { Badge } from "/snippets/badge.mdx";
   <Badge color="gray">Standards Track</Badge>
 </div>
 
-| Field         | Value                                                                    |
-| ------------- | ------------------------------------------------------------------------ |
-| **SEP**       | 1303                                                                     |
-| **Title**     | Input Validation Errors as Tool Execution Errors                         |
-| **Status**    | Final                                                                    |
-| **Type**      | Standards Track                                                          |
-| **Created**   | 2025-08-05                                                               |
-| **Author(s)** | [@fredericbarthelet](https://github.com/fredericbarthelet)               |
-| **Sponsor**   | None                                                                     |
-| **PR**        | [#1303](https://github.com/modelcontextprotocol/specification/pull/1303) |
+| Field         | Value                                                                           |
+| ------------- | ------------------------------------------------------------------------------- |
+| **SEP**       | 1303                                                                            |
+| **Title**     | Input Validation Errors as Tool Execution Errors                                |
+| **Status**    | Final                                                                           |
+| **Type**      | Standards Track                                                                 |
+| **Created**   | 2025-08-05                                                                      |
+| **Author(s)** | [@fredericbarthelet](https://github.com/fredericbarthelet)                      |
+| **Sponsor**   | None                                                                            |
+| **PR**        | [#1303](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1303) |
 
 ---
 

--- a/docs/community/seps/1319-decouple-request-payload-from-rpc-methods-definiti.mdx
+++ b/docs/community/seps/1319-decouple-request-payload-from-rpc-methods-definiti.mdx
@@ -11,16 +11,16 @@ import { Badge } from "/snippets/badge.mdx";
   <Badge color="gray">Standards Track</Badge>
 </div>
 
-| Field         | Value                                                                    |
-| ------------- | ------------------------------------------------------------------------ |
-| **SEP**       | 1319                                                                     |
-| **Title**     | Decouple Request Payload from RPC Methods Definition                     |
-| **Status**    | Final                                                                    |
-| **Type**      | Standards Track                                                          |
-| **Created**   | 2025-08-08                                                               |
-| **Author(s)** | [@kurtisvg](https://github.com/kurtisvg)                                 |
-| **Sponsor**   | None                                                                     |
-| **PR**        | [#1319](https://github.com/modelcontextprotocol/specification/pull/1319) |
+| Field         | Value                                                                           |
+| ------------- | ------------------------------------------------------------------------------- |
+| **SEP**       | 1319                                                                            |
+| **Title**     | Decouple Request Payload from RPC Methods Definition                            |
+| **Status**    | Final                                                                           |
+| **Type**      | Standards Track                                                                 |
+| **Created**   | 2025-08-08                                                                      |
+| **Author(s)** | [@kurtisvg](https://github.com/kurtisvg)                                        |
+| **Sponsor**   | None                                                                            |
+| **PR**        | [#1319](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1319) |
 
 ---
 

--- a/docs/community/seps/1330-elicitation-enum-schema-improvements-and-standards.mdx
+++ b/docs/community/seps/1330-elicitation-enum-schema-improvements-and-standards.mdx
@@ -11,16 +11,16 @@ import { Badge } from "/snippets/badge.mdx";
   <Badge color="gray">Standards Track</Badge>
 </div>
 
-| Field         | Value                                                                    |
-| ------------- | ------------------------------------------------------------------------ |
-| **SEP**       | 1330                                                                     |
-| **Title**     | Elicitation Enum Schema Improvements and Standards Compliance            |
-| **Status**    | Final                                                                    |
-| **Type**      | Standards Track                                                          |
-| **Created**   | 2025-08-11                                                               |
-| **Author(s)** | chughtapan                                                               |
-| **Sponsor**   | None                                                                     |
-| **PR**        | [#1330](https://github.com/modelcontextprotocol/specification/pull/1330) |
+| Field         | Value                                                                           |
+| ------------- | ------------------------------------------------------------------------------- |
+| **SEP**       | 1330                                                                            |
+| **Title**     | Elicitation Enum Schema Improvements and Standards Compliance                   |
+| **Status**    | Final                                                                           |
+| **Type**      | Standards Track                                                                 |
+| **Created**   | 2025-08-11                                                                      |
+| **Author(s)** | chughtapan                                                                      |
+| **Sponsor**   | None                                                                            |
+| **PR**        | [#1330](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1330) |
 
 ---
 

--- a/docs/community/seps/1577--sampling-with-tools.mdx
+++ b/docs/community/seps/1577--sampling-with-tools.mdx
@@ -11,16 +11,16 @@ import { Badge } from "/snippets/badge.mdx";
   <Badge color="gray">Standards Track</Badge>
 </div>
 
-| Field         | Value                                                                    |
-| ------------- | ------------------------------------------------------------------------ |
-| **SEP**       | 1577                                                                     |
-| **Title**     | Sampling With Tools                                                      |
-| **Status**    | Final                                                                    |
-| **Type**      | Standards Track                                                          |
-| **Created**   | 2025-09-30                                                               |
-| **Author(s)** | Olivier Chafik ([@ochafik](https://github.com/ochafik))                  |
-| **Sponsor**   | None                                                                     |
-| **PR**        | [#1577](https://github.com/modelcontextprotocol/specification/pull/1577) |
+| Field         | Value                                                                           |
+| ------------- | ------------------------------------------------------------------------------- |
+| **SEP**       | 1577                                                                            |
+| **Title**     | Sampling With Tools                                                             |
+| **Status**    | Final                                                                           |
+| **Type**      | Standards Track                                                                 |
+| **Created**   | 2025-09-30                                                                      |
+| **Author(s)** | Olivier Chafik ([@ochafik](https://github.com/ochafik))                         |
+| **Sponsor**   | None                                                                            |
+| **PR**        | [#1577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1577) |
 
 ---
 

--- a/docs/community/seps/1613-establish-json-schema-2020-12-as-default-dialect-f.mdx
+++ b/docs/community/seps/1613-establish-json-schema-2020-12-as-default-dialect-f.mdx
@@ -11,16 +11,16 @@ import { Badge } from "/snippets/badge.mdx";
   <Badge color="gray">Standards Track</Badge>
 </div>
 
-| Field         | Value                                                                    |
-| ------------- | ------------------------------------------------------------------------ |
-| **SEP**       | 1613                                                                     |
-| **Title**     | Establish JSON Schema 2020-12 as Default Dialect for MCP                 |
-| **Status**    | Final                                                                    |
-| **Type**      | Standards Track                                                          |
-| **Created**   | 2025-10-06                                                               |
-| **Author(s)** | Ola Hungerford                                                           |
-| **Sponsor**   | None                                                                     |
-| **PR**        | [#1613](https://github.com/modelcontextprotocol/specification/pull/1613) |
+| Field         | Value                                                                           |
+| ------------- | ------------------------------------------------------------------------------- |
+| **SEP**       | 1613                                                                            |
+| **Title**     | Establish JSON Schema 2020-12 as Default Dialect for MCP                        |
+| **Status**    | Final                                                                           |
+| **Type**      | Standards Track                                                                 |
+| **Created**   | 2025-10-06                                                                      |
+| **Author(s)** | Ola Hungerford                                                                  |
+| **Sponsor**   | None                                                                            |
+| **PR**        | [#1613](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1613) |
 
 ---
 

--- a/docs/community/seps/1686-tasks.mdx
+++ b/docs/community/seps/1686-tasks.mdx
@@ -11,16 +11,16 @@ import { Badge } from "/snippets/badge.mdx";
   <Badge color="gray">Standards Track</Badge>
 </div>
 
-| Field         | Value                                                                    |
-| ------------- | ------------------------------------------------------------------------ |
-| **SEP**       | 1686                                                                     |
-| **Title**     | Tasks                                                                    |
-| **Status**    | Final                                                                    |
-| **Type**      | Standards Track                                                          |
-| **Created**   | 2025-10-20                                                               |
-| **Author(s)** | Surbhi Bansal, Luca Chang                                                |
-| **Sponsor**   | None                                                                     |
-| **PR**        | [#1686](https://github.com/modelcontextprotocol/specification/pull/1686) |
+| Field         | Value                                                                           |
+| ------------- | ------------------------------------------------------------------------------- |
+| **SEP**       | 1686                                                                            |
+| **Title**     | Tasks                                                                           |
+| **Status**    | Final                                                                           |
+| **Type**      | Standards Track                                                                 |
+| **Created**   | 2025-10-20                                                                      |
+| **Author(s)** | Surbhi Bansal, Luca Chang                                                       |
+| **Sponsor**   | None                                                                            |
+| **PR**        | [#1686](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1686) |
 
 ---
 

--- a/docs/community/seps/1699-support-sse-polling-via-server-side-disconnect.mdx
+++ b/docs/community/seps/1699-support-sse-polling-via-server-side-disconnect.mdx
@@ -11,16 +11,16 @@ import { Badge } from "/snippets/badge.mdx";
   <Badge color="gray">Standards Track</Badge>
 </div>
 
-| Field         | Value                                                                    |
-| ------------- | ------------------------------------------------------------------------ |
-| **SEP**       | 1699                                                                     |
-| **Title**     | Support SSE polling via server-side disconnect                           |
-| **Status**    | Final                                                                    |
-| **Type**      | Standards Track                                                          |
-| **Created**   | 2025-10-22                                                               |
-| **Author(s)** | Jonathan Hefner ([@jonathanhefner](https://github.com/jonathanhefner))   |
-| **Sponsor**   | None                                                                     |
-| **PR**        | [#1699](https://github.com/modelcontextprotocol/specification/pull/1699) |
+| Field         | Value                                                                           |
+| ------------- | ------------------------------------------------------------------------------- |
+| **SEP**       | 1699                                                                            |
+| **Title**     | Support SSE polling via server-side disconnect                                  |
+| **Status**    | Final                                                                           |
+| **Type**      | Standards Track                                                                 |
+| **Created**   | 2025-10-22                                                                      |
+| **Author(s)** | Jonathan Hefner ([@jonathanhefner](https://github.com/jonathanhefner))          |
+| **Sponsor**   | None                                                                            |
+| **PR**        | [#1699](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1699) |
 
 ---
 

--- a/docs/community/seps/1730-sdks-tiering-system.mdx
+++ b/docs/community/seps/1730-sdks-tiering-system.mdx
@@ -11,16 +11,16 @@ import { Badge } from "/snippets/badge.mdx";
   <Badge color="gray">Standards Track</Badge>
 </div>
 
-| Field         | Value                                                                    |
-| ------------- | ------------------------------------------------------------------------ |
-| **SEP**       | 1730                                                                     |
-| **Title**     | SDKs Tiering System                                                      |
-| **Status**    | Final                                                                    |
-| **Type**      | Standards Track                                                          |
-| **Created**   | 2025-10-29                                                               |
-| **Author(s)** | Inna Harper, Felix Weinberger                                            |
-| **Sponsor**   | None                                                                     |
-| **PR**        | [#1730](https://github.com/modelcontextprotocol/specification/pull/1730) |
+| Field         | Value                                                                           |
+| ------------- | ------------------------------------------------------------------------------- |
+| **SEP**       | 1730                                                                            |
+| **Title**     | SDKs Tiering System                                                             |
+| **Status**    | Final                                                                           |
+| **Type**      | Standards Track                                                                 |
+| **Created**   | 2025-10-29                                                                      |
+| **Author(s)** | Inna Harper, Felix Weinberger                                                   |
+| **Sponsor**   | None                                                                            |
+| **PR**        | [#1730](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1730) |
 
 ---
 

--- a/docs/community/seps/1850-pr-based-sep-workflow.mdx
+++ b/docs/community/seps/1850-pr-based-sep-workflow.mdx
@@ -21,7 +21,7 @@ import { Badge } from "/snippets/badge.mdx";
 | **Accepted**  | 2025-11-28, 8 Yes, 0 No, 0 Absent per vote in Discord.                                                             |
 | **Author(s)** | Nick Cooper ([@nickcoai](https://github.com/nickcoai)), David Soria Parra ([@davidsp](https://github.com/davidsp)) |
 | **Sponsor**   | David Soria Parra ([@davidsp](https://github.com/davidsp))                                                         |
-| **PR**        | [#1850](https://github.com/modelcontextprotocol/specification/pull/1850)                                           |
+| **PR**        | [#1850](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1850)                                    |
 
 ---
 

--- a/docs/community/seps/932-model-context-protocol-governance.mdx
+++ b/docs/community/seps/932-model-context-protocol-governance.mdx
@@ -11,16 +11,16 @@ import { Badge } from "/snippets/badge.mdx";
   <Badge color="gray">Process</Badge>
 </div>
 
-| Field         | Value                             |
-| ------------- | --------------------------------- |
-| **SEP**       | 932                               |
-| **Title**     | Model Context Protocol Governance |
-| **Status**    | Final                             |
-| **Type**      | Process                           |
-| **Created**   | 2025-07-08                        |
-| **Author(s)** | David Soria Parra                 |
-| **Sponsor**   | None                              |
-| **PR**        | [#932](#931)                      |
+| Field         | Value                                                                         |
+| ------------- | ----------------------------------------------------------------------------- |
+| **SEP**       | 932                                                                           |
+| **Title**     | Model Context Protocol Governance                                             |
+| **Status**    | Final                                                                         |
+| **Type**      | Process                                                                       |
+| **Created**   | 2025-07-08                                                                    |
+| **Author(s)** | David Soria Parra                                                             |
+| **Sponsor**   | None                                                                          |
+| **PR**        | [#931](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/931) |
 
 ---
 

--- a/docs/community/seps/973-expose-additional-metadata-for-implementations-res.mdx
+++ b/docs/community/seps/973-expose-additional-metadata-for-implementations-res.mdx
@@ -11,16 +11,16 @@ import { Badge } from "/snippets/badge.mdx";
   <Badge color="gray">Standards Track</Badge>
 </div>
 
-| Field         | Value                                                                        |
-| ------------- | ---------------------------------------------------------------------------- |
-| **SEP**       | 973                                                                          |
-| **Title**     | Expose additional metadata for Implementations, Resources, Tools and Prompts |
-| **Status**    | Final                                                                        |
-| **Type**      | Standards Track                                                              |
-| **Created**   | 2025-07-15                                                                   |
-| **Author(s)** | [@jesselumarie](https://github.com/jesselumarie)                             |
-| **Sponsor**   | None                                                                         |
-| **PR**        | [#973](https://github.com/modelcontextprotocol/specification/pull/973)       |
+| Field         | Value                                                                         |
+| ------------- | ----------------------------------------------------------------------------- |
+| **SEP**       | 973                                                                           |
+| **Title**     | Expose additional metadata for Implementations, Resources, Tools and Prompts  |
+| **Status**    | Final                                                                         |
+| **Type**      | Standards Track                                                               |
+| **Created**   | 2025-07-15                                                                    |
+| **Author(s)** | [@jesselumarie](https://github.com/jesselumarie)                              |
+| **Sponsor**   | None                                                                          |
+| **PR**        | [#973](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/973) |
 
 ---
 

--- a/docs/community/seps/985-align-oauth-20-protected-resource-metadata-with-rf.mdx
+++ b/docs/community/seps/985-align-oauth-20-protected-resource-metadata-with-rf.mdx
@@ -11,16 +11,16 @@ import { Badge } from "/snippets/badge.mdx";
   <Badge color="gray">Standards Track</Badge>
 </div>
 
-| Field         | Value                                                                  |
-| ------------- | ---------------------------------------------------------------------- |
-| **SEP**       | 985                                                                    |
-| **Title**     | Align OAuth 2.0 Protected Resource Metadata with RFC 9728              |
-| **Status**    | Final                                                                  |
-| **Type**      | Standards Track                                                        |
-| **Created**   | 2025-07-16                                                             |
-| **Author(s)** | sunishsheth2009                                                        |
-| **Sponsor**   | None                                                                   |
-| **PR**        | [#985](https://github.com/modelcontextprotocol/specification/pull/985) |
+| Field         | Value                                                                         |
+| ------------- | ----------------------------------------------------------------------------- |
+| **SEP**       | 985                                                                           |
+| **Title**     | Align OAuth 2.0 Protected Resource Metadata with RFC 9728                     |
+| **Status**    | Final                                                                         |
+| **Type**      | Standards Track                                                               |
+| **Created**   | 2025-07-16                                                                    |
+| **Author(s)** | sunishsheth2009                                                               |
+| **Sponsor**   | None                                                                          |
+| **PR**        | [#985](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/985) |
 
 ---
 

--- a/docs/community/seps/986-specify-format-for-tool-names.mdx
+++ b/docs/community/seps/986-specify-format-for-tool-names.mdx
@@ -11,16 +11,16 @@ import { Badge } from "/snippets/badge.mdx";
   <Badge color="gray">Standards Track</Badge>
 </div>
 
-| Field         | Value                                                                  |
-| ------------- | ---------------------------------------------------------------------- |
-| **SEP**       | 986                                                                    |
-| **Title**     | Specify Format for Tool Names                                          |
-| **Status**    | Final                                                                  |
-| **Type**      | Standards Track                                                        |
-| **Created**   | 2025-07-16                                                             |
-| **Author(s)** | kentcdodds                                                             |
-| **Sponsor**   | None                                                                   |
-| **PR**        | [#986](https://github.com/modelcontextprotocol/specification/pull/986) |
+| Field         | Value                                                                         |
+| ------------- | ----------------------------------------------------------------------------- |
+| **SEP**       | 986                                                                           |
+| **Title**     | Specify Format for Tool Names                                                 |
+| **Status**    | Final                                                                         |
+| **Type**      | Standards Track                                                               |
+| **Created**   | 2025-07-16                                                                    |
+| **Author(s)** | kentcdodds                                                                    |
+| **Sponsor**   | None                                                                          |
+| **PR**        | [#986](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/986) |
 
 ---
 

--- a/docs/community/seps/990-enable-enterprise-idp-policy-controls-during-mcp-o.mdx
+++ b/docs/community/seps/990-enable-enterprise-idp-policy-controls-during-mcp-o.mdx
@@ -11,16 +11,16 @@ import { Badge } from "/snippets/badge.mdx";
   <Badge color="gray">Standards Track</Badge>
 </div>
 
-| Field         | Value                                                        |
-| ------------- | ------------------------------------------------------------ |
-| **SEP**       | 990                                                          |
-| **Title**     | Enable enterprise IdP policy controls during MCP OAuth flows |
-| **Status**    | Final                                                        |
-| **Type**      | Standards Track                                              |
-| **Created**   | 2025-06-04                                                   |
-| **Author(s)** | Aaron Parecki ([@aaronpk](https://github.com/aaronpk))       |
-| **Sponsor**   | None                                                         |
-| **PR**        | [#990](#646)                                                 |
+| Field         | Value                                                                         |
+| ------------- | ----------------------------------------------------------------------------- |
+| **SEP**       | 990                                                                           |
+| **Title**     | Enable enterprise IdP policy controls during MCP OAuth flows                  |
+| **Status**    | Final                                                                         |
+| **Type**      | Standards Track                                                               |
+| **Created**   | 2025-06-04                                                                    |
+| **Author(s)** | Aaron Parecki ([@aaronpk](https://github.com/aaronpk))                        |
+| **Sponsor**   | None                                                                          |
+| **PR**        | [#646](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/646) |
 
 ---
 

--- a/docs/community/seps/991-enable-url-based-client-registration-using-oauth-c.mdx
+++ b/docs/community/seps/991-enable-url-based-client-registration-using-oauth-c.mdx
@@ -20,7 +20,7 @@ import { Badge } from "/snippets/badge.mdx";
 | **Created**   | 2025-07-07                                                                                                        |
 | **Author(s)** | Paul Carleton ([@pcarleton](https://github.com/pcarleton)) Aaron Parecki ([@aaronpk](https://github.com/aaronpk)) |
 | **Sponsor**   | None                                                                                                              |
-| **PR**        | [#991](https://github.com/modelcontextprotocol/specification/pull/991)                                            |
+| **PR**        | [#991](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/991)                                     |
 
 ---
 

--- a/docs/community/seps/994-shared-communication-practicesguidelines.mdx
+++ b/docs/community/seps/994-shared-communication-practicesguidelines.mdx
@@ -11,16 +11,16 @@ import { Badge } from "/snippets/badge.mdx";
   <Badge color="gray">Process</Badge>
 </div>
 
-| Field         | Value                                     |
-| ------------- | ----------------------------------------- |
-| **SEP**       | 994                                       |
-| **Title**     | Shared Communication Practices/Guidelines |
-| **Status**    | Final                                     |
-| **Type**      | Process                                   |
-| **Created**   | 2025-07-17                                |
-| **Author(s)** | [@localden](https://github.com/localden)  |
-| **Sponsor**   | None                                      |
-| **PR**        | [#994](#1002)                             |
+| Field         | Value                                                                           |
+| ------------- | ------------------------------------------------------------------------------- |
+| **SEP**       | 994                                                                             |
+| **Title**     | Shared Communication Practices/Guidelines                                       |
+| **Status**    | Final                                                                           |
+| **Type**      | Process                                                                         |
+| **Created**   | 2025-07-17                                                                      |
+| **Author(s)** | [@localden](https://github.com/localden)                                        |
+| **Sponsor**   | None                                                                            |
+| **PR**        | [#1002](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1002) |
 
 ---
 

--- a/scripts/render-seps.ts
+++ b/scripts/render-seps.ts
@@ -29,7 +29,7 @@ interface SEPMetadata {
   accepted?: string;
   authors: string;
   sponsor: string;
-  prUrl: string;
+  prNumber: string;
   slug: string;
   filename: string;
 }
@@ -67,7 +67,7 @@ function parseSEPMetadata(content: string, filename: string): SEPMetadata | null
   const acceptedMatch = content.match(/^\s*-\s*\*\*Accepted\*\*:\s*(.+)$/m);
   const authorsMatch = content.match(/^\s*-\s*\*\*Author\(s\)\*\*:\s*(.+)$/m);
   const sponsorMatch = content.match(/^\s*-\s*\*\*Sponsor\*\*:\s*(.+)$/m);
-  const prMatch = content.match(/^\s*-\s*\*\*PR\*\*:\s*(.+)$/m);
+  const prMatch = content.match(/^\s*-\s*\*\*PR\*\*:.*?(?:#|\/pull\/)(\d+)/m);
 
   return {
     number,
@@ -78,7 +78,7 @@ function parseSEPMetadata(content: string, filename: string): SEPMetadata | null
     accepted: acceptedMatch ? acceptedMatch[1].trim() : undefined,
     authors: authorsMatch ? authorsMatch[1].trim() : "Unknown",
     sponsor: sponsorMatch ? sponsorMatch[1].trim() : "None",
-    prUrl: prMatch ? prMatch[1].trim() : `https://github.com/modelcontextprotocol/specification/pull/${number}`,
+    prNumber: prMatch ? prMatch[1] : number,
     slug,
     filename,
   };
@@ -89,6 +89,13 @@ function parseSEPMetadata(content: string, filename: string): SEPMetadata | null
  */
 function formatAuthors(authors: string): string {
   return authors.replace(/@([\w-]+)/g, "[@$1](https://github.com/$1)");
+}
+
+/**
+ * Format PR number as a GitHub link
+ */
+function formatPrLink(prNumber: string): string {
+  return `[#${prNumber}](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/${prNumber})`;
 }
 
 /**
@@ -145,7 +152,7 @@ import { Badge } from '/snippets/badge.mdx'
 | **Created** | ${sep.created} |
 ${sep.accepted ? `| **Accepted** | ${sep.accepted} |\n` : ""}| **Author(s)** | ${formatAuthors(sep.authors)} |
 | **Sponsor** | ${formatAuthors(sep.sponsor)} |
-| **PR** | [#${sep.number}](${sep.prUrl}) |
+| **PR** | ${formatPrLink(sep.prNumber)} |
 
 ---
 


### PR DESCRIPTION
The `render-seps.ts` script was generating malformed PR links like `[#932](#931)` (same-page anchors) instead of valid GitHub URLs. The script also pointed to the old `specification` repository.

Updated `render-seps.ts` to:

- Extract PR numbers from various formats (`#123` or `/pull/123`)
- Generate proper URLs to `modelcontextprotocol/modelcontextprotocol`

Regenerated all SEP documents with corrected PR links.
