### PR TITLE
(chore): Fix typo in CODEOWNERS team name for docs-maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CODEOWNERS file for MCP Specification repository
 
-# General documentation ownership - @modelcontextprotocol/docs-maintaners and core-maintainers own all of /docs
-/docs/ @modelcontextprotocol/docs-maintaners @modelcontextprotocol/core-maintainers
+# General documentation ownership - @modelcontextprotocol/docs-maintainers and core-maintainers own all of /docs
+/docs/ @modelcontextprotocol/docs-maintainers @modelcontextprotocol/core-maintainers
 
 # Specific ownership - @core-maintainer team owns docs/specification and schema/ directories
 /docs/specification/ @modelcontextprotocol/core-maintainers


### PR DESCRIPTION
The `docs-maintaners` team name in CODEOWNERS was missing an 'i' — corrected to `docs-maintainers` so GitHub properly assigns review requests to the team.