### PR TITLE
(docs): Add ecosystem support section to MCP intro page

### DIFF
--- a/docs/docs/getting-started/intro.mdx
+++ b/docs/docs/getting-started/intro.mdx
@@ -39,9 +39,9 @@ MCP is an open protocol supported across a wide range of clients and servers. AI
     Create MCP servers to expose your data and tools
   </Card>
 
-  <Card title="Build clients" icon="computer" href="/docs/develop/build-client">
-    Develop applications that connect to MCP servers
-  </Card>
+<Card title="Build clients" icon="computer" href="/docs/develop/build-client">
+  Develop applications that connect to MCP servers
+</Card>
 
   <Card title="Build MCP Apps" icon="puzzle-piece" href="/extensions/apps/overview">
     Build interactive apps that run inside AI clients


### PR DESCRIPTION
Adds a new **Broad ecosystem support** section to the MCP introduction page, highlighting that MCP is supported across a variety of clients and servers — including Claude, ChatGPT, Visual Studio Code, Cursor, MCPJam, and more — with links to their respective documentation pages and the full clients list.