### PR TITLE
SEP-2351: Explicitly specify RFC 8414 well-known URI suffix for MCP

### DIFF
--- a/docs/specification/draft/basic/authorization.mdx
+++ b/docs/specification/draft/basic/authorization.mdx
@@ -130,20 +130,42 @@ If the `scope` parameter is absent, clients **SHOULD** apply the fallback behavi
 
 ### Authorization Server Metadata Discovery
 
-To handle different issuer URL formats and ensure interoperability with both OAuth 2.0 Authorization Server Metadata and OpenID Connect Discovery 1.0 specifications, MCP clients **MUST** attempt multiple well-known endpoints when discovering authorization server metadata.
+MCP uses the default `oauth-authorization-server` well-known URI
+suffix defined in
+[RFC 8414 Section 3.1](https://datatracker.ietf.org/doc/html/rfc8414#section-3.1)
+for authorization server metadata discovery. MCP does not define
+an application-specific well-known URI suffix.
 
-The discovery approach is based on [RFC8414 Section 3.1 "Authorization Server Metadata Request"](https://datatracker.ietf.org/doc/html/rfc8414#section-3.1) for OAuth 2.0 Authorization Server Metadata discovery and [RFC8414 Section 5 "Compatibility Notes"](https://datatracker.ietf.org/doc/html/rfc8414#section-5) for OpenID Connect Discovery 1.0 interoperability.
+To handle different issuer URL formats and ensure
+interoperability with both OAuth 2.0 Authorization Server
+Metadata and OpenID Connect Discovery 1.0 specifications, MCP
+clients **MUST** attempt multiple well-known endpoints when
+discovering authorization server metadata.
 
-For issuer URLs with path components (e.g., `https://auth.example.com/tenant1`), clients **MUST** try endpoints in the following priority order:
+The discovery approach is based on
+[RFC 8414 Section 3.1 "Authorization Server Metadata Request"](https://datatracker.ietf.org/doc/html/rfc8414#section-3.1)
+for OAuth 2.0 Authorization Server Metadata discovery and
+[RFC 8414 Section 5 "Compatibility Notes"](https://datatracker.ietf.org/doc/html/rfc8414#section-5)
+for OpenID Connect Discovery 1.0 interoperability.
 
-1. OAuth 2.0 Authorization Server Metadata with path insertion: `https://auth.example.com/.well-known/oauth-authorization-server/tenant1`
-2. OpenID Connect Discovery 1.0 with path insertion: `https://auth.example.com/.well-known/openid-configuration/tenant1`
-3. OpenID Connect Discovery 1.0 path appending: `https://auth.example.com/tenant1/.well-known/openid-configuration`
+For issuer URLs with path components
+(e.g., `https://auth.example.com/tenant1`), clients **MUST**
+try endpoints in the following priority order:
 
-For issuer URLs without path components (e.g., `https://auth.example.com`), clients **MUST** try:
+1. OAuth 2.0 Authorization Server Metadata with path insertion:
+   `https://auth.example.com/.well-known/oauth-authorization-server/tenant1`
+2. OpenID Connect Discovery 1.0 with path insertion:
+   `https://auth.example.com/.well-known/openid-configuration/tenant1`
+3. OpenID Connect Discovery 1.0 path appending:
+   `https://auth.example.com/tenant1/.well-known/openid-configuration`
 
-1. OAuth 2.0 Authorization Server Metadata: `https://auth.example.com/.well-known/oauth-authorization-server`
-2. OpenID Connect Discovery 1.0: `https://auth.example.com/.well-known/openid-configuration`
+For issuer URLs without path components
+(e.g., `https://auth.example.com`), clients **MUST** try:
+
+1. OAuth 2.0 Authorization Server Metadata:
+   `https://auth.example.com/.well-known/oauth-authorization-server`
+2. OpenID Connect Discovery 1.0:
+   `https://auth.example.com/.well-known/openid-configuration`
 
 ### Authorization Server Discovery Sequence Diagram
 


### PR DESCRIPTION
## Summary

- Explicitly state that MCP uses the default `oauth-authorization-server` well-known URI suffix defined in RFC 8414 Section 3.1, satisfying the RFC's requirement that applications specify their well-known URI suffix
- Clarify that MCP does not define an application-specific well-known URI suffix

Fixes #1650

## Test plan
- [x] Verify the draft spec renders correctly with `npm run serve:docs`
- [x] Confirm no new broken links introduced by changes


🤖 Generated with [Claude Code](https://claude.com/claude-code)