### PR TITLE
Remove authentication, capabilities, and requires to limit Server Card scope

### DIFF
--- a/docs/seps/2127-mcp-server-cards.mdx
+++ b/docs/seps/2127-mcp-server-cards.mdx
@@ -28,7 +28,7 @@ description: "MCP Server Cards - HTTP Server Discovery via .well-known"
 
 ## Abstract
 
-This SEP proposes adding a standardized, self-contained format to describe MCP servers, e.g. for discovery using a `.well-known` endpoint. This enables clients to automatically discover available transports and protocol versions before establishing a connection.
+This SEP proposes adding a standardized, self-contained format to describe MCP servers, e.g. for discovery using a `.well-known` endpoint. This enables clients to automatically discover available transports, protocol versions, and connection guidance before establishing a connection.
 
 ## Motivation
 

--- a/docs/seps/2127-mcp-server-cards.mdx
+++ b/docs/seps/2127-mcp-server-cards.mdx
@@ -28,7 +28,7 @@ description: "MCP Server Cards - HTTP Server Discovery via .well-known"
 
 ## Abstract
 
-This SEP proposes adding a standardized, self-contained format to describe MCP servers, e.g. for discovery using a `.well-known` endpoint. This enables clients to automatically discover server capabilities, available transports, authentication requirements, and protocol versions before establishing a connection.
+This SEP proposes adding a standardized, self-contained format to describe MCP servers, e.g. for discovery using a `.well-known` endpoint. This enables clients to automatically discover available transports and protocol versions before establishing a connection.
 
 ## Motivation
 
@@ -48,11 +48,11 @@ This SEP introduces **MCP Server Cards** – structured metadata documents that 
 
 - **Autoconfiguration**: IDE extensions can automatically configure themselves when pointed at a domain, eliminating manual setup.
 - **Automated Discovery**: Clients and registries can crawl domains to discover available MCP servers, enabling ecosystem-wide server indexes.
-- **Reduced Latency:** Display server information, capabilities, and metadata without waiting for full initialization sequences.
+- **Reduced Latency:** Display server information and metadata without waiting for full initialization sequences.
 
 ### Design Philosophy
 
-The discovery mechanism complements rather than replaces initialization. Discovery answers where to connect and what capabilities are available, while initialization handles the communication handshake.
+The discovery mechanism complements rather than replaces initialization. Discovery answers where to connect and what transports and protocol versions are available, while initialization handles the communication handshake.
 
 ### Discovery
 
@@ -113,8 +113,6 @@ This section provides the technical specification for MCP Server Cards.
   },
   "icons": [ ... ],
   "remotes": [ ... ],
-  "capabilities":  { ... },
-  "requires": { ... },
   "_meta": { ... }
 }
 ```
@@ -164,38 +162,14 @@ Fleshed out (contrived values) example:
             "ap-southeast-1"
           ]
         }
-      ],
-      "authentication": {
-        "required": true,
-        "schemes": ["bearer", "oauth2"]
-      },
+      ]
     },
     {
       "type": "sse",
       "url": "https://mcp.anonymous.modelcontextprotocol.io/sse",
-      "supportedProtocolVersions": [ "2025-03-12", "2025-06-15" ],
-      "authentication": {
-        "required": true,
-        "schemes": ["bearer", "oauth2"]
-      },
+      "supportedProtocolVersions": [ "2025-03-12", "2025-06-15" ]
     }
   ],
-  "capabilities": {
-    "tools": {
-      "listChanged": true
-    },
-    "prompts": {
-      "listChanged": true
-    },
-    "resources": {
-      "subscribe": true,
-      "listChanged": true
-    }
-  },
-  "requires": {
-    "sampling": {},
-    "roots": {}
-  },
   "_meta": { ... }
 }
 
@@ -215,27 +189,8 @@ Most fields follow the current MCP Registry `server.json` standard: https://gith
 7. **icons** (array of object, optional): Optional set of sized icons that the client can display in a user interface. Clients that support rendering icons MUST support at least the following MIME types: image/png and image/jpeg (safe, universal compatibility). Clients SHOULD also support: image/svg+xml (scalable but requires security precautions) and image/webp (modern, efficient format). [See details](https://github.com/modelcontextprotocol/registry/blob/3f3383bb6199990c853ae8be3715e150af5e8bcb/docs/reference/server-json/server.schema.json#L18).
 8. **remotes** (array of object, optional): Metadata helpful for making HTTP-based connections to this MCP server.
    1. **supportedProtocolVersions** (array of string, optional): list of MCP protocol versions actively supported by this Remote.
-   2. **authentication** (object, optional): Authentication requirements
-      1. **required** (boolean, required): Whether authentication is mandatory
-      2. **schemes** (array, required): Supported schemes (e.g., ["bearer", "oauth2"])
-   3. [See details](https://github.com/modelcontextprotocol/registry/blob/3f3383bb6199990c853ae8be3715e150af5e8bcb/docs/reference/server-json/server.schema.json#L344) for other fields.
-9. **capabilities** (object, optional): Server capabilities following `ServerCapabilities`
-   1. **experimental** (object, optional): Experimental capabilities
-   2. **logging** (object, optional): Log message support
-   3. **completions** (object, optional): Argument autocompletion support
-   4. **prompts** (object, optional): Prompt template support
-      1. **listChanged** (boolean, optional): Change notification support
-   5. **resources** (object, optional): Resource support
-      1. **subscribe** (boolean, optional): Subscription support
-      2. **listChanged** (boolean, optional): Change notification support
-   6. **tools** (object, optional): Tool support
-      1. **listChanged** (boolean, optional): Change notification support
-10. **requires** (object, optional): Required client capabilities following `ClientCapabilities`
-    1. **experimental** (object, optional): Required experimental capabilities
-    2. **roots** (object, optional): Root access requirement
-    3. **sampling** (object, optional): LLM sampling requirement
-    4. **elicitation** (object, optional): User elicitation requirement
-11. **\_meta** (object, optional): Additional metadata following [\_meta definition](https://modelcontextprotocol.io/specification/2025-06-18/basic/index#meta)
+   2. [See details](https://github.com/modelcontextprotocol/registry/blob/3f3383bb6199990c853ae8be3715e150af5e8bcb/docs/reference/server-json/server.schema.json#L344) for other fields.
+9. **\_meta** (object, optional): Additional metadata following [\_meta definition](https://modelcontextprotocol.io/specification/2025-06-18/basic/index#meta)
 
 ### `server.json` Schema
 
@@ -396,7 +351,7 @@ This specification intentionally omits primitive definitions (tools, resources, 
 
 ### Why Not Wait for Primitives?
 
-The debate around primitives should not delay server card adoption. Discovery (knowing that a server exists, where to connect, what transports it supports, and what authentication it requires) is enormously valuable on its own. It is the information an end user or IDE needs to install and configure a server, and it is the information a registry needs to index one. None of this depends on knowing the server's tool list in advance.
+The debate around primitives should not delay server card adoption. Discovery (knowing that a server exists, where to connect, and what transports and protocol versions it supports) is enormously valuable on its own. It is the information an end user or IDE needs to install and configure a server, and it is the information a registry needs to index one. None of this depends on knowing the server's tool list in advance.
 
 Server cards without primitives already enable the core use cases that motivate this SEP: autoconfiguration, domain-level discovery, reduced-latency metadata retrieval, and registry integration. Primitives can be added in a future revision once the ecosystem has the right mechanisms to advertise them safely. Shipping discovery now, and shipping it correctly, is more important than shipping a larger surface that risks being wrong.
 

--- a/seps/2127-mcp-server-cards.md
+++ b/seps/2127-mcp-server-cards.md
@@ -9,7 +9,7 @@
 
 ## Abstract
 
-This SEP proposes adding a standardized, self-contained format to describe MCP servers, e.g. for discovery using a `.well-known` endpoint. This enables clients to automatically discover available transports and protocol versions before establishing a connection.
+This SEP proposes adding a standardized, self-contained format to describe MCP servers, e.g. for discovery using a `.well-known` endpoint. This enables clients to automatically discover available transports, protocol versions, and connection guidance before establishing a connection.
 
 ## Motivation
 

--- a/seps/2127-mcp-server-cards.md
+++ b/seps/2127-mcp-server-cards.md
@@ -9,7 +9,7 @@
 
 ## Abstract
 
-This SEP proposes adding a standardized, self-contained format to describe MCP servers, e.g. for discovery using a `.well-known` endpoint. This enables clients to automatically discover server capabilities, available transports, authentication requirements, and protocol versions before establishing a connection.
+This SEP proposes adding a standardized, self-contained format to describe MCP servers, e.g. for discovery using a `.well-known` endpoint. This enables clients to automatically discover available transports and protocol versions before establishing a connection.
 
 ## Motivation
 
@@ -29,11 +29,11 @@ This SEP introduces **MCP Server Cards** – structured metadata documents that 
 
 - **Autoconfiguration**: IDE extensions can automatically configure themselves when pointed at a domain, eliminating manual setup.
 - **Automated Discovery**: Clients and registries can crawl domains to discover available MCP servers, enabling ecosystem-wide server indexes.
-- **Reduced Latency:** Display server information, capabilities, and metadata without waiting for full initialization sequences.
+- **Reduced Latency:** Display server information and metadata without waiting for full initialization sequences.
 
 ### Design Philosophy
 
-The discovery mechanism complements rather than replaces initialization. Discovery answers where to connect and what capabilities are available, while initialization handles the communication handshake.
+The discovery mechanism complements rather than replaces initialization. Discovery answers where to connect and what transports and protocol versions are available, while initialization handles the communication handshake.
 
 ### Discovery
 
@@ -94,8 +94,6 @@ This section provides the technical specification for MCP Server Cards.
   },
   "icons": [ ... ],
   "remotes": [ ... ],
-  "capabilities":  { ... },
-  "requires": { ... },
   "_meta": { ... }
 }
 ```
@@ -145,38 +143,14 @@ Fleshed out (contrived values) example:
             "ap-southeast-1"
           ]
         }
-      ],
-      "authentication": {
-        "required": true,
-        "schemes": ["bearer", "oauth2"]
-      },
+      ]
     },
     {
       "type": "sse",
       "url": "https://mcp.anonymous.modelcontextprotocol.io/sse",
-      "supportedProtocolVersions": [ "2025-03-12", "2025-06-15" ],
-      "authentication": {
-        "required": true,
-        "schemes": ["bearer", "oauth2"]
-      },
+      "supportedProtocolVersions": [ "2025-03-12", "2025-06-15" ]
     }
   ],
-  "capabilities": {
-    "tools": {
-      "listChanged": true
-    },
-    "prompts": {
-      "listChanged": true
-    },
-    "resources": {
-      "subscribe": true,
-      "listChanged": true
-    }
-  },
-  "requires": {
-    "sampling": {},
-    "roots": {}
-  },
   "_meta": { ... }
 }
 
@@ -196,27 +170,8 @@ Most fields follow the current MCP Registry `server.json` standard: https://gith
 7. **icons** (array of object, optional): Optional set of sized icons that the client can display in a user interface. Clients that support rendering icons MUST support at least the following MIME types: image/png and image/jpeg (safe, universal compatibility). Clients SHOULD also support: image/svg+xml (scalable but requires security precautions) and image/webp (modern, efficient format). [See details](https://github.com/modelcontextprotocol/registry/blob/3f3383bb6199990c853ae8be3715e150af5e8bcb/docs/reference/server-json/server.schema.json#L18).
 8. **remotes** (array of object, optional): Metadata helpful for making HTTP-based connections to this MCP server.
    1. **supportedProtocolVersions** (array of string, optional): list of MCP protocol versions actively supported by this Remote.
-   2. **authentication** (object, optional): Authentication requirements
-      1. **required** (boolean, required): Whether authentication is mandatory
-      2. **schemes** (array, required): Supported schemes (e.g., ["bearer", "oauth2"])
-   3. [See details](https://github.com/modelcontextprotocol/registry/blob/3f3383bb6199990c853ae8be3715e150af5e8bcb/docs/reference/server-json/server.schema.json#L344) for other fields.
-9. **capabilities** (object, optional): Server capabilities following `ServerCapabilities`
-   1. **experimental** (object, optional): Experimental capabilities
-   2. **logging** (object, optional): Log message support
-   3. **completions** (object, optional): Argument autocompletion support
-   4. **prompts** (object, optional): Prompt template support
-      1. **listChanged** (boolean, optional): Change notification support
-   5. **resources** (object, optional): Resource support
-      1. **subscribe** (boolean, optional): Subscription support
-      2. **listChanged** (boolean, optional): Change notification support
-   6. **tools** (object, optional): Tool support
-      1. **listChanged** (boolean, optional): Change notification support
-10. **requires** (object, optional): Required client capabilities following `ClientCapabilities`
-    1. **experimental** (object, optional): Required experimental capabilities
-    2. **roots** (object, optional): Root access requirement
-    3. **sampling** (object, optional): LLM sampling requirement
-    4. **elicitation** (object, optional): User elicitation requirement
-11. **\_meta** (object, optional): Additional metadata following [\_meta definition](https://modelcontextprotocol.io/specification/2025-06-18/basic/index#meta)
+   2. [See details](https://github.com/modelcontextprotocol/registry/blob/3f3383bb6199990c853ae8be3715e150af5e8bcb/docs/reference/server-json/server.schema.json#L344) for other fields.
+9. **\_meta** (object, optional): Additional metadata following [\_meta definition](https://modelcontextprotocol.io/specification/2025-06-18/basic/index#meta)
 
 ### `server.json` Schema
 
@@ -377,7 +332,7 @@ This specification intentionally omits primitive definitions (tools, resources, 
 
 ### Why Not Wait for Primitives?
 
-The debate around primitives should not delay server card adoption. Discovery (knowing that a server exists, where to connect, what transports it supports, and what authentication it requires) is enormously valuable on its own. It is the information an end user or IDE needs to install and configure a server, and it is the information a registry needs to index one. None of this depends on knowing the server's tool list in advance.
+The debate around primitives should not delay server card adoption. Discovery (knowing that a server exists, where to connect, and what transports and protocol versions it supports) is enormously valuable on its own. It is the information an end user or IDE needs to install and configure a server, and it is the information a registry needs to index one. None of this depends on knowing the server's tool list in advance.
 
 Server cards without primitives already enable the core use cases that motivate this SEP: autoconfiguration, domain-level discovery, reduced-latency metadata retrieval, and registry integration. Primitives can be added in a future revision once the ecosystem has the right mechanisms to advertise them safely. Shipping discovery now, and shipping it correctly, is more important than shipping a larger surface that risks being wrong.
 


### PR DESCRIPTION
Building on [#2127](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127) - addresses [this comment](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127#issuecomment-4113070096)

> There are a few additive fields on top of server.json that I'm conceptually on board with (we'd add them to server.json to maintain compatibility), but by including them we are adding a whole lot in one swoop, so my suggestion would actually be to remove these and not add them unless there are clear use cases / demand / more folks have inputted as to whether we've designed them right: authentication, supportedProtocolVersions, capabilities, requires

## Summary

Removes three additive fields from the Server Card / server.json shape to limit the scope of this SEP:

- **`authentication`** (from `remotes[]`) — removed
- **`capabilities`** (top-level) — removed
- **`requires`** (top-level) — removed
- **`supportedProtocolVersions`** — **retained** (see rationale below)

These fields are conceptually sound and should probably be added in the future. However, we have had limited/no discussion about them, and have no precedent to lean on in the more battle-tested `server.json`-matching shapes.

Rather than push them through prematurely, I propose cutting scope and revisiting these (for both Server Cards and server.json) at a later date once there is clear demand and design consensus.

## Why keep `supportedProtocolVersions`?

Unlike the other three fields, `supportedProtocolVersions` has been discussed and iterated on since the earliest versions of this SEP:

1. [We iterated on the cardinality of this](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1649#issuecomment-3416511851) from `protocolVersion` (singular string) to `supportedProtocolVersions` (array), noting that servers would want to communicate support for multiple protocol versions.
2. **@simonrussell** [explicitly requested](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1649#issuecomment-3453683897) multi-version support.
3. **@ggoodman** [proposed](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1649#issuecomment-3452324511) placing protocol versions inside an "endpoints" (now `remotes`) array so different endpoints could advertise different versions — this is the structure we have today.
4. The field was identified as potentially important at the recent **MCP Dev Summit maintainer day**, reinforcing its value as a pre-connection discovery signal.

Given this history and the fact that version compatibility is a core concern for pre-connection discovery (clients need to know which protocol versions a remote supports before attempting to connect), `supportedProtocolVersions` has earned its place in the initial scope (and `server.json` should be updated to match this addition when this SEP lands).