### PR TITLE
Add Tapan Chugh as maintainer for Primitive Grouping Interest Group

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -197,6 +197,10 @@ This document lists current maintainers in the Model Context Protocol project.
 - [Liad Yosef](https://github.com/liady)
 - [Ido Salomon](https://github.com/idosal)
 
+### Primitive Grouping Interest Group
+
+- [Tapan Chugh](https://github.com/chughtapan)
+
 ## About This Document
 
 This document is updated by the MCP maintainers and reflects the current


### PR DESCRIPTION
## Description
In MAINTAINERS.md
  - Add Tapan Chugh as maintainer for Primitive Grouping Interest Group

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
We are transitioning primitive-working-group-wg to primitive-working-group-wg and Tapan Chugh will be the facilitator/maintainer.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
Also see the update to the access repo for Tapan: https://github.com/modelcontextprotocol/access/pull/58