### PR TITLE
SEP-2245: Sign-In with Ethereum (SIWE) for Model Context Protocol

### DIFF
--- a/docs/community/seps/2245-sign-in-with-ethereum-siwe-for-mcp.mdx
+++ b/docs/community/seps/2245-sign-in-with-ethereum-siwe-for-mcp.mdx
@@ -1,11 +1,30 @@
-# SEP-0000: Sign-In with Ethereum (SIWE) for Model Context Protocol
+---
+title: "SEP-2245: Sign-In with Ethereum (SIWE) for Model Context Protocol"
+sidebarTitle: "SEP-2245: Sign-In with Ethereum (SIWE) for Model…"
+description: "Sign-In with Ethereum (SIWE) for Model Context Protocol"
+---
 
-- **Status**: Draft
-- **Type**: Standards Track
-- **Created**: 2025-02-13
-- **Author(s)**: Nikko Ambroselli @d3l33t
-- **Sponsor**: None (seeking sponsor)
-- **PR**: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/0000
+<div className="flex items-center gap-2 mb-4">
+  <Badge color="gray" shape="pill">
+    Draft
+  </Badge>
+  <Badge color="gray" shape="pill">
+    Standards Track
+  </Badge>
+</div>
+
+| Field         | Value                                                                           |
+| ------------- | ------------------------------------------------------------------------------- |
+| **SEP**       | 2245                                                                            |
+| **Title**     | Sign-In with Ethereum (SIWE) for Model Context Protocol                         |
+| **Status**    | Draft                                                                           |
+| **Type**      | Standards Track                                                                 |
+| **Created**   | 2025-02-13                                                                      |
+| **Author(s)** | Nikko Ambroselli [@d3l33t](https://github.com/d3l33t)                           |
+| **Sponsor**   | None (seeking sponsor)                                                          |
+| **PR**        | [#2245](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2245) |
+
+---
 
 ## Abstract
 

--- a/docs/community/seps/index.mdx
+++ b/docs/community/seps/index.mdx
@@ -12,13 +12,14 @@ Specification Enhancement Proposals (SEPs) are the primary mechanism for proposi
 
 ## Summary
 
-- **Final**: 24
 - **Draft**: 1
+- **Final**: 24
 
 ## All SEPs
 
 | SEP                                                                                 | Title                                                                         | Status                                          | Type             | Created    |
 | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------- | ---------------- | ---------- |
+| [SEP-2245](/community/seps/2245-sign-in-with-ethereum-siwe-for-mcp)                 | Sign-In with Ethereum (SIWE) for Model Context Protocol                       | <Badge color="gray" shape="pill">Draft</Badge>  | Standards Track  | 2025-02-13 |
 | [SEP-2133](/community/seps/2133-extensions)                                         | Extensions                                                                    | <Badge color="green" shape="pill">Final</Badge> | Standards Track  | 2025-01-21 |
 | [SEP-2085](/community/seps/2085-governance-succession-and-amendment)                | Governance Succession and Amendment Procedures                                | <Badge color="green" shape="pill">Final</Badge> | Process          | 2025-12-05 |
 | [SEP-1865](/community/seps/1865-mcp-apps-interactive-user-interfaces-for-mcp)       | MCP Apps - Interactive User Interfaces for MCP                                | <Badge color="green" shape="pill">Final</Badge> | Extensions Track | 2025-11-21 |
@@ -43,7 +44,6 @@ Specification Enhancement Proposals (SEPs) are the primary mechanism for proposi
 | [SEP-985](/community/seps/985-align-oauth-20-protected-resource-metadata-with-rf)   | Align OAuth 2.0 Protected Resource Metadata with RFC 9728                     | <Badge color="green" shape="pill">Final</Badge> | Standards Track  | 2025-07-16 |
 | [SEP-973](/community/seps/973-expose-additional-metadata-for-implementations-res)   | Expose additional metadata for Implementations, Resources, Tools and Prompts  | <Badge color="green" shape="pill">Final</Badge> | Standards Track  | 2025-07-15 |
 | [SEP-932](/community/seps/932-model-context-protocol-governance)                    | Model Context Protocol Governance                                             | <Badge color="green" shape="pill">Final</Badge> | Process          | 2025-07-08 |
-| [SEP-0000](/community/seps/0000-sign-in-with-ethereum-siwe-for-mcp)                 | Sign-In with Ethereum (SIWE) for Model Context Protocol                       | <Badge color="gray" shape="pill">Draft</Badge>  | Standards Track  | 2025-02-13 |
 
 ## SEP Status Definitions
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -406,7 +406,7 @@
               {
                 "group": "Draft",
                 "pages": [
-                  "community/seps/0000-sign-in-with-ethereum-siwe-for-mcp"
+                  "community/seps/2245-sign-in-with-ethereum-siwe-for-mcp"
                 ]
               }
             ]

--- a/docs/specification/draft/basic/authorization.mdx
+++ b/docs/specification/draft/basic/authorization.mdx
@@ -701,7 +701,7 @@ cannot be misused across different services.
 
 ## Sign-In with Ethereum (SIWE)
 
-MCP servers **MAY** support [Sign-In with Ethereum (SIWE)](https://eips.ethereum.org/EIPS/eip-4361) as an alternative to OAuth for Web3 users who authenticate via wallet signatures. SIWE support is specified in [SEP-0000: Sign-In with Ethereum (SIWE) for Model Context Protocol](/community/seps/0000-sign-in-with-ethereum-siwe-for-mcp) (draft).
+MCP servers **MAY** support [Sign-In with Ethereum (SIWE)](https://eips.ethereum.org/EIPS/eip-4361) as an alternative to OAuth for Web3 users who authenticate via wallet signatures. SIWE support is specified in [SEP-2245: Sign-In with Ethereum (SIWE) for Model Context Protocol](/community/seps/2245-sign-in-with-ethereum-siwe-for-mcp) (draft).
 
 ### SIWE Discovery
 
@@ -734,7 +734,7 @@ The SIWE Protected Resource Metadata document includes:
 5. Server verifies the signature and returns `{ "token", "address" }`
 6. Client uses `Authorization: Bearer <token>` for subsequent MCP requests
 
-MCP servers **MAY** support both OAuth and SIWE; clients **MAY** choose based on user context. See the full [SIWE SEP](/community/seps/0000-sign-in-with-ethereum-siwe-for-mcp) for complete specification.
+MCP servers **MAY** support both OAuth and SIWE; clients **MAY** choose based on user context. See the full [SIWE SEP](/community/seps/2245-sign-in-with-ethereum-siwe-for-mcp) for complete specification.
 
 ## MCP Authorization Extensions
 
@@ -745,4 +745,4 @@ There are several authorization extensions to the core protocol that define addi
 - **Composable** - Extensions are modular and designed to work together without conflicts, allowing implementations to adopt multiple extensions simultaneously
 - **Versioned independently** - Extensions follow the core MCP versioning cycle but may adopt independent versioning as needed
 
-A list of supported extensions can be found in the [MCP Authorization Extensions](https://github.com/modelcontextprotocol/ext-auth) repository. A proposed extension for Sign-In with Ethereum (SIWE) is documented in [SEP-0000](/community/seps/0000-sign-in-with-ethereum-siwe-for-mcp).
+A list of supported extensions can be found in the [MCP Authorization Extensions](https://github.com/modelcontextprotocol/ext-auth) repository. A proposed extension for Sign-In with Ethereum (SIWE) is documented in [SEP-2245](/community/seps/2245-sign-in-with-ethereum-siwe-for-mcp).

--- a/seps/2245-sign-in-with-ethereum-siwe-for-mcp.md
+++ b/seps/2245-sign-in-with-ethereum-siwe-for-mcp.md
@@ -1,30 +1,11 @@
----
-title: "SEP-0000: Sign-In with Ethereum (SIWE) for Model Context Protocol"
-sidebarTitle: "SEP-0000: Sign-In with Ethereum (SIWE) for Model…"
-description: "Sign-In with Ethereum (SIWE) for Model Context Protocol"
----
+# SEP-2245: Sign-In with Ethereum (SIWE) for Model Context Protocol
 
-<div className="flex items-center gap-2 mb-4">
-  <Badge color="gray" shape="pill">
-    Draft
-  </Badge>
-  <Badge color="gray" shape="pill">
-    Standards Track
-  </Badge>
-</div>
-
-| Field         | Value                                                                           |
-| ------------- | ------------------------------------------------------------------------------- |
-| **SEP**       | 0000                                                                            |
-| **Title**     | Sign-In with Ethereum (SIWE) for Model Context Protocol                         |
-| **Status**    | Draft                                                                           |
-| **Type**      | Standards Track                                                                 |
-| **Created**   | 2025-02-13                                                                      |
-| **Author(s)** | (Add your name and [@github-username](https://github.com/github-username))      |
-| **Sponsor**   | None (seeking sponsor)                                                          |
-| **PR**        | [#0000](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/0000) |
-
----
+- **Status**: Draft
+- **Type**: Standards Track
+- **Created**: 2025-02-13
+- **Author(s)**: Nikko Ambroselli @d3l33t
+- **Sponsor**: None (seeking sponsor)
+- **PR**: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2245
 
 ## Abstract
 


### PR DESCRIPTION
This PR adds a Specification Enhancement Proposal (SEP) for SIWE-based authentication in MCP and updates the authorization spec to reference it.

## Motivation and Context
MCP authorization is currently OAuth-centric. Many MCP use cases involve Web3 users who authenticate via wallet signatures (Sign-In with Ethereum, SIWE) rather than OAuth. There is no standard way for MCP servers to advertise SIWE support or for clients to discover SIWE endpoints.

This SEP defines SIWE Protected Resource Metadata—a discovery format and flow that parallels RFC 9728 (OAuth 2.0 Protected Resource Metadata). It enables MCP servers to advertise SIWE authentication and clients to obtain Bearer tokens via wallet signing. The scope is limited to HTTP-based MCP transports (Streamable HTTP); STDIO and other transports are out of scope.

## How Has This Been Tested?
SEP document reviewed against SEP guidelines

npm run prep passes (schema check, generate, docs check, format)

A reference implementation is planned before the SEP reaches Final status

## Breaking Changes
None. This SEP adds an optional authorization mechanism. Existing OAuth-only MCP servers and clients are unaffected.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Files changed:
seps/0000-sign-in-with-ethereum-siwe-for-mcp.md — New SEP document
docs/specification/draft/basic/authorization.mdx — SIWE section and EIP-4361 reference
docs/community/seps/* — Auto-generated SEP docs (via npm run generate:seps)
