### PR TITLE
Add explicit permissions to markdown-format and sep-lifecycle workflows

### DIFF
--- a/.github/workflows/markdown-format.yml
+++ b/.github/workflows/markdown-format.yml
@@ -10,6 +10,9 @@ on:
       - '**/*.md'
       - '**/*.mdx'
 
+permissions:
+  contents: read
+
 jobs:
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/sep-lifecycle.yml
+++ b/.github/workflows/sep-lifecycle.yml
@@ -32,6 +32,7 @@ jobs:
       contains(github.event.issue.title, 'SEP') ||
       contains(github.event.pull_request.title, 'SEP')
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
       issue_number: ${{ steps.check.outputs.issue_number }}


### PR DESCRIPTION
Follow-up to #2449, which merged before these two landed on the branch.

| Workflow | Permission | Rationale |
|---|---|---|
| `markdown-format.yml` | `contents: read` | checkout + format/link checks only |
| `sep-lifecycle.yml` `check-sep` job | `{}` | only writes to `$GITHUB_OUTPUT`, no checkout or API calls (the `run-automation` job already declares its own permissions) |

Resolves code scanning alerts [#18](https://github.com/modelcontextprotocol/modelcontextprotocol/security/code-scanning/18) and [#16](https://github.com/modelcontextprotocol/modelcontextprotocol/security/code-scanning/16).