### PR TITLE
Add /lgtm and /hold slash-commands workflow

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -1,0 +1,47 @@
+name: Slash Commands
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  # Parse and execute /lgtm, /hold, /unhold comment commands; invalidate
+  # approval when new commits are pushed.
+  handle:
+    if: >-
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request) ||
+      (github.event_name == 'pull_request_target' && github.event.action == 'synchronize')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: modelcontextprotocol/actions/slash-commands@slash-commands
+        with:
+          github-token: ${{ secrets.SLASH_COMMANDS_TOKEN }}
+          always-allow-teams: core-maintainers,lead-maintainers
+
+  # Merge-gate status check — make "Slash Commands / status" a required
+  # check in branch protection so the labels become enforceable.
+  status:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require approval, block on hold
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          echo "Labels: $LABELS"
+          if ! jq -e 'contains(["approved"])' <<<"$LABELS" > /dev/null; then
+            echo "::error::Missing 'approved' label — have a maintainer or CODEOWNER comment /lgtm"
+            exit 1
+          fi
+          if jq -e 'contains(["do-not-merge/hold"])' <<<"$LABELS" > /dev/null; then
+            echo "::error::'do-not-merge/hold' present — resolve concerns, then comment /unhold"
+            exit 1
+          fi
+          echo "✅ approved and not held"


### PR DESCRIPTION
## Summary

Adds a caller workflow for the new [`slash-commands` composite action](https://github.com/modelcontextprotocol/actions/pull/1), implementing Prow-style PR approval via comment commands.

Fixes #2199 — SEP-2148 (Contributor Ladder) calls out that Members can use shortcut commands like `/lgtm`.

## Commands

| Command | Effect |
|---|---|
| `/lgtm` | Add `approved` label + bot APPROVE review ("Approved on behalf of @user via /lgtm") |
| `/lgtm cancel` | Remove label + dismiss review |
| `/hold` | Add `do-not-merge/hold` label |
| `/hold cancel` / `/unhold` | Remove hold label |

**Authorization:** members of `core-maintainers` or `lead-maintainers`, OR any user/team listed in CODEOWNERS for the PR's changed files. CODEOWNERS is read from the **base** ref, so PR authors can't tamper.

**Invalidation:** pushing new commits removes `approved` and dismisses the bot review, with a brief comment asking for re-approval.

**UX:** 👍 on success, 👎 on unauthorized or self-approval attempts. No comment spam.

## Merge gate

The `status` job is a required-check candidate — it passes only when `approved` is present and `do-not-merge/hold` is absent.

## Setup needed before this is effective

- [ ] Create labels: `approved` (`#0e8a16`), `do-not-merge/hold` (`#d93f0b`)
- [ ] Create `SLASH_COMMANDS_TOKEN` repo secret — fine-grained PAT with **Org → Members: read** + **Repo → Contents: read, Pull requests: write, Issues: write** (see [action README](https://github.com/modelcontextprotocol/actions/tree/slash-commands/slash-commands#required-secrets))
- [ ] Add `Slash Commands / status` to branch protection required checks

## Testing

Currently references `@slash-commands` branch of the actions repo (modelcontextprotocol/actions#1). I'll bump to `@main` after that PR merges.

You can test by commenting `/lgtm`, `/hold`, etc. on this PR once the secret is configured.