### PR TITLE
SEP-2343: Clarify that elicitation requires authorization for remote servers

### DIFF
--- a/docs/specification/draft/client/elicitation.mdx
+++ b/docs/specification/draft/client/elicitation.mdx
@@ -576,6 +576,12 @@ Servers implementing elicitation **MUST** securely associate this state with ind
 - State storage **MUST** be protected against unauthorized access
 - For remote MCP servers, user identification **MUST** be derived from credentials acquired via [MCP authorization](../basic/authorization) when possible (e.g. `sub` claim)
 
+<Warning>
+
+These requirements mean that remote MCP servers implementing elicitation **SHOULD** implement [MCP authorization](../basic/authorization). Without authorization, there is no reliable mechanism to bind elicitation state to individual users, making the above requirements unsatisfiable.
+
+</Warning>
+
 <Note>
   The examples in this section are non-normative and illustrate potential uses
   of elicitation. Implementers should adapt these patterns to their specific
@@ -696,7 +702,7 @@ Clients **MUST** return standard JSON-RPC errors for common failure cases:
 
 ## Security Considerations
 
-1. Servers **MUST** bind elicitation requests to the client and user identity
+1. Servers **MUST** bind elicitation requests to the client and user identity. For remote servers, this binding requires [MCP authorization](../basic/authorization) to establish user identity (see [Statefulness](#statefulness)).
 1. Clients **MUST** provide clear indication of which server is requesting information
 1. Clients **SHOULD** implement user approval controls
 1. Clients **SHOULD** allow users to decline elicitation requests at any time


### PR DESCRIPTION
## Summary

The elicitation spec requires servers to bind state to user identity (`MUST bind elicitation requests to the client and user identity`) and prohibits association with session IDs alone (`State MUST NOT be associated with session IDs alone`). However, MCP authorization is optional — making these requirements unsatisfiable for remote servers that don't implement auth.

This PR makes the dependency explicit:

1. Adds a **Warning** in the Statefulness section stating that remote servers implementing elicitation SHOULD implement MCP authorization
2. Adds a cross-reference in Security Considerations clarifying that identity binding requires authorization for remote servers

### Context

This gap was surfaced during review of an H1 bug bounty report demonstrating phantom task injection via leaked session IDs. While the PoC relied on a non-compliant server (violating multiple existing MUSTs), the reviewers noted that the spec could be clearer about elicitation's implicit dependency on authorization.

Note: the Tasks spec already handles this well by explicitly acknowledging the no-auth case and providing a fallback (crypto-random IDs + short TTL). This PR brings elicitation's clarity in line with that approach.