### PR TITLE
Update ext-apps docs URLs to new subdomain

### DIFF
--- a/blog/content/posts/2026-01-26-mcp-apps.md
+++ b/blog/content/posts/2026-01-26-mcp-apps.md
@@ -25,7 +25,7 @@ Since then, the spec has been refined, the SDK has matured, and clients like Cha
 Goose and Visual Studio Code have shipped support for this capability, with more clients
 coming soon.
 
-{{< button text="Get Started with MCP Apps" url="https://modelcontextprotocol.github.io/ext-apps/api/documents/Quickstart.html" >}}
+{{< button text="Get Started with MCP Apps" url="https://apps.extensions.modelcontextprotocol.io/api/documents/Quickstart.html" >}}
 
 ## **What Are MCP Apps?**
 
@@ -223,7 +223,7 @@ Pick one close to what you're building and start from there!
 ### **Resources**
 
 - **Documentation**: [MCP Apps Guide](https://modelcontextprotocol.io/docs/extensions/apps)
-- **Quickstart**: [Getting Started with MCP Apps](https://modelcontextprotocol.github.io/ext-apps/api/documents/Quickstart.html)
+- **Quickstart**: [Getting Started with MCP Apps](https://apps.extensions.modelcontextprotocol.io/api/documents/Quickstart.html)
 - **SDK**: [`@modelcontextprotocol/ext-apps`](https://www.npmjs.com/package/@modelcontextprotocol/ext-apps)
 - **Examples**: [ext-apps repository](https://github.com/modelcontextprotocol/ext-apps)
 

--- a/docs/extensions/apps/build.mdx
+++ b/docs/extensions/apps/build.mdx
@@ -174,7 +174,7 @@ A typical MCP App project separates the server code from the UI code:
   </Tree.Folder>
 </Tree>
 
-The server registers the tool and serves the UI resource. The UI resource will eventually be rendered in a secure iframe with deny-by-default CSP configuration. If your app has CSS and JS assets, you will need to [configure CSP](https://modelcontextprotocol.github.io/ext-apps/api/documents/Patterns.html#configuring-csp-and-cors), or you can bundle your assets into the HTML with a tool like `vite-plugin-singlefile`, which is what we will do in this tutorial.
+The server registers the tool and serves the UI resource. The UI resource will eventually be rendered in a secure iframe with deny-by-default CSP configuration. If your app has CSS and JS assets, you will need to [configure CSP](https://apps.extensions.modelcontextprotocol.io/api/documents/Patterns.html#configuring-csp-and-cors), or you can bundle your assets into the HTML with a tool like `vite-plugin-singlefile`, which is what we will do in this tutorial.
 
 </Step>
 <Step title="Install dependencies">
@@ -184,7 +184,7 @@ npm install @modelcontextprotocol/ext-apps @modelcontextprotocol/sdk
 npm install -D typescript vite vite-plugin-singlefile express cors @types/express @types/cors tsx
 ```
 
-The `ext-apps` package provides helpers for both the server side (registering tools and resources) and the client side (the `App` class for UI-to-host communication). Vite with the `vite-plugin-singlefile` plugin is used here to bundle your UI and assets into a single HTML file for convenience, but this is optional — you can use any bundler or serve unbundled files if you [configure CSP](https://modelcontextprotocol.github.io/ext-apps/api/documents/Patterns.html#configuring-csp-and-cors).
+The `ext-apps` package provides helpers for both the server side (registering tools and resources) and the client side (the `App` class for UI-to-host communication). Vite with the `vite-plugin-singlefile` plugin is used here to bundle your UI and assets into a single HTML file for convenience, but this is optional — you can use any bundler or serve unbundled files if you [configure CSP](https://apps.extensions.modelcontextprotocol.io/api/documents/Patterns.html#configuring-csp-and-cors).
 
 </Step>
 <Step title="Configure the project">
@@ -427,7 +427,7 @@ The key parts:
 
 The `App` class provides additional methods for logging, opening URLs, and
 updating the model's context with structured data from your app. See the full
-[API documentation](https://modelcontextprotocol.github.io/ext-apps/api/).
+[API documentation](https://apps.extensions.modelcontextprotocol.io/api/).
 
 ## Testing your app
 
@@ -535,7 +535,7 @@ app and verify that tool calls work correctly.
   <Card
     title="API Documentation"
     icon="book"
-    href="https://modelcontextprotocol.github.io/ext-apps/api/"
+    href="https://apps.extensions.modelcontextprotocol.io/api/"
   >
     Full SDK reference and API details
   </Card>

--- a/docs/extensions/apps/overview.mdx
+++ b/docs/extensions/apps/overview.mdx
@@ -5,7 +5,7 @@ description: Interactive UI applications that render inside MCP hosts like Claud
 
 <Tip>
 
-For comprehensive API documentation, advanced patterns, and the full specification, visit the [official MCP Apps documentation](https://modelcontextprotocol.github.io/ext-apps).
+For comprehensive API documentation, advanced patterns, and the full specification, visit the [official MCP Apps documentation](https://apps.extensions.modelcontextprotocol.io).
 
 </Tip>
 
@@ -183,13 +183,13 @@ If you're building an MCP client and want to support MCP Apps, you have two opti
    [MCP-UI documentation](https://mcpui.dev/) for usage details.
 
 2. **Build on AppBridge**: The SDK includes an
-   [**App Bridge**](https://modelcontextprotocol.github.io/ext-apps/api/modules/app-bridge.html)
+   [**App Bridge**](https://apps.extensions.modelcontextprotocol.io/api/modules/app-bridge.html)
    module that handles rendering apps in sandboxed iframes, message passing, tool
    call proxying, and security policy enforcement. The
    [basic-host example](https://github.com/modelcontextprotocol/ext-apps/tree/main/examples/basic-host)
    shows how to integrate it.
 
-See the [API documentation](https://modelcontextprotocol.github.io/ext-apps/api/)
+See the [API documentation](https://apps.extensions.modelcontextprotocol.io/api/)
 for implementation details.
 
 ## Examples

--- a/docs/extensions/overview.mdx
+++ b/docs/extensions/overview.mdx
@@ -49,7 +49,7 @@ Official extensions live inside the [Model Context Protocol GitHub organization]
 | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | [MCP Apps](/extensions/apps/overview) | Allows MCP Servers to display interactive UI elements (charts, forms, video players) inline within conversations |
 
-To get started building MCP Apps, see the [quickstart guide](/extensions/apps/build#getting-started) or read the full [MCP Apps documentation](https://modelcontextprotocol.github.io/ext-apps/api/documents/Quickstart.html).
+To get started building MCP Apps, see the [quickstart guide](/extensions/apps/build#getting-started) or read the full [MCP Apps documentation](https://apps.extensions.modelcontextprotocol.io/api/documents/Quickstart.html).
 
 ## Experimental Extensions
 


### PR DESCRIPTION
The `modelcontextprotocol/ext-apps` project now has an official custom domain. Replace all `modelcontextprotocol.github.io/ext-apps` URLs with `apps.extensions.modelcontextprotocol.io` across docs and blog posts.
