### PR TITLE
[Doc] Remove unnecessary `bundle install` in Ruby MCP server example

### DIFF
--- a/docs/docs/develop/build-server.mdx
+++ b/docs/docs/develop/build-server.mdx
@@ -1830,9 +1830,6 @@ bundle init
 # Add the MCP SDK dependency
 bundle add mcp
 
-# Install dependencies
-bundle install
-
 # Create our server file
 touch weather.rb
 ```
@@ -1847,9 +1844,6 @@ bundle init
 
 # Add the MCP SDK dependency
 bundle add mcp
-
-# Install dependencies
-bundle install
 
 # Create our server file
 new-item weather.rb


### PR DESCRIPTION
## Motivation and Context

Follow-up to https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2431#issuecomment-4114678034.

This PR removes unnecessary `bundle install` in build Ruby MCP server example.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
