### PR TITLE
SEP-2127: Remove primitives from server cards

### DIFF
--- a/seps/2127-mcp-server-cards.md
+++ b/seps/2127-mcp-server-cards.md
@@ -33,7 +33,7 @@ This SEP introduces **MCP Server Cards** – structured metadata documents that 
 
 ### Design Philosophy
 
-The discovery mechanism complements rather than replaces initialization. Discovery answers where to connect and what capabilities are available, while initialization handles the communication handshake and reveals the full server surface including primitives (tools, resources, and prompts).
+The discovery mechanism complements rather than replaces initialization. Discovery answers where to connect and what capabilities are available, while initialization handles the communication handshake.
 
 ### Discovery
 
@@ -416,7 +416,7 @@ Server cards are publicly accessible by design. Servers MUST NOT include sensiti
 
 ### Primitive Information
 
-Server cards intentionally exclude primitive definitions (tools, resources, prompts). This avoids a class of security concerns where clients might trust a static manifest's tool descriptions for access-control or safety decisions, when the actual primitives at runtime may differ due to auth scoping, feature flags, configuration, or other dynamic factors. Primitives MUST always be discovered and validated through the protocol's standard list operations after connection establishment.
+Server cards intentionally exclude primitive definitions (tools, resources, prompts). This avoids a class of security concerns where clients might trust a static manifest's tool descriptions for access-control or safety decisions, when the actual primitives at runtime may differ due to auth scoping, feature flags, configuration, or other dynamic factors. Primitives SHOULD always be discovered and validated through the protocol's standard list operations after connection establishment.
 
 ### CORS Requirements
 


### PR DESCRIPTION
## Summary

This PR removes primitive definitions (tools, resources, prompts) from the MCP Server Cards SEP, making server cards focused on identity, transport, capability, and authentication discovery.

## Why remove primitives?

MCP servers are inherently dynamic. The primitives a server exposes can vary by authenticated user, session, configuration, feature flags, deployment state, and more. A static document cannot reliably represent this surface.

Key concerns with including primitives in a pre-connection document:

- **No substitute for runtime listing.** Only `tools/list`, `resources/list`, and `prompts/list` with the logged-in user's identity produce correct results. A static manifest cannot know the user's OAuth scopes, subscription tier, feature-flag cohort, or which deployment version they will reach.
- **Deployment is not atomic.** During rolling deploys, the server card and live fleet can disagree. Even nominally static servers have a window where the card is wrong.
- **Cache without invalidation.** A server card with primitives is effectively a cache of the runtime surface, but the protocol provides no invalidation signal. Cache coherence problems are notoriously hard, and introducing a cache without an invalidation strategy is a well-known source of distributed-systems bugs.
- **Disadvantages dynamic servers.** If server cards normalise primitive listings, clients and gateways will prefer servers that provide a complete static listing, structurally penalising servers that are dynamic for legitimate reasons (auth-scoped filtering, feature flags, paid tiers, configuration-based surfaces).
- **A [survey of dynamic server behaviors](https://gist.github.com/SamMorrowDrums/e73a6ab4336b6dc8dc6aff904bce4059)** catalogs at least ten dimensions of dynamism that make static primitive advertisement unreliable.

Until proposals like [Server Variants (SEP-2053)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2053) provide a mechanism for clients to understand which primitive surface applies to their context, server cards should be conservative.

## Discovery should not wait

The primitives debate should not delay server card adoption. Discovery (where to connect, what transports are available, what auth is required) is enormously valuable on its own. It is the information an end user or IDE needs to install a server, and the information a registry needs to index one. None of this depends on knowing the tool list in advance.

## What changed (13 insertions, 96 deletions)

- Removed `resources`, `tools`, `prompts` fields from schema and examples
- Removed "Dynamic Primitives" section and field descriptions 11-13
- Replaced "Why Support Both Static and Dynamic Primitives?" with concise "Why Exclude Primitives?" rationale
- Added "Why Not Wait for Primitives?" rationale section
- Updated Security section: "Primitive Information" replaces "Tool Description Security"
- Minor wording in Abstract, Design Philosophy, and Enabled Use Cases

Everything else is preserved: identity, transport, capabilities, auth, `server.json` alignment, `.well-known` endpoints, CORS, caching, IETF registration.