### PR TITLE
Update roadmap to reflect 2026 core maintainer priorities

### DIFF
--- a/docs/development/roadmap.mdx
+++ b/docs/development/roadmap.mdx
@@ -43,9 +43,9 @@ We will **not** be introducing additional official transports this cycle. Keepin
 The Tasks primitive ([SEP-1686](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1686)) gave agents a reliable call-now / fetch-later pattern. Running it in production has surfaced gaps in the lifecycle semantics that the **Agents WG** should close:
 
 - **Retry semantics**: what happens when a task fails transiently, and who decides whether to retry.
-- **Cancellation guarantees**: what state a task is left in when a client cancels, and whether servers must honor cancellation.
 - **Expiry policies**: how long results are retained after completion, and how clients learn a result has expired.
-- **Error reporting**: richer failure information from long-running operations than the current binary success/failure.
+
+These are the gaps we can point to today. The Agents WG should also collect and triage operational issues from production deployments—this list will grow as more of the ecosystem runs Tasks at scale.
 
 ### 3. Governance Maturation
 
@@ -59,7 +59,7 @@ The **Governance WG** should deliver:
 
 ### 4. Enterprise Readiness
 
-Enterprises are deploying MCP at scale and hitting gaps the protocol does not yet address. 
+Enterprises are deploying MCP at scale and hitting gaps the protocol does not yet address.
 
 Areas where we need clear problem statements and directional proposals:
 


### PR DESCRIPTION
## Summary

Replaces the release-oriented roadmap with a strategic, WG-oriented document reflecting the consensus of core maintainer priority votes collected in a MCP Roadmap: Priorities doc..

## Methodology

Six core maintainers provided ranked priority lists. Aggregated with a Borda count:

| Area                 | Score | Voters | Notes                               |
| -------------------- | ----- | ------ | ----------------------------------- |
| Transport            | 26    | 6/6    | Unanimous; ranked #1 by four people |
| Agent Communication  | 14–17 | 4–5/6  | Consistently #2–3                   |
| Governance           | 14    | 5/6    | Bimodal: 2× #1, 3× bottom           |
| Triggers             | 7     | 3/6    | Mid-tier when present               |
| Enterprise           | 8     | 5/6    | Broadly mentioned but always low    |
| Security             | 7     | 2/6    | Concentrated (Kurtis, Den)          |
| Extensions           | 6     | 3/6    | Mostly bottom ranks                 |

## Structure

- **Priority Areas (1–4):** Transport, Agent Communication, Governance, Triggers — each with *what we want to achieve* and *WG focus*. These are areas where we actively drive WG formation.
- **On the Horizon:** Security, Enterprise, Extensions — real interest, active SEPs, but we support community-driven WGs rather than standing them up ourselves this cycle.
- **SEP Prioritization guidance:** aligned SEPs get expedited review; out-of-band SEPs face a higher bar.

## Review ask

Please check that your priority area is accurately distilled from the draft doc — particularly the *what we will not be doing* list under Transport and the Agent Communication scope (partial results + streaming folded in).