### PR TITLE
Add Ruby SDK Tier 3 assessment to SDK listing

### DIFF
--- a/docs/docs/sdk.mdx
+++ b/docs/docs/sdk.mdx
@@ -17,7 +17,7 @@ Build MCP servers and clients using our official SDKs. SDKs are classified into 
 | <Icon icon="square-k" size={24} /> &nbsp; Kotlin      | [modelcontextprotocol/kotlin-sdk](https://github.com/modelcontextprotocol/kotlin-sdk)         |                                                                                TBD |
 | <Icon icon="swift" size={24} /> &nbsp; Swift          | [modelcontextprotocol/swift-sdk](https://github.com/modelcontextprotocol/swift-sdk)           | [Tier 3](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2309) |
 | <Icon icon="rust" size={24} /> &nbsp; Rust            | [modelcontextprotocol/rust-sdk](https://github.com/modelcontextprotocol/rust-sdk)             |                                                                                TBD |
-| <Icon icon="gem" size={24} /> &nbsp; Ruby             | [modelcontextprotocol/ruby-sdk](https://github.com/modelcontextprotocol/ruby-sdk)             |                                                                                TBD |
+| <Icon icon="gem" size={24} /> &nbsp; Ruby             | [modelcontextprotocol/ruby-sdk](https://github.com/modelcontextprotocol/ruby-sdk)             | [Tier 3](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2340) |
 | <Icon icon="php" size={24} /> &nbsp; PHP              | [modelcontextprotocol/php-sdk](https://github.com/modelcontextprotocol/php-sdk)               | [Tier 3](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2305) |
 
 _\*Official tier assignments will be published February 23, 2026. See [SDK Tiering System](/community/sdk-tiers) for details._


### PR DESCRIPTION
This refers to assessment report #2340.
The Ruby SDK is currently at tier 3 in the assessment and development toward tier 2 is ongoing.
cc @modelcontextprotocol/ruby-sdk 