### PR TITLE
slash-commands: only move SEP-labeled PRs to the project board

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -31,3 +31,4 @@ jobs:
           stageblog-workflow: stage-blog.yml
           remove-labels-on-accept: in-review,draft,proposal
           project-number: 12
+          project-gate-label: SEP


### PR DESCRIPTION
## Summary

Gate the SEP Review Pipeline project update on the `SEP` label. PRs
accepted via `/lgtm` that aren't SEPs (docs fixes, schema tweaks, etc.)
won't get added to the SEP board.

Label cleanup (`in-review`, `draft`, `proposal`) still runs on every
accept — only the project-board move is gated.

## Dependencies

- [ ] modelcontextprotocol/actions#18 must be merged first (adds the
      `project-gate-label` input)