### PR TITLE
Mark rendered SEP docs as `linguist-generated`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,5 @@ package-lock.json linguist-generated=true
 schema/*/schema.json linguist-generated=true
 docs/specification/*/schema.md linguist-generated=true
 docs/specification/*/schema.mdx linguist-generated=true
+docs/community/seps/index.mdx linguist-generated=true
+docs/community/seps/[0-9]*.mdx linguist-generated=true


### PR DESCRIPTION
The `render-seps.ts` script generates `docs/community/seps/index.mdx` and individual SEP pages like `docs/community/seps/1850-*.mdx`. Mark these with `linguist-generated=true` so GitHub collapses them in diffs. The `[0-9]*` pattern avoids accidentally matching non-generated files that don't start with a digit.
