### PR TITLE
Clarifications on mcp-server-card `dynamic` flag

### DIFF
--- a/seps/2127-mcp-server-cards.md
+++ b/seps/2127-mcp-server-cards.md
@@ -290,12 +290,12 @@ With the help of the `.well-known` URI a client can discover what primitive capa
 
 1. Static Primitives
 
-    The server's available primitives, which would normally be listed in the MCP protocol lifecycle initialization phase (`*/list`), will be listed under the root document `$.tools`, `$.resources`, and `$.prompts` properties.
+   The server's available primitives, which would normally be listed in the MCP protocol lifecycle initialization phase (`*/list`), will be listed under the root document `$.tools`, `$.resources`, and `$.prompts` properties.
 
 2. Dynamic Primitives
 
-    To indicate that a list of primitives is dynamic in nature and can change at runtime, authors can set the `$.capabilities.tools.listChanged`, `$.capabilities.resources.listChanged`, or `$.capabilities.prompts.listChanged` boolean to `true`.
-    This indicates that the server will inform the client at runtime when some of its list of primitives has changed.
+   To indicate that a list of primitives is dynamic in nature and can change at runtime, authors can set the `$.capabilities.tools.listChanged`, `$.capabilities.resources.listChanged`, or `$.capabilities.prompts.listChanged` boolean to `true`.
+   This indicates that the server will inform the client at runtime when some of its list of primitives has changed.
 
 ### `server.json` Schema
 


### PR DESCRIPTION
Clarifications on mcp-server-card `dynamic` flag

Builds on https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127

The scope of this PR is strictly limited to provide clarifications for point `2.` from @tadasant  [comment](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127#issuecomment-3824934160)
```Whether to have dynamic as a value in tools/primitives```?

The answer to this question is probably `NO`.
A dynamic flag is not necessary to be introduced, if a MCP primitive is "dynamic" or not can be already expressed by using the `listChanged` flag from the MCP protocol itself.

This PR incorporates feedback from @Fannon [comment](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1649#issuecomment-3471320524)
And solves concerns about "dynamic" raised by:
- @tadasant [comment](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1649#issuecomment-3416551135)
- @connor4312 [comment](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1649#issuecomment-3416602009)
- @sdatspun2 [comment](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1649#issuecomment-3470669197)
- [Whether dynamic is an appropriate tools (and other primitives) field value](https://docs.google.com/document/d/13fVsxAeRWgHzG6XXcH_Ouh-0sMsk0t93AgUkOctap7g/edit?tab=t.0#heading=h.jcx25kx4jn97)