### PR TITLE
fix(docs): use relative links for SDK tiers in sdk.mdx

### DIFF
--- a/docs/docs/sdk.mdx
+++ b/docs/docs/sdk.mdx
@@ -3,7 +3,7 @@ title: SDKs
 description: Official SDKs for building with Model Context Protocol
 ---
 
-Build MCP servers and clients using our official SDKs. SDKs are classified into tiers based on feature completeness, protocol support, and maintenance commitment. Learn more about [SDK tiers](/docs/community/sdk-tiers).
+Build MCP servers and clients using our official SDKs. SDKs are classified into tiers based on feature completeness, protocol support, and maintenance commitment. Learn more about [SDK tiers](../community/sdk-tiers).
 
 ## Available SDKs
 
@@ -20,7 +20,7 @@ Build MCP servers and clients using our official SDKs. SDKs are classified into 
 | <Icon icon="gem" size={24} /> &nbsp; Ruby             | [modelcontextprotocol/ruby-sdk](https://github.com/modelcontextprotocol/ruby-sdk)             |                                                                                TBD |
 | <Icon icon="php" size={24} /> &nbsp; PHP              | [modelcontextprotocol/php-sdk](https://github.com/modelcontextprotocol/php-sdk)               | [Tier 3](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2305) |
 
-_\*Official tier assignments will be published February 23, 2026. See [SDK Tiering System](/docs/community/sdk-tiers) for details._
+_\*Official tier assignments will be published February 23, 2026. See [SDK Tiering System](../community/sdk-tiers) for details._
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- The two links to the SDK Tiering System page in `docs/docs/sdk.mdx` use absolute paths (`/community/sdk-tiers`) which resolve to a 404 when viewed on GitHub, because the target file lives at `docs/community/sdk-tiers.mdx`, not `community/sdk-tiers`
- Changed both links to use relative paths (`../community/sdk-tiers`) so they resolve correctly on both GitHub and the Mintlify docs site