### PR TITLE
Clarify that sampling `tools` are scoped to the request

### DIFF
--- a/docs/specification/draft/client/sampling.mdx
+++ b/docs/specification/draft/client/sampling.mdx
@@ -37,7 +37,7 @@ Applications **SHOULD**:
 
 ## Tools in Sampling
 
-Servers can request that the client's LLM use tools during sampling by providing a `tools` array and optional `toolChoice` configuration in their sampling requests. This enables servers to implement agentic behaviors where the LLM can call tools, receive results, and continue the conversation - all within a single sampling request flow.
+Servers can request that the client's LLM use tools during sampling by providing a `tools` array and optional `toolChoice` configuration in their sampling requests. The tool definitions in the `tools` array are scoped to the sampling request — they don't need to correspond to registered tools. This enables servers to implement agentic behaviors where the LLM can call specially designated tools, receive results, and continue the conversation - all within a single sampling request flow.
 
 Clients **MUST** declare support for tool use via the `sampling.tools` capability to receive tool-enabled sampling requests. Servers **MUST NOT** send tool-enabled sampling requests to Clients that have not declared support for tool use via the `sampling.tools` capability.
 


### PR DESCRIPTION
The `tools` array in a `sampling/createMessage` request defines tools specifically for that sampling request. They don't need to correspond to registered tools on the server. This was a source of confusion discussed in the community.

Closes #1988.
