### PR TITLE
Clarify SEP finalization requirements

### DIFF
--- a/docs/community/sep-guidelines.mdx
+++ b/docs/community/sep-guidelines.mdx
@@ -142,11 +142,11 @@ Why particular design decisions were made, alternate designs considered, and rel
 
 All SEPs introducing backward incompatibilities must describe these incompatibilities, their severity, and how to deal with them.
 
-### 7. Reference Implementation
+### 7. Specification Changes
 
-For Standards Track SEPs, the reference implementation is the set of specification changes — schema updates, specification text, and a changelog entry — added to the SEP's pull request. These must be complete before the SEP reaches "Final" status, but need not be present before acceptance. SDK implementations are **not** required beyond the [prototype](#prototype-requirements); SDKs implement the feature after the specification is released.
+For Standards Track SEPs, the schema updates, specification text, and changelog entry are added to the SEP's pull request. These must be complete before the SEP reaches "Final" status, but need not be present before acceptance. SDK implementations are **not** required beyond the [prototype](#prototype-requirements); SDKs can begin implementing once the SEP is merged.
 
-For Process and Informational SEPs, the reference implementation is the corresponding documentation or process change.
+For Process and Informational SEPs, this is the corresponding documentation or process change.
 
 ### 8. Security Implications
 

--- a/docs/community/sep-guidelines.mdx
+++ b/docs/community/sep-guidelines.mdx
@@ -64,7 +64,7 @@ flowchart TD
     InReview --> Decision
     Decision --> Accepted
     Decision --> Rejected
-    Accepted -->|"Reference implementation complete"| Final
+    Accepted -->|"Specification changes complete"| Final
 ```
 
 ### Step-by-Step Process
@@ -97,20 +97,20 @@ flowchart TD
 
 8. **Resolution**: The SEP may be `accepted`, `rejected`, or returned for revision. The sponsor updates the status.
 
-9. **Finalization**: Once accepted, the reference implementation must be completed. When complete and incorporated into the specification, the sponsor updates the status to `final`.
+9. **Finalization**: Once accepted, the author adds the specification changes (schema, specification text, and changelog entry) to the same PR. When those changes are complete, the sponsor updates the status to `final` and the PR can be merged.
 
 ### SEP Statuses
 
-| Status       | Meaning                                          |
-| ------------ | ------------------------------------------------ |
-| `draft`      | Has a sponsor, undergoing informal review        |
-| `in-review`  | Ready for formal Core Maintainer review          |
-| `accepted`   | Approved, awaiting reference implementation      |
-| `rejected`   | Declined by Core Maintainers                     |
-| `withdrawn`  | Author withdrew the proposal                     |
-| `final`      | Complete with reference implementation           |
-| `superseded` | Replaced by a newer SEP                          |
-| `dormant`    | No sponsor found within 6 months; can be revived |
+| Status       | Meaning                                           |
+| ------------ | ------------------------------------------------- |
+| `draft`      | Has a sponsor, undergoing informal review         |
+| `in-review`  | Ready for formal Core Maintainer review           |
+| `accepted`   | Approved, awaiting specification changes          |
+| `rejected`   | Declined by Core Maintainers                      |
+| `withdrawn`  | Author withdrew the proposal                      |
+| `final`      | Specification changes complete; PR ready to merge |
+| `superseded` | Replaced by a newer SEP                           |
+| `dormant`    | No sponsor found within 6 months; can be revived  |
 
 **Important distinction**: `dormant` is not the same as `rejected`. A dormant SEP simply didn't find a sponsor - the idea may still be valid. If circumstances change (new community interest, new use cases), a dormant SEP can be revived by finding a sponsor and reopening the PR.
 
@@ -144,7 +144,9 @@ All SEPs introducing backward incompatibilities must describe these incompatibil
 
 ### 7. Reference Implementation
 
-Must be completed before the SEP reaches "Final" status, but need not be complete before acceptance.
+For Standards Track SEPs, the reference implementation is the set of specification changes — schema updates, specification text, and a changelog entry — added to the SEP's pull request. These must be complete before the SEP reaches "Final" status, but need not be present before acceptance. SDK implementations are **not** required beyond the [prototype](#prototype-requirements); SDKs implement the feature after the specification is released.
+
+For Process and Informational SEPs, the reference implementation is the corresponding documentation or process change.
 
 ### 8. Security Implications
 
@@ -212,7 +214,7 @@ For a SEP to be accepted it must meet these criteria:
 - Clear benefit to the MCP ecosystem
 - Community support and consensus
 
-Once a SEP has been accepted, the reference implementation must be completed. When complete and incorporated into the main repository, the status changes to "Final".
+Once a SEP has been accepted, the author adds the specification changes — schema updates, specification text, and a changelog entry — to the SEP's pull request. SDK implementations are not required at this stage; the prototype is sufficient. When the specification changes are complete, the status changes to "Final" and the PR can be merged.
 
 ## After Rejection
 

--- a/docs/community/sep-guidelines.mdx
+++ b/docs/community/sep-guidelines.mdx
@@ -142,11 +142,9 @@ Why particular design decisions were made, alternate designs considered, and rel
 
 All SEPs introducing backward incompatibilities must describe these incompatibilities, their severity, and how to deal with them.
 
-### 7. Specification Changes
+### 7. Prototype Implementation
 
-For Standards Track SEPs, the schema updates, specification text, and changelog entry are added to the SEP's pull request. These must be complete before the SEP reaches "Final" status, but need not be present before acceptance. SDK implementations are **not** required beyond the [prototype](#prototype-requirements); SDKs can begin implementing once the SEP is merged.
-
-For Process and Informational SEPs, this is the corresponding documentation or process change.
+A link to a working prototype demonstrating the proposal. See [Prototype Requirements](#prototype-requirements) for what qualifies. A prototype is required before acceptance; SDK implementations are **not** required for Final status.
 
 ### 8. Security Implications
 

--- a/seps/TEMPLATE.md
+++ b/seps/TEMPLATE.md
@@ -74,8 +74,6 @@ If there are no security implications, state that explicitly.
 
 Link to a prototype demonstrating the proposal — for example, a branch or fork of an official SDK, a standalone proof-of-concept, or a reference server/client. A prototype is required before a SEP can be accepted; it does not need to be production-ready.
 
-SDK implementations are **not** required for Final status. SDKs can begin implementing once the SEP is merged.
-
 ---
 
 ## Additional Optional Sections

--- a/seps/TEMPLATE.md
+++ b/seps/TEMPLATE.md
@@ -70,17 +70,17 @@ Describe any security concerns related to this proposal, including:
 
 If there are no security implications, state that explicitly.
 
-## Reference Implementation
+## Specification Changes
 
-For Standards Track SEPs, the reference implementation is the set of specification changes added to this pull request before the SEP reaches "Final" status:
+For Standards Track SEPs, add the specification changes to this pull request before the SEP reaches "Final" status:
 
 - Schema changes in `schema/draft/schema.ts` (regenerated with `npm run generate:schema`)
 - Specification text in `docs/specification/draft/`
 - A changelog entry in `docs/specification/draft/changelog.mdx`
 
-SDK implementations are **not** required for Final status — the prototype demonstrates feasibility, and SDKs implement the feature after the specification is released. Link to the prototype here.
+SDK implementations are **not** required for Final status — the prototype demonstrates feasibility, and SDKs can begin implementing once the SEP is merged. Link to the prototype here.
 
-For Process and Informational SEPs, the reference implementation is the corresponding documentation or process change included in this PR.
+For Process and Informational SEPs, include the corresponding documentation or process change in this PR.
 
 ---
 

--- a/seps/TEMPLATE.md
+++ b/seps/TEMPLATE.md
@@ -70,17 +70,11 @@ Describe any security concerns related to this proposal, including:
 
 If there are no security implications, state that explicitly.
 
-## Specification Changes
+## Prototype Implementation
 
-For Standards Track SEPs, add the specification changes to this pull request before the SEP reaches "Final" status:
+Link to a prototype demonstrating the proposal — for example, a branch or fork of an official SDK, a standalone proof-of-concept, or a reference server/client. A prototype is required before a SEP can be accepted; it does not need to be production-ready.
 
-- Schema changes in `schema/draft/schema.ts` (regenerated with `npm run generate:schema`)
-- Specification text in `docs/specification/draft/`
-- A changelog entry in `docs/specification/draft/changelog.mdx`
-
-SDK implementations are **not** required for Final status — the prototype demonstrates feasibility, and SDKs can begin implementing once the SEP is merged. Link to the prototype here.
-
-For Process and Informational SEPs, include the corresponding documentation or process change in this PR.
+SDK implementations are **not** required for Final status. SDKs can begin implementing once the SEP is merged.
 
 ---
 

--- a/seps/TEMPLATE.md
+++ b/seps/TEMPLATE.md
@@ -72,15 +72,15 @@ If there are no security implications, state that explicitly.
 
 ## Reference Implementation
 
-Link to or describe a reference implementation. A reference implementation is required before any SEP can be given "Final" status.
+For Standards Track SEPs, the reference implementation is the set of specification changes added to this pull request before the SEP reaches "Final" status:
 
-The principle of "rough consensus and running code" is useful when resolving discussions of protocol details.
+- Schema changes in `schema/draft/schema.ts` (regenerated with `npm run generate:schema`)
+- Specification text in `docs/specification/draft/`
+- A changelog entry in `docs/specification/draft/changelog.mdx`
 
-Include:
+SDK implementations are **not** required for Final status — the prototype demonstrates feasibility, and SDKs implement the feature after the specification is released. Link to the prototype here.
 
-- Links to prototype code or pull requests
-- Pointers to example usage
-- Test results or validation
+For Process and Informational SEPs, the reference implementation is the corresponding documentation or process change included in this PR.
 
 ---
 


### PR DESCRIPTION
## Summary

Tightens up what's required for a SEP to reach `final` status and be merged.

The previous wording around "reference implementation" was ambiguous — it wasn't clear whether it meant SDK PRs, spec changes, or something else, and in practice most Final SEPs had no reference implementation section at all. Note that the guidelines already have "prototype implementation" as a requirement to review. It seems that "reference implementation" is a leftover phrase from before we added the prototype requirement.

## Changes

- Replace "reference implementation" with **"specification changes"** in the guidelines and SEP template — for Standards Track SEPs this means schema updates, spec text, and a changelog entry added to the SEP's PR.
- Clarify that **SDK implementations are not required** for Final status (the prototype is sufficient); SDKs can begin implementing once the SEP is merged.
- State explicitly that a SEP's **PR can be merged once it reaches `final`**.
- Update the workflow diagram, status table, step-by-step process, and `seps/TEMPLATE.md` to match.