### PR TITLE
Bump slash-commands action ref to @main

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -20,7 +20,7 @@ jobs:
       (github.event_name == 'pull_request_target' && github.event.action == 'synchronize')
     runs-on: ubuntu-latest
     steps:
-      - uses: modelcontextprotocol/actions/slash-commands@slash-commands
+      - uses: modelcontextprotocol/actions/slash-commands@main
         with:
           github-token: ${{ secrets.SLASH_COMMANDS_TOKEN }}
           always-allow-teams: core-maintainers,lead-maintainers


### PR DESCRIPTION
The `slash-commands` branch in `modelcontextprotocol/actions` was deleted after modelcontextprotocol/actions#1 merged, so the current workflow fails with:

```
Error: Unable to resolve action `modelcontextprotocol/actions@slash-commands`, unable to find version `slash-commands`
```

Point at `@main` where the action now lives.