### PR TITLE
slash-commands: trim pull_request_target triggers to opened/synchronize

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -4,7 +4,7 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [synchronize, opened, reopened, labeled, unlabeled]
+    types: [opened, synchronize]
 
 permissions:
   pull-requests: write
@@ -29,8 +29,8 @@ jobs:
           stageblog-workflow: stage-blog.yml
 
   # Merge-gate commit status. Mark `slash-commands/approval` as a required
-  # status check in branch protection. Stays pending (yellow) until /lgtm
-  # adds the approved label; goes failure (red) only on /hold.
+  # status check in branch protection. This job sets it pending on PR open
+  # and on every push; only the /lgtm handler in the job above writes success.
   status:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Companion to the actions-repo fix for `/lgtm` not turning the merge-gate status green.

## Why these triggers are dead weight

**`labeled`/`unlabeled`** — the status sub-action was designed to re-evaluate when the `handle` job added/removed the `approved` label. But `handle` writes labels via `GITHUB_TOKEN`, and GitHub suppresses workflow runs for `GITHUB_TOKEN`-triggered events. These never fired for bot writes — only for manual label edits, which is worse (see below). The actions-repo fix moves the status write into the `/lgtm` handler itself, so the event cascade is no longer needed.

**`reopened`** — commit statuses persist on the SHA across close/reopen. Re-running the `status` job on reopen would overwrite a legitimate `success` with `pending`.

## Security hardening

With `labeled` in the trigger list, anyone with `triage` permissions could manually add the `approved` label → `labeled` event fires (real user, not suppressed) → `status` job reads the label → sets the merge-gate check to `success`. That bypasses the whole CODEOWNERS/team auth check.

After this change the only path to `success` is the auth-gated `/lgtm` handler. Manual labeling is cosmetic.

## Merge order

Safe to merge in either order relative to the actions-repo PR — `/lgtm` is already broken today, and dropping these triggers doesn't make it worse. The actions-repo PR is what actually fixes the behavior.