### PR TITLE
chore: skip SEP reminder job on forks

### DIFF
--- a/.github/workflows/sep-reminder.yml
+++ b/.github/workflows/sep-reminder.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   discord-reminder:
     runs-on: ubuntu-latest
-
+    if: github.repository == 'modelcontextprotocol/modelcontextprotocol'
     steps:
       - name: Post Discord reminder
         run: |


### PR DESCRIPTION
Skips the SEP reminder GHA job on forks.

## Motivation and Context
Avoids unnecessary job failure notifications due to the webhook secret not being set.

## How Has This Been Tested?
Manual dispatch: https://github.com/LucaButBoring/modelcontextprotocol/actions/runs/21921275388

## Breaking Changes
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
