### PR TITLE
Add PHP SDK Tier 3 assessment to SDK listing

### DIFF
--- a/docs/docs/sdk.mdx
+++ b/docs/docs/sdk.mdx
@@ -18,7 +18,7 @@ Build MCP servers and clients using our official SDKs. SDKs are classified into 
 | <Icon icon="swift" size={24} /> &nbsp; Swift          | [modelcontextprotocol/swift-sdk](https://github.com/modelcontextprotocol/swift-sdk)           |                                                                                TBD |
 | <Icon icon="rust" size={24} /> &nbsp; Rust            | [modelcontextprotocol/rust-sdk](https://github.com/modelcontextprotocol/rust-sdk)             |                                                                                TBD |
 | <Icon icon="gem" size={24} /> &nbsp; Ruby             | [modelcontextprotocol/ruby-sdk](https://github.com/modelcontextprotocol/ruby-sdk)             |                                                                                TBD |
-| <Icon icon="php" size={24} /> &nbsp; PHP              | [modelcontextprotocol/php-sdk](https://github.com/modelcontextprotocol/php-sdk)               |                                                                                TBD |
+| <Icon icon="php" size={24} /> &nbsp; PHP              | [modelcontextprotocol/php-sdk](https://github.com/modelcontextprotocol/php-sdk)               | [Tier 3](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2305) |
 
 _\*Official tier assignments will be published February 23, 2026. See [SDK Tiering System](/community/sdk-tiers) for details._
 


### PR DESCRIPTION
Handing in the first assessment for PHP as Tier 3, see #2305.
We didn't make it in time for Tier 2, but I don't think we're far off ... :running_man: 