### PR TITLE
Restore docs navigation structure lost in merge

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -64,10 +64,32 @@
             ]
           },
           {
-            "group": "Extensions",
+            "group": "Examples",
             "pages": [
-              "docs/extensions/overview",
-              "docs/extensions/apps"
+              "clients",
+              "examples"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Extensions",
+        "pages": [
+          "extensions/overview",
+          "extensions/client-matrix",
+          {
+            "group": "MCP Apps",
+            "pages": [
+              "extensions/apps/overview",
+              "extensions/apps/build"
+            ]
+          },
+          {
+            "group": "Authorization Extensions",
+            "pages": [
+              "extensions/auth/overview",
+              "extensions/auth/oauth-client-credentials",
+              "extensions/auth/enterprise-managed-authorization"
             ]
           }
         ]
@@ -402,16 +424,28 @@
       {
         "tab": "Community",
         "pages": [
-          "community/contributing",
-          "community/communication",
+          {
+            "group": "Get Involved",
+            "pages": [
+              "community/contributing",
+              "community/communication",
+              "community/working-interest-groups",
+              "community/charter-template"
+            ]
+          },
+          {
+            "group": "Propose Changes",
+            "pages": [
+              "community/design-principles",
+              "community/sep-guidelines"
+            ]
+          },
           {
             "group": "Governance",
             "pages": [
               "community/governance",
-              "community/sep-guidelines",
+              "community/contributor-ladder",
               "community/sdk-tiers",
-              "community/working-interest-groups",
-              "community/charter-template",
               "community/antitrust"
             ]
           },
@@ -419,13 +453,6 @@
             "group": "Roadmap",
             "pages": [
               "development/roadmap"
-            ]
-          },
-          {
-            "group": "Examples",
-            "pages": [
-              "clients",
-              "examples"
             ]
           }
         ]
@@ -548,7 +575,23 @@
     },
     {
       "source": "/extensions",
-      "destination": "/docs/extensions/overview"
+      "destination": "/extensions/overview"
+    },
+    {
+      "source": "/docs/extensions/overview",
+      "destination": "/extensions/overview"
+    },
+    {
+      "source": "/docs/extensions/apps",
+      "destination": "/extensions/apps/overview"
+    },
+    {
+      "source": "/community/seps",
+      "destination": "/seps"
+    },
+    {
+      "source": "/community/seps/:slug*",
+      "destination": "/seps/:slug*"
     }
   ],
   "contextual": {


### PR DESCRIPTION
## Summary

Fixes a regression in `docs/docs.json` where the navigation structure was partially reverted, leaving several pages orphaned and the Extensions section with incorrect `docs/` path prefixes.

- **Extensions tab**: promoted from a nested group to a top-level tab; fixes incorrect `docs/extensions/*` paths → `extensions/*`; adds MCP Apps (overview, build) and Authorization Extensions (OAuth client credentials, enterprise managed auth) subgroups; adds `client-matrix` page
- **Community tab**: reorganized into logical groups — *Get Involved* (contributing, communication, WG/IG, charter template), *Propose Changes* (design principles, SEP guidelines), *Governance* (governance, contributor ladder, SDK tiers, antitrust)
- **Examples**: moved out of Community tab back to the main docs area
- **Redirects**: added for `/docs/extensions/*` → `/extensions/*` and `/community/seps/*` → `/seps/*` to preserve inbound links

## Test plan

- [ ] `npm run serve:docs` — verify Extensions tab renders with all subgroups
- [ ] Verify Community tab shows Get Involved / Propose Changes / Governance groups
- [ ] Check that `contributor-ladder`, `charter-template`, `working-interest-groups`, `design-principles` pages are reachable from nav
- [ ] Test redirects: `/docs/extensions/apps`, `/community/seps`, `/extensions`
- [ ] `npm run check:docs` passes