### PR TITLE
spec: tools/list SHOULD return tools in deterministic order

### DIFF
--- a/docs/specification/draft/changelog.mdx
+++ b/docs/specification/draft/changelog.mdx
@@ -15,6 +15,7 @@ N/A
 
 1. Add `extensions` field to `ClientCapabilities` and `ServerCapabilities` to support optional [extensions](/docs/extensions/overview) beyond the core protocol.
 2. Document OpenTelemetry trace context propagation conventions for `_meta` keys (`traceparent`, `tracestate`, `baggage`) ([SEP-414](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/414)).
+3. Servers **SHOULD** return tools from `tools/list` in a deterministic order to enable client-side caching and improve LLM prompt cache hit rates.
 
 ## Other schema changes
 

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -55,6 +55,11 @@ with the set of tools currently available to the requesting client. This set **M
 empty and **MAY** change over the lifetime of the connection (see
 [List Changed Notification](#list-changed-notification)).
 
+Servers **SHOULD** return tools in a deterministic order (i.e., the same ordering across
+requests when the underlying set of tools has not changed). Deterministic ordering enables
+clients to reliably cache the tool list and improves LLM prompt cache hit rates when tools
+are included in model context.
+
 ## Protocol Messages
 
 ### Listing Tools


### PR DESCRIPTION
Deterministic ordering enables clients to reliably cache the tool list
and improves LLM prompt cache hit rates when tools are included in
model context.
