### PR TITLE
slash-commands: clean up SEP labels and project status on /lgtm

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -29,3 +29,5 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           always-allow-teams: core-maintainers,lead-maintainers
           stageblog-workflow: stage-blog.yml
+          remove-labels-on-accept: in-review,draft,proposal
+          project-number: 12


### PR DESCRIPTION
## Summary

When `/lgtm` (or `/lgtm force`) accepts a SEP PR:

- Remove the `in-review`, `draft`, and `proposal` labels
- Move the PR to the **Accepted** column in the
  [SEP Review Pipeline](https://github.com/orgs/modelcontextprotocol/projects/12)
  project

## Dependencies

- [ ] modelcontextprotocol/actions#17 must be merged first (adds the
      `remove-labels-on-accept` and `project-number` inputs)
- [ ] MCP Commander App must be granted **Organization Projects: write**
      permission (App settings → Permissions & events → Organization
      permissions → Projects → Read and write, then accept the updated
      permission request on the installation)

Without the App permission, `/lgtm` still approves and cleans up labels;
the project update logs a warning and skips.