### PR TITLE
Add explicit permissions to workflows missing them

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
 
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds least-privilege `permissions` blocks to three workflows flagged by CodeQL (`actions/missing-workflow-permissions`):

| Workflow | Permission | Rationale |
|---|---|---|
| `main.yml` | `contents: read` | checkout + schema checks only |
| `markdown-format.yml` | `contents: read` | checkout + format/link checks only |
| `sep-lifecycle.yml` `check-sep` job | `{}` | only writes to `$GITHUB_OUTPUT`, no checkout or API calls (the `run-automation` job already declares its own permissions) |

Resolves code scanning alerts [#19](https://github.com/modelcontextprotocol/modelcontextprotocol/security/code-scanning/19), [#18](https://github.com/modelcontextprotocol/modelcontextprotocol/security/code-scanning/18), and [#16](https://github.com/modelcontextprotocol/modelcontextprotocol/security/code-scanning/16).