### PR TITLE
(docs): Make stdio shutdown sequence platform-neutral

### DIFF
--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -269,9 +269,20 @@ For the stdio [transport](/specification/draft/basic/transports), the client **S
 shutdown by:
 
 1. First, closing the input stream to the child process (the server)
-2. Waiting for the server to exit, or sending `SIGTERM` if the server does not exit
-   within a reasonable time
-3. Sending `SIGKILL` if the server does not exit within a reasonable time after `SIGTERM`
+2. Waiting for the server to exit
+3. If the server does not exit within a reasonable time, forcibly terminating the
+   process using the mechanism appropriate for the operating system
+
+On POSIX systems, forced termination typically escalates from
+[`SIGTERM`](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/signal.h.html) to
+`SIGKILL`. On Windows, where POSIX signals are not available, clients can use
+[`TerminateProcess`](https://learn.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-terminateprocess)
+or
+[Job Objects](https://learn.microsoft.com/windows/win32/procthread/job-objects).
+
+Servers **SHOULD** exit promptly when their standard input is closed or reads return
+end-of-file. This is the primary graceful-shutdown signal and the only portable one, so
+honoring it reduces the need for forced termination.
 
 The server **MAY** initiate shutdown by closing its output stream to the client and
 exiting.


### PR DESCRIPTION
Fixes #1090.

## Problem

The stdio shutdown sequence in `lifecycle.mdx` prescribes closing stdin, then sending `SIGTERM`, then `SIGKILL`. These signals are POSIX-only. On Windows there is no clean equivalent: `TerminateProcess` is a hard kill (no handlers run), and `GenerateConsoleCtrlEvent` has enough caveats that libuv explicitly declined to implement it.

A survey of the four official SDKs shows none of them attempt a graceful-signal intermediate step on Windows. They all close stdin, wait, then hard-kill via `TerminateProcess` or `TerminateJobObject`. The spec's three-step escalation effectively collapses to two steps on Windows.

## Changes

**Platform-neutral steps.** Restructured the numbered list to describe intent (close stdin → wait → force-kill) rather than POSIX mechanics. Added a follow-up paragraph naming the platform-specific APIs with links to their documentation: POSIX `signal.h` (Open Group), Win32 `TerminateProcess` and Job Objects (Microsoft Learn).

**Server-side EOF obligation.** Added a normative `SHOULD` that servers exit promptly when stdin closes or returns EOF. Per [Larry Osterman's comment](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1090#issuecomment-3145184386), this is the real fix: if servers honor stdin closure, forced termination becomes a rare fallback rather than the norm. Stdin close is the only portable graceful-shutdown signal.

## Scope

Draft spec only.