### PR TITLE
fix: Clarify ID-JAG role in Enterprise Managed Authorization

### DIFF
--- a/docs/extensions/auth/enterprise-managed-authorization.mdx
+++ b/docs/extensions/auth/enterprise-managed-authorization.mdx
@@ -101,9 +101,9 @@ To support Enterprise-Managed Authorization, your client must:
 }
 ```
 
-2. **Support SSO with OpenID Connect** — users should authenticate to the MCP Client using the enterprise IdP over OpenID Connect SSO. Save the ID Token issued during login for later use.
+2. **Support SSO** — users should authenticate to the MCP Client using the enterprise IdP. Save the Identity Assertion (either an OpenID ID Token or SAML assertion) issued during login for later use.
 
-3. **Handle ID-JAGs** — when the server indicates that enterprise-managed auth is required, request an ID-JAG token from the enterprise IdP's authorization endpoint using the previously obtained ID Token. Exchange this ID-JAG for an access token from the MCP Authorization Server. Do not redirect the user to the MCP Authorization Server's authorization endpoint.
+3. **Handle ID-JAGs** — when the server indicates that enterprise-managed auth is required, request an ID-JAG token from the enterprise IdP's authorization endpoint using the previously obtained Identity Assertion. Exchange this ID-JAG for an access token from the MCP Authorization Server. Do not redirect the user to the MCP Authorization Server's authorization endpoint.
 
 4. **Support organization configuration** — allow administrators to configure the enterprise IdP's endpoints, typically via organization-level settings rather than per-user settings.
 


### PR DESCRIPTION
The existing sequence diagram and instructions are written in such a way that the MCP Client receives an access token directly from the enterprise IdP. This is not the case - the enterprise IdP issues an ID-JAG, which the MCP Client then exchanges for an access token at the MCP Authorization Server.

This PR makes the ID-JAG step clearer (hopefully!)

I have lifted the sequence diagram from the [draft spec](https://github.com/modelcontextprotocol/ext-auth/blob/main/specification/draft/enterprise-managed-authorization.mdx) pretty much verbatim. 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
