### PR TITLE
stage-blog: repost preview comment on each /stageblog (minimize old as outdated)

### DIFF
--- a/.github/workflows/stage-blog.yml
+++ b/.github/workflows/stage-blog.yml
@@ -57,3 +57,4 @@ jobs:
           commit-sha: ${{ inputs.head_sha }}
           comment-title: "📰 Blog Preview (staged via /stageblog)"
           comment-marker: "<!-- stage-blog-comment -->"
+          comment-mode: repost


### PR DESCRIPTION
Sets `comment-mode: repost` on the `cloudflare-pages-preview/deploy` step so each `/stageblog` run:
1. Minimizes all prior `<!-- stage-blog-comment -->` comments as **OUTDATED** (GitHub's native collapse UI)
2. Posts a fresh comment at the bottom of the conversation with the latest preview links

Previously the comment was updated in place, which meant the link history was lost and the comment stayed wherever it was first posted in the thread.

Depends on modelcontextprotocol/actions#11.

`blog-preview.yml` (the automatic non-fork preview) is unchanged — it still uses the default `sticky` mode since it uses a different marker.