### PR TITLE
slash-commands: switch to MCP Commander App + auto-merge

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -27,6 +27,5 @@ jobs:
       - uses: modelcontextprotocol/actions/slash-commands@main
         with:
           github-token: ${{ steps.app-token.outputs.token }}
-          bot-token: ${{ steps.app-token.outputs.token }}
           always-allow-teams: core-maintainers,lead-maintainers
           stageblog-workflow: stage-blog.yml


### PR DESCRIPTION
Moves `/lgtm` from a custom commit-status merge gate to GitHub's native **required-reviews + auto-merge** flow, using the **MCP Commander** GitHub App as the approval identity.

**Depends on** modelcontextprotocol/actions#14 — merge that first.

## What changes

- Mints an App installation token via `actions/create-github-app-token` using the `MCP_COMMANDER_APP_ID` / `MCP_COMMANDER_APP_KEY` secrets (already configured on this repo)
- Passes the App token as both `github-token` (team-membership checks) and `bot-token` (approval, labels, auto-merge, `/stageblog` dispatch) — so approvals come from the App and always count toward required reviews, independent of the "Allow GitHub Actions to approve" repo setting
- Drops the `status` job — the commit-status gate is removed upstream
- Drops `opened` from `pull_request_target` triggers — no initial pending status to set anymore
- Shrinks workflow `permissions:` to `contents: read` — the App token handles all writes

## Branch-protection migration (do alongside merging this)

- [ ] Enable **Require approvals (1)** on `main` branch protection
- [ ] Enable **Allow auto-merge** in Settings → General → Pull Requests
- [ ] Remove `slash-commands/approval` from required status checks
- [ ] Create the `accepted` label (the upstream default changed from `approved`; color `#0e8a16`)
- [ ] Confirm the MCP Commander App is installed on this repo with Pull requests: write, Contents: read, Actions: write, Members (org): read

## Behavior after this merges

`/lgtm` (core/lead maintainers only) → adds `accepted` label + App APPROVE review + enables auto-merge → PR merges when CI passes. `/lgtm cancel` or a new push → label removed, review dismissed, auto-merge disabled.