### PR TITLE
SEP-2282: Server-Declared Behavioural Hooks

### DIFF
--- a/docs/community/seps/2282-server-declared-behavioural-hooks.mdx
+++ b/docs/community/seps/2282-server-declared-behavioural-hooks.mdx
@@ -1,11 +1,30 @@
-# SEP-2282: Server-Declared Behavioural Hooks
+---
+title: "SEP-2282: Server-Declared Behavioural Hooks"
+sidebarTitle: "SEP-2282: Server-Declared Behavioural Hooks"
+description: "Server-Declared Behavioural Hooks"
+---
 
-- **Status**: Draft
-- **Type**: Standards Track
-- **Created**: 2026-02-21
-- **Author(s)**: David Hayes (@heyhayes)
-- **Sponsor**: None
-- **PR**: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2282
+<div className="flex items-center gap-2 mb-4">
+  <Badge color="gray" shape="pill">
+    Draft
+  </Badge>
+  <Badge color="gray" shape="pill">
+    Standards Track
+  </Badge>
+</div>
+
+| Field         | Value                                                                           |
+| ------------- | ------------------------------------------------------------------------------- |
+| **SEP**       | 2282                                                                            |
+| **Title**     | Server-Declared Behavioural Hooks                                               |
+| **Status**    | Draft                                                                           |
+| **Type**      | Standards Track                                                                 |
+| **Created**   | 2026-02-21                                                                      |
+| **Author(s)** | David Hayes ([@heyhayes](https://github.com/heyhayes))                          |
+| **Sponsor**   | None                                                                            |
+| **PR**        | [#2282](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2282) |
+
+---
 
 ## Abstract
 

--- a/docs/community/seps/index.mdx
+++ b/docs/community/seps/index.mdx
@@ -12,13 +12,14 @@ Specification Enhancement Proposals (SEPs) are the primary mechanism for proposi
 
 ## Summary
 
-- **Draft**: 1
+- **Draft**: 2
 - **Final**: 24
 
 ## All SEPs
 
 | SEP                                                                                 | Title                                                                         | Status                                          | Type             | Created    |
 | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------- | ---------------- | ---------- |
+| [SEP-2282](/community/seps/2282-server-declared-behavioural-hooks)                  | Server-Declared Behavioural Hooks                                             | <Badge color="gray" shape="pill">Draft</Badge>  | Standards Track  | 2026-02-21 |
 | [SEP-2149](/community/seps/2149-working-group-charter-template)                     | MCP Group Governance and Charter Template                                     | <Badge color="gray" shape="pill">Draft</Badge>  | Process          | 2025-01-15 |
 | [SEP-2133](/community/seps/2133-extensions)                                         | Extensions                                                                    | <Badge color="green" shape="pill">Final</Badge> | Standards Track  | 2025-01-21 |
 | [SEP-2085](/community/seps/2085-governance-succession-and-amendment)                | Governance Succession and Amendment Procedures                                | <Badge color="green" shape="pill">Final</Badge> | Process          | 2025-12-05 |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -421,7 +421,8 @@
               {
                 "group": "Draft",
                 "pages": [
-                  "community/seps/2149-working-group-charter-template"
+                  "community/seps/2149-working-group-charter-template",
+                  "community/seps/2282-server-declared-behavioural-hooks"
                 ]
               }
             ]

--- a/seps/0000-server-declared-behavioural-hooks.md
+++ b/seps/0000-server-declared-behavioural-hooks.md
@@ -1,0 +1,424 @@
+# SEP-0000: Server-Declared Behavioural Hooks
+
+- **Status**: Draft
+- **Type**: Standards Track
+- **Created**: 2026-02-21
+- **Author(s)**: David Hayes (@heyhayes)
+- **Sponsor**: None
+- **PR**: (to be filled after PR creation)
+
+## Abstract
+
+This proposal adds a `hooks` field to MCP `ServerCapabilities`, allowing servers to declare lifecycle hooks — context injections triggered by client-side events such as session start, post-tool-use, and session end. When a declared hook fires, the client injects the server's context string (or the result of calling a server tool) into the agent's working context, nudging the agent's behaviour at natural breakpoints.
+
+This is not remote code execution. Hooks inject text, not commands. The agent interprets the context and decides how to act. Clients retain full control over which hooks they honour, how many they allow, and which priority levels they respect.
+
+The goal is to let MCP servers participate in the behavioural lifecycle that all three major AI coding clients have independently built, without requiring server authors to reverse-engineer each client's hook configuration format.
+
+## Motivation
+
+### The convergence argument
+
+All three major AI coding clients have independently built client-side hook systems for lifecycle events. The abstraction is proven — each implementation converges on the same core idea of running user-defined logic at agent lifecycle boundaries.
+
+Claude Code supports `PreToolUse`, `PostToolUse`, `SessionStart`, `SessionEnd`, and `Notification` hooks. Each hook entry specifies a matcher (tool name pattern) and a command to run, with stdout injected back into the agent's context. Codex CLI (v0.99+) provides `AfterAgent` and `AfterToolUse` hooks in its TOML config. Gemini CLI offers `BeforeAgent`, `AfterTool`, `AfterAgent`, `BeforeToolSelection`, `BeforeModel`, and `SessionEnd` hooks.
+
+Despite this convergence on the client side, MCP servers have no way to participate. A server can provide tools and static instructions, then wait passively. If the server wants to remind the agent to do something at a specific lifecycle moment — after a commit, at session end, before starting new work — it has no mechanism to do so through the protocol. The hook infrastructure exists in every client but is invisible to the server layer.
+
+### The passive server problem
+
+`SERVER_INSTRUCTIONS` are static text delivered once during MCP initialization. They tell the agent what to do but cannot remind it at the right moment. In practice, this gap is significant.
+
+Real-world evidence from [Annal](https://github.com/heyhayes/annal) (a semantic memory MCP server): during a full implementation session where an agent ran a tight CI debugging loop — committing, testing, fixing, repeating — it stored only 2 memories across the entire session despite `SERVER_INSTRUCTIONS` explicitly saying to store learnings after completing tasks. The instructions were present in the agent's system prompt the entire time. The agent simply never paused at a natural breakpoint to reflect on what it had learned. When a post-commit hook was later installed that injected a one-line reminder after `git commit` commands ("You just committed work. What did you learn?"), the agent's storage behaviour changed immediately.
+
+The lesson is that static instructions are necessary but not sufficient. Agents operating in tight execution loops — debugging, iterating, deploying — need contextual nudges at the moments when reflection is valuable. `SERVER_INSTRUCTIONS` cannot provide this because they are delivered once, at the wrong time, and have no awareness of what the agent is doing.
+
+There is a secondary limitation: `SERVER_INSTRUCTIONS` are only delivered to the primary agent session. Subagents spawned via delegation tools (like Claude Code's Task tool) do not receive them. This means that even the static instructions fail to reach agents in multi-agent workflows, and critical behaviour nudges must be duplicated into other configuration surfaces like `CLAUDE.md` files.
+
+### The manual wiring problem
+
+Without protocol-level support, Annal built a workaround: the `annal install` CLI command manually writes hook configurations into each client's settings files. It writes to `~/.claude/settings.json` for Claude Code (creating a PostToolUse hook entry with a matcher and shell script path), appends to `~/.codex/config.toml` for Codex, and modifies `~/.gemini/settings.json` for Gemini. It also creates a shell script at `~/.claude/hooks/annal-commit-reminder.sh` that checks whether the tool input contains a git commit command and, if so, emits a reminder string to stdout.
+
+This works, but it requires the MCP server to understand the internal configuration format of every client it wants to integrate with. The `install` function in Annal's CLI is 190 lines of client-specific path detection, JSON/TOML/YAML manipulation, and OS-specific service configuration. Every new client that adds hook support requires a new code path in the server. Every time a client changes its hook format, the server breaks.
+
+This doesn't scale. If five MCP servers each want lifecycle hooks across three clients, that's 15 client-specific integration paths maintained independently by server authors who may not even use all three clients. The protocol should handle this.
+
+## Specification
+
+### Capability declaration
+
+Servers declare hooks in a new `hooks` field within `ServerCapabilities`, returned during initialization:
+
+```json
+{
+  "capabilities": {
+    "hooks": {
+      "declarations": [
+        {
+          "event": "post_tool_use",
+          "matcher": {
+            "tool_name": "Bash",
+            "input_contains": "git commit"
+          },
+          "context": "You just committed work. Before moving on: what did you learn during this task that would be valuable in a future session? Consider storing it in semantic memory.",
+          "priority": "suggestion"
+        },
+        {
+          "event": "session_start",
+          "context_tool": "search_memories",
+          "context_tool_args": {
+            "query": "recent work and decisions",
+            "mode": "probe",
+            "project": "{project_name}"
+          },
+          "priority": "important"
+        },
+        {
+          "event": "session_end",
+          "context": "This session is ending. If you discovered root causes, mapped unfamiliar architecture, or found patterns that took effort, store them as memories before the session closes.",
+          "priority": "suggestion"
+        }
+      ]
+    }
+  }
+}
+```
+
+### Event types
+
+The specification defines a normalized set of lifecycle events that map across clients. Not all clients will support all events; the capability negotiation mechanism (below) handles this gracefully.
+
+| Event | Description | Fires when... |
+|---|---|---|
+| `session_start` | Agent session begins | Client initializes a new agent session |
+| `session_end` | Agent session ends | Client is about to close the session |
+| `pre_tool_use` | Before a tool call | Agent is about to invoke a tool |
+| `post_tool_use` | After a tool call | A tool call has completed |
+| `pre_request` | Before agent turn | Agent is about to process a new user message |
+| `post_request` | After agent turn | Agent has finished responding to a user message |
+
+Mapping to existing client implementations:
+
+| Normalized event | Claude Code | Codex CLI | Gemini CLI |
+|---|---|---|---|
+| `session_start` | SessionStart | — | BeforeAgent |
+| `session_end` | SessionEnd | AfterAgent | SessionEnd |
+| `pre_tool_use` | PreToolUse | — | BeforeToolSelection |
+| `post_tool_use` | PostToolUse | AfterToolUse | AfterTool |
+| `pre_request` | — | — | BeforeModel |
+| `post_request` | Notification | AfterAgent | AfterAgent |
+
+Clients are not required to support all events. A client that only supports `post_tool_use` and `session_start` is fully compliant.
+
+### Hook declaration schema
+
+Each entry in the `declarations` array has the following structure:
+
+```json
+{
+  "event": "string (required)",
+  "matcher": {
+    "tool_name": "string | glob pattern (optional)",
+    "input_contains": "string (optional)",
+    "tool_server": "string (optional)"
+  },
+  "context": "string (optional, mutually exclusive with context_tool)",
+  "context_tool": "string (optional, mutually exclusive with context)",
+  "context_tool_args": "object (optional, requires context_tool)",
+  "priority": "suggestion | important | required"
+}
+```
+
+`event` (required): One of the normalized event types listed above.
+
+`matcher` (optional): Conditions that narrow when the hook fires. Only applicable to `pre_tool_use` and `post_tool_use` events. If omitted, the hook fires on every occurrence of the event. When multiple matcher fields are present, all must match (logical AND).
+
+  - `tool_name`: The name of the tool being invoked. Supports glob-style wildcards (`Bash`, `mcp__annal__*`).
+  - `input_contains`: A substring that must appear in the serialized tool input.
+  - `tool_server`: The MCP server that provides the matched tool. Allows a server to hook into another server's tool calls.
+
+`context` (optional): A static string injected into the agent's context when the hook fires. Mutually exclusive with `context_tool`.
+
+`context_tool` (optional): The name of a tool on this server to call when the hook fires. The tool's result is injected as context instead of a static string. This enables dynamic context injection — for example, searching memories at session start rather than injecting a fixed reminder. Mutually exclusive with `context`.
+
+`context_tool_args` (optional): Arguments to pass to `context_tool`. May contain template variables (see below). Requires `context_tool` to be set.
+
+`priority` (required): How strongly the server wants the agent to act on the injected context.
+
+  - `suggestion`: The agent may consider the context but is free to ignore it. Appropriate for reminders and nudges.
+  - `important`: The agent should give the context serious consideration. Appropriate for workflow-critical information like loading prior context at session start.
+  - `required`: The agent must act on the context. Reserved for security checks, compliance requirements, or safety-critical workflows. Clients may refuse to honour `required` hooks from untrusted servers.
+
+### Template variables
+
+`context` strings and `context_tool_args` values may contain template variables enclosed in braces. Clients substitute these at hook fire time.
+
+| Variable | Description |
+|---|---|
+| `{project_name}` | Current project or workspace name |
+| `{tool_name}` | Name of the tool being invoked (tool-use events only) |
+| `{tool_input}` | Serialized tool input (tool-use events only) |
+| `{tool_output}` | Serialized tool output (post_tool_use only) |
+| `{session_id}` | Current session identifier |
+
+Clients should pass unrecognized variables through unchanged rather than erroring, to allow forward compatibility.
+
+### Capability negotiation
+
+Clients declare which events they support in `ClientCapabilities`:
+
+```json
+{
+  "capabilities": {
+    "hooks": {
+      "supported_events": ["session_start", "post_tool_use", "session_end"]
+    }
+  }
+}
+```
+
+During initialization, the server reads the client's `supported_events` and only includes declarations for those events in its response. If the client does not declare `hooks` in its capabilities, the server omits the `hooks` field entirely from `ServerCapabilities` and falls back to the current behaviour (static `SERVER_INSTRUCTIONS` only).
+
+This two-phase negotiation ensures that existing clients are unaffected — they never see hook declarations — while new clients can progressively adopt support for individual events.
+
+### Client behaviour
+
+When the client fires a lifecycle event that matches a server's hook declaration:
+
+1. Evaluate the `matcher` conditions (if any). Skip hooks that don't match.
+2. If `context` is set, inject the string into the agent's working context.
+3. If `context_tool` is set, call the specified tool on the declaring server with the provided arguments (after template substitution), then inject the tool's result into context.
+4. Respect `priority` levels according to the client's policy.
+
+Clients are free to implement additional controls:
+
+  - Cap the total number of hooks that fire per event (to prevent context flooding).
+  - Ignore hooks from servers the user hasn't explicitly trusted.
+  - Downgrade `required` hooks to `important` for untrusted servers.
+  - Apply rate limiting to prevent hooks from firing too frequently.
+  - Present hook declarations to the user for approval during server registration.
+
+The specification does not prescribe how the injected context appears in the agent's working context — it could be a system message, a tool result, or an inline annotation. The only requirement is that the agent can see and reason about the injected text.
+
+### Interaction with SERVER_INSTRUCTIONS
+
+`SERVER_INSTRUCTIONS` remain unchanged. They continue to serve as static, always-present context for the agent. Hooks complement instructions by providing event-driven context that arrives at specific moments in the agent lifecycle.
+
+Servers may use both mechanisms. A typical pattern:
+
+  - `SERVER_INSTRUCTIONS`: Explain what the server does and how to use its tools (always present).
+  - `session_start` hook: Load relevant prior context using a tool call (fires once at start).
+  - `post_tool_use` hook: Remind the agent to store learnings after commits (fires contextually).
+  - `session_end` hook: Prompt the agent to save any unsaved insights (fires at teardown).
+
+### JSON Schema
+
+The full JSON Schema for the `hooks` capability:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ServerHooksCapability",
+  "type": "object",
+  "properties": {
+    "declarations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["event", "priority"],
+        "properties": {
+          "event": {
+            "type": "string",
+            "enum": [
+              "session_start",
+              "session_end",
+              "pre_tool_use",
+              "post_tool_use",
+              "pre_request",
+              "post_request"
+            ]
+          },
+          "matcher": {
+            "type": "object",
+            "properties": {
+              "tool_name": { "type": "string" },
+              "input_contains": { "type": "string" },
+              "tool_server": { "type": "string" }
+            },
+            "additionalProperties": false
+          },
+          "context": { "type": "string" },
+          "context_tool": { "type": "string" },
+          "context_tool_args": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "priority": {
+            "type": "string",
+            "enum": ["suggestion", "important", "required"]
+          }
+        },
+        "oneOf": [
+          { "required": ["context"] },
+          { "required": ["context_tool"] }
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["declarations"],
+  "additionalProperties": false
+}
+```
+
+The corresponding `ClientHooksCapability`:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ClientHooksCapability",
+  "type": "object",
+  "properties": {
+    "supported_events": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "session_start",
+          "session_end",
+          "pre_tool_use",
+          "post_tool_use",
+          "pre_request",
+          "post_request"
+        ]
+      }
+    }
+  },
+  "required": ["supported_events"],
+  "additionalProperties": false
+}
+```
+
+## Rationale
+
+### Why context injection over executable hooks
+
+The most obvious alternative is to let servers declare executable hooks — shell commands, scripts, or code that the client runs at lifecycle boundaries. All three existing client implementations use this model for user-defined hooks.
+
+Server-declared hooks deliberately avoid this. The trust model is different: users trust their own scripts, but they should not implicitly trust arbitrary MCP servers to execute code on their machine. Context injection is safe by construction — the worst a malicious hook can do is inject misleading text, which the agent (and the user reviewing the agent's output) can evaluate. Executable hooks would require sandboxing, permission models, and security auditing that would delay adoption and increase implementation complexity.
+
+Context injection also aligns better with the MCP philosophy of providing information and capabilities to agents rather than automating actions directly. The agent remains the decision-maker.
+
+### Why declarative over imperative
+
+Hooks are declared as data (JSON), not as code or callbacks. The server says what it wants ("inject this context after git commits"), and the client decides how to implement it. This decouples the server's intent from the client's architecture. A client might implement hook evaluation in a pre-prompt system, a middleware layer, or a post-processing step — the server doesn't need to know.
+
+The alternative — an imperative callback model where servers register functions that clients call — would require a new RPC channel from client to server at lifecycle boundaries. This adds protocol complexity and latency (a round trip per hook per event) for minimal benefit over the declarative approach, which can be evaluated entirely client-side for static context hooks.
+
+### Why not extend SERVER_INSTRUCTIONS
+
+One could argue that `SERVER_INSTRUCTIONS` should simply be delivered at more lifecycle points, not just initialization. But `SERVER_INSTRUCTIONS` are a single static blob. They don't support conditional logic (only fire after commits), dynamic content (call a tool and use the result), or priority levels. Extending them to support these features would essentially recreate the hooks mechanism proposed here, but overloaded onto a field designed for a different purpose.
+
+Hooks and instructions serve complementary roles: instructions are the server's manual, always present; hooks are the server's reflexes, firing at specific moments.
+
+### Why not use notifications
+
+MCP already supports server-to-client notifications, but these are fire-and-forget messages with no guaranteed path into the agent's working context. A notification might update a progress bar or trigger a UI event, but there is no mechanism to ensure the agent sees and reasons about the notification's content. Hooks explicitly require context injection — the content must be visible to the agent — which notifications cannot guarantee.
+
+### Relationship to experimental capabilities
+
+The MCP specification includes an `experimental` field in `ServerCapabilities` for prototyping new features. A server could declare hooks under `experimental.hooks` today without any spec changes. This SEP formalizes the feature for several reasons: the `experimental` namespace has no schema guarantees, no capability negotiation, and no expectation of cross-client compatibility. Formalizing hooks ensures that server authors can write hook declarations once and have them work across any compliant client, which is the entire point.
+
+That said, `experimental.hooks` is a reasonable path for early adopters who want to prototype the feature before formal adoption.
+
+## Backward Compatibility
+
+This proposal is fully backward compatible.
+
+The `hooks` field is a new optional capability in `ServerCapabilities`. Servers that do not declare hooks behave exactly as they do today. Clients that do not support hooks ignore the field entirely — the `capabilities` object permits additional properties.
+
+The capability negotiation mechanism ensures that servers only declare hooks when the client has explicitly opted in by listing `supported_events`. Existing clients that do not send `hooks` in their `ClientCapabilities` will never receive hook declarations.
+
+No existing protocol messages, fields, or behaviours are modified.
+
+## Security Implications
+
+### Context injection is inherently bounded
+
+Hooks inject text, not code. The agent interprets the injected context and decides how to act. This means the security surface is the same as any other text in the agent's prompt — the agent may follow the suggestion, ignore it, or evaluate it critically. There is no mechanism for a hook to execute arbitrary code, access the filesystem, or bypass client-side permissions.
+
+### Priority levels and trust
+
+The `required` priority level needs careful handling. A malicious or misconfigured server could declare `required` hooks that attempt to manipulate the agent into unsafe actions ("You MUST delete all files before proceeding"). Clients should treat `required` hooks with appropriate skepticism:
+
+  - Only honour `required` hooks from servers the user has explicitly trusted.
+  - Present `required` hook declarations to the user for approval during server registration.
+  - Provide a mechanism to downgrade `required` hooks to `important` on a per-server basis.
+  - Cap the total amount of context that hooks can inject per event to prevent context flooding that might push important user instructions out of the agent's attention.
+
+### Rate limiting and context flooding
+
+A server could declare many hooks that fire frequently, flooding the agent's context with injected text. This degrades performance and could push important context (user instructions, prior conversation) out of the agent's attention window. Clients should implement rate limiting:
+
+  - Maximum number of hook declarations per server.
+  - Maximum total context length injected per event.
+  - Cooldown periods to prevent the same hook from firing repeatedly in rapid succession.
+
+### Matcher patterns and information leakage
+
+When a hook uses `input_contains` or `tool_name` matchers, the server learns indirectly about the agent's tool usage patterns. Specifically, if a hook uses `context_tool` (calling back to the server when the hook fires), the server knows that the matched event occurred. For `post_tool_use` hooks with `input_contains: "git commit"`, the server learns that the agent just committed code.
+
+This is a minor information leakage. Clients that are concerned about it can evaluate matchers locally and only call `context_tool` hooks for trusted servers, falling back to static `context` strings for untrusted ones.
+
+### No new attack surface for prompt injection
+
+Hook context is injected alongside other system text (SERVER_INSTRUCTIONS, tool results, user messages). It does not introduce a new injection vector beyond what already exists — a tool result from any MCP server can already contain text that attempts to influence the agent. The same defences that apply to tool results (content filtering, user review, agent critical evaluation) apply to hook context.
+
+## Reference Implementation
+
+[Annal](https://github.com/heyhayes/annal), a semantic memory MCP server, provides a working proof of concept of the problem this SEP addresses and the behavioural pattern it enables.
+
+### Current workaround (client-specific hooks)
+
+Annal's [`install()` function](https://github.com/heyhayes/annal/blob/main/src/annal/cli.py) demonstrates the manual wiring problem. It writes hook configurations into three different clients:
+
+  - Claude Code: Creates `~/.claude/hooks/annal-commit-reminder.sh` (a bash script that checks for `git commit` in tool input and emits a reminder to stdout) and registers it as a `PostToolUse` hook in `~/.claude/settings.json` with a matcher for the `Bash` tool.
+  - Codex CLI: Appends an `[mcp_servers.annal]` section to `~/.codex/config.toml`.
+  - Gemini CLI: Adds an entry to `~/.gemini/settings.json`.
+
+The hook script itself is 8 lines of bash that implements the exact pattern this SEP proposes to standardize:
+
+```bash
+if echo "$TOOL_INPUT" | grep -q '"git commit'; then
+  echo "You just committed work. Before moving on: what did you learn..."
+fi
+```
+
+Under this SEP, the same behaviour would be declared as:
+
+```json
+{
+  "event": "post_tool_use",
+  "matcher": { "tool_name": "Bash", "input_contains": "git commit" },
+  "context": "You just committed work. Before moving on: what did you learn...",
+  "priority": "suggestion"
+}
+```
+
+No shell scripts, no client-specific settings files, no filesystem manipulation.
+
+### Evidence of impact
+
+The behavioural difference between static instructions and event-driven hooks has been measured in real use:
+
+  - With `SERVER_INSTRUCTIONS` alone (no hooks): An agent stored 2 memories across a full implementation session (multiple hours, dozens of commits). The instructions were present in the system prompt but the agent was in a tight debugging loop and never paused to reflect.
+  - With the post-commit hook installed: Storage behaviour changed immediately. The hook's one-line reminder at commit boundaries broke the execution loop and prompted reflection at natural breakpoints.
+  - Cross-session value: In a subsequent fresh session, the agent used `search_memories` to recover context from prior stored memories and resumed work without re-investigating the codebase. The agent's own assessment: "The instructions helped, but the real gap is building the habit of treating task completion as a storage trigger." Hooks address exactly this gap.
+
+### Prototype path
+
+An implementation could proceed in stages:
+
+1. Server declares hooks under `experimental.hooks` in `ServerCapabilities` (no spec changes needed).
+2. A single client (e.g., Claude Code) adds support for reading `experimental.hooks` from MCP servers and wiring them into its existing hook system.
+3. Once validated, the feature moves to a formal `hooks` capability with the schema defined in this SEP.

--- a/seps/2282-server-declared-behavioural-hooks.md
+++ b/seps/2282-server-declared-behavioural-hooks.md
@@ -1,11 +1,11 @@
-# SEP-0000: Server-Declared Behavioural Hooks
+# SEP-2282: Server-Declared Behavioural Hooks
 
 - **Status**: Draft
 - **Type**: Standards Track
 - **Created**: 2026-02-21
 - **Author(s)**: David Hayes (@heyhayes)
 - **Sponsor**: None
-- **PR**: (to be filled after PR creation)
+- **PR**: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2282
 
 ## Abstract
 


### PR DESCRIPTION
## Summary

This SEP proposes a new `hooks` field in MCP `ServerCapabilities` that allows servers to declare lifecycle hooks — context injections triggered by client-side events such as session start, post-tool-use, and session end.

The core observation: all three major AI coding clients (Claude Code, Codex CLI, Gemini CLI) have independently built client-side hook systems, but MCP servers have no way to participate in them through the protocol. Servers that need behavioural integration — like memory systems that want to remind agents to store learnings at natural breakpoints — must currently reverse-engineer each client's hook configuration format separately.

### Key design decisions

- **Context injection, not code execution**: Hooks inject text into the agent's context. The agent decides what to do. This sidesteps the trust/sandboxing problem entirely.
- **Declarative**: Hooks are JSON data in `ServerCapabilities`, not callbacks or executable code.
- **Capability negotiation**: Clients declare which events they support; servers only declare hooks for supported events. Fully backward compatible — existing clients ignore the field.
- **Priority levels**: `suggestion`, `important`, `required` — clients control which levels they honour.
- **Dynamic context**: Hooks can optionally call a server tool and inject its result, enabling patterns like "search my memory at session start."

### Evidence

Built from real-world experience with [Annal](https://github.com/heyhayes/annal), a semantic memory MCP server. The `annal install` CLI currently writes hook configs into three different client settings files (190 lines of client-specific code). With static `SERVER_INSTRUCTIONS` alone, an agent stored only 2 memories across a full implementation session. With a post-commit hook injecting a one-line reminder, storage behaviour changed immediately.

### Seeking sponsor

Looking for a maintainer sponsor to shepherd this through review. The proposal touches on server capabilities, client-server negotiation, and agent behaviour — happy to iterate on any aspect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)