### PR TITLE
fix(docs): remove broken link to min-py-mcp-auth sample repo

### DIFF
--- a/docs/docs/tutorials/security/authorization.mdx
+++ b/docs/docs/tutorials/security/authorization.mdx
@@ -616,8 +616,6 @@ For more details about implementing MCP servers in TypeScript, refer to the [Typ
 
 <Tab title='Python'>
 
-You can see the complete Python project in the [sample repository](https://github.com/localden/min-py-mcp-auth).
-
 To simplify our authorization interaction, in Python scenarios we rely on [FastMCP](https://gofastmcp.com/getting-started/welcome). Many of the conventions around authorization, like the endpoints and token validation logic, are consistent across languages, but some offer simpler ways of integrating them in production scenarios.
 
 Prior to writing the actual server, we need to set up our configuration in `config.py` - the contents are entirely based on your local server setup:


### PR DESCRIPTION
## Summary

Removes a dead link from the authorization tutorial that has been returning 404 for several months.

**Closes #1790**

## What changed

The Python tab in the [authorization tutorial](https://modelcontextprotocol.io/docs/tutorials/security/authorization#python) linked to `https://github.com/localden/min-py-mcp-auth`, which returns HTTP 404. The repository does not exist anywhere on GitHub (confirmed by searching the GitHub API). Removed the sentence referencing it.

The tutorial content is complete and self-contained without the link. The Python tab already ends with a reference to the official Python SDK documentation, which is the appropriate canonical reference.

The TypeScript (`min-ts-mcp-auth`) and C# (`min-cs-mcp-auth`) sample repo links were verified as live (HTTP 200) and left unchanged.

## Checklist

- [x] `npm run format:docs` — no changes needed
- [x] `npm run check:docs` — passes, no broken links

## AI Disclosure

This fix was identified and implemented with assistance from an AI agent (OpenCode / Claude). The change was verified by the human contributor: HTTP status of all three sample repo links was confirmed programmatically before making any edits.