### PR TITLE
Move `counter-increment` from `::before` to `hN` for section numbering

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -31,23 +31,33 @@ body:has(#enable-section-numbers) {
 
   #content-area h2[id],
   #table-of-contents li[data-depth="0"] {
+    counter-increment: h2-counter;
     counter-set: h3-counter h4-counter h5-counter h6-counter;
   }
 
   #content-area h3[id],
   #table-of-contents li[data-depth="1"] {
+    counter-increment: h3-counter;
     counter-set: h4-counter h5-counter h6-counter;
   }
 
   #content-area h4[id],
   #table-of-contents li[data-depth="2"] {
+    counter-increment: h4-counter;
     counter-set: h5-counter h6-counter;
   }
 
   #content-area h5[id],
   #content-area h5,
   #table-of-contents li[data-depth="3"] {
+    counter-increment: h5-counter;
     counter-set: h6-counter;
+  }
+
+  #content-area h6[id],
+  #content-area h6,
+  #table-of-contents li[data-depth="4"] {
+    counter-increment: h6-counter;
   }
 
   #table-of-contents li a::before {
@@ -56,19 +66,16 @@ body:has(#enable-section-numbers) {
 
   #content-area h2[id]::before,
   #table-of-contents li[data-depth="0"] a::before {
-    counter-increment: h2-counter;
     content: counter(h2-counter) ". ";
   }
 
   #content-area h3[id]::before,
   #table-of-contents li[data-depth="1"] a::before {
-    counter-increment: h3-counter;
     content: counter(h2-counter) "." counter(h3-counter) " ";
   }
 
   #content-area h4[id]::before,
   #table-of-contents li[data-depth="2"] a::before {
-    counter-increment: h4-counter;
     content: counter(h2-counter) "." counter(h3-counter) "." counter(h4-counter)
       " ";
   }
@@ -76,7 +83,6 @@ body:has(#enable-section-numbers) {
   #content-area h5[id]::before,
   #content-area h5::before,
   #table-of-contents li[data-depth="3"] a::before {
-    counter-increment: h5-counter;
     content: counter(h2-counter) "." counter(h3-counter) "." counter(h4-counter)
       "." counter(h5-counter) " ";
   }
@@ -84,7 +90,6 @@ body:has(#enable-section-numbers) {
   #content-area h6[id]::before,
   #content-area h6::before,
   #table-of-contents li[data-depth="4"] a::before {
-    counter-increment: h6-counter;
     content: counter(h2-counter) "." counter(h3-counter) "." counter(h4-counter)
       "." counter(h5-counter) "." counter(h6-counter) " ";
   }


### PR DESCRIPTION
A recent Mintlify update added `container-type: inline-size` to the content wrapper div (for responsive container queries), which per the CSS spec implicitly enables `contain: style`. This style containment boundary broke CSS counter propagation between sibling headings -- a change outside our control.

When `counter-increment` was on `::before` (a child pseudo-element of the heading), the incremented values were trapped inside each heading's subtree by the containment boundary and didn't propagate to subsequent siblings. This caused every `h2` to display "1." and every `h3` to see `h2-counter` as 0.

Moving `counter-increment` to the heading element itself fixes propagation, since counter changes on the element (as opposed to a child pseudo-element) do propagate to siblings even under style containment. The `::before` rules now only read counter values via `content`.

| Before | After |
| --- | --- |
| <img width="1828" height="926" alt="before" src="https://github.com/user-attachments/assets/3b0dc530-bf7b-40ff-8279-5cefdbd1fd8c" /> | <img width="1828" height="926" alt="after" src="https://github.com/user-attachments/assets/42746144-8387-4f72-8c38-2c81d304ee42" /> |
