### PR TITLE
Track user activity instead of `updated_at` for `daysSinceActivity`

### DIFF
--- a/tools/sep-automation/src/processor.ts
+++ b/tools/sep-automation/src/processor.ts
@@ -107,7 +107,7 @@ export class SEPProcessor {
       results.push(...maintainerResults);
       for (const result of maintainerResults) {
         if (result.success && result.action.targetUser) {
-          const activity = await this.analyzer.checkMaintainerActivity(
+          const activity = await this.analyzer.checkUserActivity(
             sep,
             result.action.targetUser,
           );
@@ -185,7 +185,7 @@ export class SEPProcessor {
         continue;
       }
 
-      const activity = await this.analyzer.checkMaintainerActivity(
+      const activity = await this.analyzer.checkUserActivity(
         sep,
         assignee,
       );


### PR DESCRIPTION
The ping bot's `daysSinceActivity` was computed from GitHub's `updated_at` field, which gets reset by the bot's own ping comments. This created a cycle where `daysSinceActivity` could never exceed ~14 days (the ping cooldown), preventing staleness thresholds (30/90/180 days) from ever being reached.

`analyze()` now fetches events and comments, then filters to the responsible person's activity: the first assignee for most states (falling back to the author), or always the author for accepted SEPs. Bot comments are excluded via `BOT_COMMENT_MARKER`, and the fallback is `item.createdAt` instead of the bot-tainted `item.updatedAt`.

Also renames `checkMaintainerActivity()` to `checkUserActivity()` and fixes the same `updatedAt` fallback bug there.

---

Mostly implemented by Claude.  Reviewed by me.  I will flag that it is challenging to test these changes without relying on GitHub API mocks (which I would prefer to avoid).