### PR TITLE
[Doc] Fix Prettier format check failure

### DIFF
--- a/docs/community/governance.mdx
+++ b/docs/community/governance.mdx
@@ -21,12 +21,12 @@ All documentation (excluding specifications) will be made available under Creati
 
 The MCP project adopts a hierarchical structure, similar to Python, PyTorch, and other open source projects:
 
-| Role | Scope |
-| --- | --- |
-| **Lead Maintainers (BDFL)** | Final decision authority |
-| **Core Maintainers** | Overall project direction |
-| **Maintainers** | Working Groups, SDKs, components |
-| **Contributors** | Issues, PRs, discussions |
+| Role                        | Scope                            |
+| --------------------------- | -------------------------------- |
+| **Lead Maintainers (BDFL)** | Final decision authority         |
+| **Core Maintainers**        | Overall project direction        |
+| **Maintainers**             | Working Groups, SDKs, components |
+| **Contributors**            | Issues, PRs, discussions         |
 
 - **Contributors** file issues, make pull requests, and contribute to the project.
 - **Maintainers** drive components within the MCP project, such as SDKs, documentation, and Working Groups.


### PR DESCRIPTION
## Motivation and Context

Format the Markdown table that was added in commit 94daefdb to comply with Prettier's formatting rules. This fixes the CI format check failure. https://github.com/modelcontextprotocol/modelcontextprotocol/actions/runs/21668476308/job/62469969079

## How Has This Been Tested?

```console
$ npm run check:docs:format                    

> @modelcontextprotocol/specification@0.1.0 check:docs:format
> prettier --check "**/*.{md,mdx}"

Checking formatting...
All matched files use Prettier code style!
```

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
