### PR TITLE
ci(blog): use shared cloudflare-pages-preview action

### DIFF
--- a/.github/workflows/blog-preview.yml
+++ b/.github/workflows/blog-preview.yml
@@ -14,10 +14,6 @@ concurrency:
   group: blog-preview-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-env:
-  # Cloudflare Pages project name — must be created in the Cloudflare dashboard first
-  CF_PAGES_PROJECT: mcp-blog-preview
-
 jobs:
   build-and-deploy:
     # Explicitly refuse to run for fork PRs. Blog content is authored by maintainers
@@ -59,139 +55,25 @@ jobs:
             --buildFuture \
             --baseURL "/"
 
-      # Prevent preview deployments from being indexed by search engines.
-      # Cloudflare Pages serves _headers as HTTP headers for matching paths.
-      # X-Robots-Tag covers all content types (HTML, RSS, sitemaps, etc.)
-      - name: Add noindex headers
-        run: |
-          cat > blog/public/_headers <<'EOF'
-          /*
-            X-Robots-Tag: noindex, nofollow, noarchive, nosnippet
-          EOF
-
-      # Also inject a <meta> tag into every HTML page as belt-and-suspenders
-      # in case the site is later served from somewhere that ignores _headers.
-      - name: Inject noindex meta tag
-        run: |
-          find blog/public -name '*.html' -print0 | \
-            xargs -0 sed -i 's|<head>|<head><meta name="robots" content="noindex, nofollow, noarchive, nosnippet">|'
-
-      # Each PR gets its own preview URL via Cloudflare Pages branch aliases.
-      # Using `pr-<number>` as the branch name gives stable, predictable URLs
-      # across force-pushes and keeps concurrent PR previews isolated.
-      #
-      # Secrets are intentionally scoped to *this workflow only*:
-      #   CF_BLOG_PREVIEW_API_TOKEN  — Cloudflare API token with Pages:Edit on the
-      #                                 mcp-blog-preview project and nothing else
-      #   CF_BLOG_PREVIEW_ACCOUNT_ID — Cloudflare account ID (not secret, but kept
-      #                                 as a secret to co-locate with the token)
-      # Do NOT reuse a general-purpose Cloudflare token here.
-      - name: Deploy to Cloudflare Pages
-        id: deploy
-        uses: cloudflare/wrangler-action@v3
+      - name: Deploy preview
+        uses: modelcontextprotocol/actions/cloudflare-pages-preview/deploy@main
         with:
-          apiToken: ${{ secrets.CF_BLOG_PREVIEW_API_TOKEN }}
-          accountId: ${{ secrets.CF_BLOG_PREVIEW_ACCOUNT_ID }}
-          command: pages deploy blog/public --project-name=${{ env.CF_PAGES_PROJECT }} --branch=pr-${{ github.event.pull_request.number }}
+          directory: blog/public
+          project-name: mcp-blog-preview
+          api-token: ${{ secrets.CF_BLOG_PREVIEW_API_TOKEN }}
+          account-id: ${{ secrets.CF_BLOG_PREVIEW_ACCOUNT_ID }}
+          comment-title: "📰 Blog Preview Deployed"
+          comment-marker: "<!-- blog-preview-comment -->"
 
-      - name: Comment with preview URL
-        uses: actions/github-script@v8
-        env:
-          DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
-          ALIAS_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const prNumber = context.payload.pull_request.number;
-            const deployUrl = process.env.DEPLOY_URL;
-            const aliasUrl = process.env.ALIAS_URL || deployUrl;
-
-            const marker = '<!-- blog-preview-comment -->';
-            const body = `${marker}
-            ## 📰 Blog Preview Deployed
-
-            | | |
-            |---|---|
-            | **Preview (stable)** | ${aliasUrl} |
-            | **This commit** | ${deployUrl} |
-            | **Commit** | \`${context.sha.slice(0, 7)}\` |
-
-            _Includes drafts and future-dated posts. All pages served with \`noindex, nofollow\` — search engines will not crawl this preview._`;
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner, repo, issue_number: prNumber
-            });
-            const existing = comments.find(c =>
-              c.user.type === 'Bot' && c.body.includes(marker)
-            );
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner, repo, comment_id: existing.id, body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner, repo, issue_number: prNumber, body
-              });
-            }
-
-  # When a PR closes (merged or abandoned), delete all Cloudflare Pages
-  # deployments for its branch alias so stale previews don't stay publicly
-  # accessible forever.
   cleanup:
     if: >-
       github.event.action == 'closed' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - name: Delete preview deployments
-        env:
-          CF_API_TOKEN: ${{ secrets.CF_BLOG_PREVIEW_API_TOKEN }}
-          CF_ACCOUNT_ID: ${{ secrets.CF_BLOG_PREVIEW_ACCOUNT_ID }}
-          CF_PROJECT: ${{ env.CF_PAGES_PROJECT }}
-          PR_BRANCH: pr-${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          api="https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/pages/projects/${CF_PROJECT}/deployments"
-
-          echo "Listing deployments for branch alias: ${PR_BRANCH}"
-          # Cloudflare paginates at 25/page. One PR rarely has >25 deploys, but
-          # loop until the branch alias returns empty just in case of a long-
-          # running PR with many pushes.
-          while :; do
-            ids=$(curl -sS -H "Authorization: Bearer ${CF_API_TOKEN}" "${api}?per_page=25" \
-              | jq -r --arg b "$PR_BRANCH" '.result[] | select(.deployment_trigger.metadata.branch == $b) | .id')
-
-            if [ -z "$ids" ]; then
-              echo "No deployments remaining for ${PR_BRANCH}."
-              break
-            fi
-
-            for id in $ids; do
-              echo "Deleting deployment ${id}"
-              curl -sS -X DELETE -H "Authorization: Bearer ${CF_API_TOKEN}" "${api}/${id}?force=true" \
-                | jq -r '"  → success=\(.success) errors=\(.errors // [])"'
-            done
-          done
-
-      - name: Update PR comment
-        uses: actions/github-script@v8
+      - uses: modelcontextprotocol/actions/cloudflare-pages-preview/cleanup@main
         with:
-          script: |
-            const { owner, repo } = context.repo;
-            const prNumber = context.payload.pull_request.number;
-            const marker = '<!-- blog-preview-comment -->';
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner, repo, issue_number: prNumber
-            });
-            const existing = comments.find(c =>
-              c.user.type === 'Bot' && c.body.includes(marker)
-            );
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner, repo, comment_id: existing.id,
-                body: `${marker}\n## 📰 Blog Preview\n\n_Preview deployments for this PR have been cleaned up._`
-              });
-            }
+          project-name: mcp-blog-preview
+          api-token: ${{ secrets.CF_BLOG_PREVIEW_API_TOKEN }}
+          account-id: ${{ secrets.CF_BLOG_PREVIEW_ACCOUNT_ID }}
+          comment-marker: "<!-- blog-preview-comment -->"


### PR DESCRIPTION
Replaces the inline Cloudflare Pages preview logic with the shared composite actions now in [`modelcontextprotocol/actions`](https://github.com/modelcontextprotocol/actions/tree/main/cloudflare-pages-preview).

## What moved

| Was | Now |
|---|---|
| Inline noindex `_headers` + `<meta>` sed | `cloudflare-pages-preview/deploy` |
| Inline `cloudflare/wrangler-action` call | `cloudflare-pages-preview/deploy` |
| Inline `github-script` sticky PR comment | `cloudflare-pages-preview/deploy` |
| Inline CF API deletion loop | `cloudflare-pages-preview/cleanup` |
| Inline `github-script` comment update | `cloudflare-pages-preview/cleanup` |

## What stayed

- Trigger, permissions, concurrency, fork-PR guard — all unchanged
- Checkout + Go + Hugo install + build — unchanged
- Same comment marker (`<!-- blog-preview-comment -->`) and title, so open PRs with existing preview comments will keep updating in place

## Diff stats

198 → 79 lines (-131)

## Verification

- [ ] Open a PR touching `blog/` → CF Pages deploys to `pr-<N>` alias, sticky comment posted
- [ ] `curl -I <preview>` shows `X-Robots-Tag: noindex, ...`
- [ ] Page source has `<meta name="robots" ...>` in `<head>`
- [ ] Force-push → comment updates (no duplicate)
- [ ] Close PR → deployments deleted, comment shows "cleaned up"