### PR TITLE
[Doc] Add Ruby SDK example to build-server documentation

### DIFF
--- a/docs/docs/develop/build-server.mdx
+++ b/docs/docs/develop/build-server.mdx
@@ -1797,21 +1797,13 @@ This quickstart assumes you have familiarity with:
 
 When implementing MCP servers, be careful about how you handle logging:
 
-**For STDIO-based servers:** Never write to standard output (stdout). This includes:
-
-- `print()` statements in Python
-- `console.log()` in JavaScript
-- `puts` in Ruby
-- Similar stdout functions in other languages
-
-Writing to stdout will corrupt the JSON-RPC messages and break your server.
+**For STDIO-based servers:** Never use `puts` or `print`, as they write to standard output (stdout) by default. Writing to stdout will corrupt the JSON-RPC messages and break your server.
 
 **For HTTP-based servers:** Standard output logging is fine since it doesn't interfere with HTTP responses.
 
 ### Best Practices
 
-1. Use a logging library that writes to stderr or files.
-2. For Ruby, be especially careful - `puts` and `print` write to stdout by default.
+- Use a logging library that writes to stderr or files.
 
 ### Quick Examples
 
@@ -2035,7 +2027,7 @@ transport = MCP::Server::Transports::StdioTransport.new(server)
 transport.open
 ```
 
-Your server is complete! The server will listen for MCP messages on stdin and respond on stdout.
+Your server is complete! Run `bundle exec ruby weather.rb` to start the MCP server, which will listen for messages from MCP hosts.
 
 Let's now test your server from an existing MCP host, Claude for Desktop.
 


### PR DESCRIPTION
## Motivation and Context

Add a Ruby tab to the "Build an MCP server" tutorial page, following the same weather server pattern as other language examples.

The Ruby tab includes:

- Environment setup using Bundler and the `mcp` gem
- Helper methods using `Net::HTTP` for NWS API calls
- Tool class definitions (`GetAlerts` and `GetForecast`) using `MCP::Tool`
- Server initialization with StdioTransport

The implementation uses the Ruby SDK and aligns with the structure of existing Python, TypeScript, Java, Kotlin, C#, and Rust SDKs.

https://github.com/modelcontextprotocol/ruby-sdk

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

