### PR TITLE
fix(spec): align outputSchema prose with schema — require type: object

### DIFF
--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -205,6 +205,7 @@ A tool definition includes:
 - `outputSchema`: Optional JSON Schema defining expected output structure
   - Follows the [JSON Schema usage guidelines](/specification/draft/basic#json-schema-usage)
   - Defaults to 2020-12 if no `$schema` field is present
+  - **MUST** have `type: "object"` at the root level (consistent with `inputSchema`)
 - `annotations`: Optional properties describing tool behavior
 - `execution`: Optional object describing execution-related properties
   - `taskSupport`: Indicates whether this tool supports [task-augmented execution](/specification/draft/basic/utilities/tasks#tool-level-negotiation). Values: `"forbidden"` (default), `"optional"`, or `"required"`


### PR DESCRIPTION
## Summary

Fixes a documented inconsistency between the JSON schema and the prose spec for `outputSchema`.

**Closes #1906**

## Problem

`schema/draft/schema.ts` restricts `outputSchema` to `type: "object"` at the root level (matching `inputSchema`), and the JSDoc comment explicitly states _"Currently restricted to `type: "object"` at the root level."_

However, the prose in `docs/specification/draft/server/tools.mdx` had no such constraint — it simply described `outputSchema` as "Optional JSON Schema defining expected output structure" with no type restriction mentioned.

This caused real-world interoperability breakage:
- The **TypeScript SDK** and **C# SDK** both enforce `type: "object"` (following the schema)
- The **Python SDK** allowed any root type (following the permissive prose)
- Server authors targeting the Python SDK could define `outputSchema` with an array root type, which would then be silently rejected by TypeScript/C# clients

## Fix

Added a `MUST` clause to the `outputSchema` bullet in the prose, matching the existing schema constraint:

```
- **MUST** have `type: "object"` at the root level (consistent with `inputSchema`)
```

This aligns the spec prose with the existing schema definition and makes the constraint explicit so SDK authors implement it consistently.

## Decision rationale

The issue raised two options: make it permissive (remove the schema restriction) or make it strict (add the restriction to the prose). This PR takes the strict approach because:

1. The schema already enforces it — this PR makes the prose match, not the other way around
2. TypeScript and C# SDKs (the two most widely used) both already enforce it — relaxing would require changes to multiple SDKs
3. The JSDoc in `schema.ts` already says "Currently restricted" — this was clearly intentional, just undocumented in prose

## Checklist

- [x] `npm run format:docs` — no changes needed
- [x] `npm run check:docs` — passes, no broken links

## AI Disclosure

This fix was identified and implemented with assistance from an AI agent (OpenCode / Claude). The human contributor reviewed the schema source (`schema/draft/schema.ts`), the prose spec, the issue discussion, and the SDK implementations before approving the change direction.