### PR TITLE
docs: reorder SDK table by tier

### DIFF
--- a/docs/docs/sdk.mdx
+++ b/docs/docs/sdk.mdx
@@ -7,20 +7,18 @@ Build MCP servers and clients using our official SDKs. SDKs are classified into 
 
 ## Available SDKs
 
-| SDK                                                   | Repository                                                                                    |                                                                             Tier\* |
+| SDK                                                   | Repository                                                                                    |                                                                               Tier |
 | :---------------------------------------------------- | :-------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------: |
 | <Icon icon="square-js" size={24} /> &nbsp; TypeScript | [modelcontextprotocol/typescript-sdk](https://github.com/modelcontextprotocol/typescript-sdk) | [Tier 1](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2271) |
 | <Icon icon="python" size={24} /> &nbsp; Python        | [modelcontextprotocol/python-sdk](https://github.com/modelcontextprotocol/python-sdk)         | [Tier 1](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2304) |
-| <Icon icon="java" size={24} /> &nbsp; Java            | [modelcontextprotocol/java-sdk](https://github.com/modelcontextprotocol/java-sdk)             | [Tier 2](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2301) |
 | <Icon icon="square-c" size={24} /> &nbsp; C#          | [modelcontextprotocol/csharp-sdk](https://github.com/modelcontextprotocol/csharp-sdk)         | [Tier 1](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2261) |
 | <Icon icon="golang" size={24} /> &nbsp; Go            | [modelcontextprotocol/go-sdk](https://github.com/modelcontextprotocol/go-sdk)                 | [Tier 1](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2279) |
-| <Icon icon="square-k" size={24} /> &nbsp; Kotlin      | [modelcontextprotocol/kotlin-sdk](https://github.com/modelcontextprotocol/kotlin-sdk)         |                                                                                TBD |
-| <Icon icon="swift" size={24} /> &nbsp; Swift          | [modelcontextprotocol/swift-sdk](https://github.com/modelcontextprotocol/swift-sdk)           | [Tier 3](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2309) |
+| <Icon icon="java" size={24} /> &nbsp; Java            | [modelcontextprotocol/java-sdk](https://github.com/modelcontextprotocol/java-sdk)             | [Tier 2](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2301) |
 | <Icon icon="rust" size={24} /> &nbsp; Rust            | [modelcontextprotocol/rust-sdk](https://github.com/modelcontextprotocol/rust-sdk)             | [Tier 2](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2346) |
+| <Icon icon="swift" size={24} /> &nbsp; Swift          | [modelcontextprotocol/swift-sdk](https://github.com/modelcontextprotocol/swift-sdk)           | [Tier 3](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2309) |
 | <Icon icon="gem" size={24} /> &nbsp; Ruby             | [modelcontextprotocol/ruby-sdk](https://github.com/modelcontextprotocol/ruby-sdk)             | [Tier 3](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2340) |
 | <Icon icon="php" size={24} /> &nbsp; PHP              | [modelcontextprotocol/php-sdk](https://github.com/modelcontextprotocol/php-sdk)               | [Tier 3](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2305) |
-
-_\*Official tier assignments will be published February 23, 2026. See [SDK Tiering System](/community/sdk-tiers) for details._
+| <Icon icon="square-k" size={24} /> &nbsp; Kotlin      | [modelcontextprotocol/kotlin-sdk](https://github.com/modelcontextprotocol/kotlin-sdk)         |                                                                                TBD |
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- Reorder the SDK table on `/docs/sdk` so SDKs are grouped by tier (Tier 1 → Tier 2 → Tier 3 → TBD)
- Remove the `*` from the Tier column header and the accompanying footnote about the Feb 23 publication date, since official assignments are now published

<img width="799" height="803" alt="CleanShot 2026-03-09 at 12 16 47" src="https://github.com/user-attachments/assets/e860b1b6-49fa-489b-9ae7-cb425bddd876" />

## Test Plan
- Preview the page and verify table renders with Tier 1 SDKs (TypeScript, Python, C#, Go) on top, followed by Tier 2 (Java, Rust), Tier 3 (Swift, Ruby, PHP), and Kotlin (TBD) last