### PR TITLE
Style Schema Reference index-property-only types

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -314,7 +314,7 @@ body:has(#schema-reference) {
 
     /* Sub-members */
     .tsd-type-declaration {
-      /* Templated heading */
+      /* Templated heading ("Type Declaration") */
       [data-typedoc-h="4"] {
         display: none;
       }
@@ -362,6 +362,25 @@ body:has(#schema-reference) {
 
     svg {
       display: none;
+    }
+  }
+
+  /* Types with only index properties (e.g., `type Foo = { [key: string]: unknown }`) */
+  .type > .tsd-type-declaration {
+    /* Hide property if no doc comments */
+    &:not(:has(.tsd-comment)) {
+      display: none;
+    }
+
+    /* Templated heading ("Type Declaration") */
+    [data-typedoc-h="4"] {
+      display: none;
+    }
+
+    /* Index property */
+    [data-typedoc-h="5"] {
+      font-family: var(--font-mono);
+      font-weight: 700;
     }
   }
 }


### PR DESCRIPTION
TypeDoc generates a `.tsd-type-declaration` block as a direct child of the `.type` wrapper for types with only index properties (e.g., `type Foo = { [key: string]: unknown }`). This differs from interface members, which are nested inside `.tsd-member` elements.

Add CSS rules for `.type > .tsd-type-declaration` to hide the redundant block when there are no doc comments, hide the templated "Type Declaration" heading, and style the index property heading with monospace font to match other member headings.

---

Related to https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2139.