### PR TITLE
Document CSP requirements for MCP App UI resources

### DIFF
--- a/docs/docs/extensions/apps.mdx
+++ b/docs/docs/extensions/apps.mdx
@@ -295,7 +295,7 @@ A typical MCP App project separates the server code from the UI code:
   </Tree.Folder>
 </Tree>
 
-The server registers the tool and serves the UI resource. The UI doesn't need to be bundled into a single file — you can serve it however you like, including as separate HTML, CSS, and JS files. This guide uses `vite-plugin-singlefile` as a convenience, but any approach that produces valid HTML works.
+The server registers the tool and serves the UI resource. The UI resource will eventually be rendered in a secure iframe with deny-by-default CSP configuration. If your app has CSS and JS assets, you will need to [configure CSP](https://modelcontextprotocol.github.io/ext-apps/api/documents/Patterns.html#configuring-csp-and-cors), or you can bundle your assets into the HTML with a tool like `vite-plugin-singlefile`, which is what we will do in this tutorial.
 
 </Step>
 <Step title="Install dependencies">
@@ -305,7 +305,7 @@ npm install @modelcontextprotocol/ext-apps @modelcontextprotocol/sdk
 npm install -D typescript vite vite-plugin-singlefile express cors @types/express @types/cors tsx
 ```
 
-The `ext-apps` package provides helpers for both the server side (registering tools and resources) and the client side (the `App` class for UI-to-host communication). Vite with the `vite-plugin-singlefile` plugin is used here to bundle your UI into a single HTML file for convenience, but this is optional — you can use any bundler or serve unbundled files.
+The `ext-apps` package provides helpers for both the server side (registering tools and resources) and the client side (the `App` class for UI-to-host communication). Vite with the `vite-plugin-singlefile` plugin is used here to bundle your UI and assets into a single HTML file for convenience, but this is optional — you can use any bundler or serve unbundled files if you [configure CSP](https://modelcontextprotocol.github.io/ext-apps/api/documents/Patterns.html#configuring-csp-and-cors).
 
 </Step>
 <Step title="Configure the project">


### PR DESCRIPTION
The apps tutorial previously stated that UI doesn't need to be bundled into a single file without mentioning the security constraints. Update the guidance to explain that UI resources are rendered in a secure iframe with deny-by-default CSP, and link to the CSP configuration docs as the alternative to bundling with `vite-plugin-singlefile`.
