### PR TITLE
slash-commands: pending (yellow) merge-gate status instead of red ❌

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -11,6 +11,7 @@ permissions:
   issues: write
   contents: read
   actions: write
+  statuses: write
 
 jobs:
   # Parse and execute /lgtm, /hold, /unhold, /stageblog comment commands;
@@ -27,23 +28,11 @@ jobs:
           always-allow-teams: core-maintainers,lead-maintainers
           stageblog-workflow: stage-blog.yml
 
-  # Merge-gate status check — make "Slash Commands / status" a required
-  # check in branch protection so the labels become enforceable.
+  # Merge-gate commit status. Mark `slash-commands/approval` as a required
+  # status check in branch protection. Stays pending (yellow) until /lgtm
+  # adds the approved label; goes failure (red) only on /hold.
   status:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
-      - name: Require approval, block on hold
-        env:
-          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
-        run: |
-          echo "Labels: $LABELS"
-          if ! jq -e 'contains(["approved"])' <<<"$LABELS" > /dev/null; then
-            echo "::error::Missing 'approved' label — have a maintainer or CODEOWNER comment /lgtm"
-            exit 1
-          fi
-          if jq -e 'contains(["do-not-merge/hold"])' <<<"$LABELS" > /dev/null; then
-            echo "::error::'do-not-merge/hold' present — resolve concerns, then comment /unhold"
-            exit 1
-          fi
-          echo "✅ approved and not held"
+      - uses: modelcontextprotocol/actions/slash-commands/status@main


### PR DESCRIPTION
Replaces the exit-code-based `status` job with the new `slash-commands/status` sub-action (modelcontextprotocol/actions#9), which sets an explicit commit status via the API.

## Before
Every fresh PR shows a **red ❌** on `Slash Commands / status` because the job exits 1 when `approved` is absent.

## After
The check shows **🟡 pending** ("Awaiting /lgtm from a maintainer or CODEOWNER") until `/lgtm` is applied. It only goes **❌ failure** when `/hold` is active.

| Labels | Status | UI |
|---|---|---|
| neither | `pending` | 🟡 |
| `approved` | `success` | ✅ |
| `do-not-merge/hold` | `failure` | ❌ |

## Branch protection change required

After merging, in **Settings → Branches → main → Edit**, swap the required status check:
- Remove: `Slash Commands / status` (the old job-based check)
- Add: `slash-commands/approval` (the new commit-status context)

The status job still exists and still runs — it just now always succeeds itself; the commit status it *creates* is what's enforced.

Depends on modelcontextprotocol/actions#9 being merged (already is).