### PR TITLE
Update MCP client capability documentation for Claude Code (Elicitation), Claude Desktop (Roots), claude.ai (Apps)

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -686,7 +686,7 @@ Chorus is a native Mac app for chatting with AIs. Chat with multiple models at o
 <McpClient
   name="Claude Code"
   homepage="https://claude.com/product/claude-code"
-  supports="Resources, Prompts, Tools, Roots, Instructions, Discovery, DCR"
+  supports="Resources, Prompts, Tools, Roots, Elicitation, Instructions, Discovery, DCR"
   instructions="https://code.claude.com/docs/en/mcp"
 >
 
@@ -702,7 +702,7 @@ Claude Code is an interactive agentic coding tool from Anthropic that helps you 
 <McpClient
   name="Claude Desktop App"
   homepage="https://claude.ai/download"
-  supports="Resources, Prompts, Tools, Apps, DCR"
+  supports="Resources, Prompts, Tools, Roots, Apps, DCR"
   instructions={[
     ["Local servers", "https://support.claude.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop"],
     ["Remote servers", "https://support.claude.com/en/articles/11175166-getting-started-with-custom-connectors-using-remote-mcp"]
@@ -723,7 +723,7 @@ Claude Desktop provides comprehensive support for MCP, enabling deep integration
 <McpClient
   name="Claude.ai"
   homepage="https://claude.ai"
-  supports="Resources, Prompts, Tools, CIMD, DCR"
+  supports="Resources, Prompts, Tools, Apps, CIMD, DCR"
 >
 
 Claude.ai is Anthropic's web-based AI assistant that provides MCP support for remote servers.


### PR DESCRIPTION
Updated capability docs for Anthropic's clients.

- **Claude Code**: Added "Elicitation" (since [2.1.76](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2176))
- **Claude Desktop App**: Added "Roots"
- **Claude.ai**: Added "Apps"
