### PR TITLE
Recommend clients expose resource read to models

### DIFF
--- a/docs/specification/draft/server/resources.mdx
+++ b/docs/specification/draft/server/resources.mdx
@@ -24,10 +24,10 @@ For example, applications could:
 ![Example of resource context picker](/specification/draft/server/resource-picker.png)
 
 However, implementations are free to expose resources through any interface pattern that
-suits their needs&mdash;the protocol itself does not mandate any specific user
+suits their needs—the protocol itself does not mandate any specific user
 interaction model.
 
-Clients **SHOULD** provide a mechanism&mdash;such as a tool&mdash;for the language model
+Clients **SHOULD** provide a mechanism—such as a tool—for the language model
 to read a resource by URI. Clients **MAY** additionally provide a mechanism for the model
 to list available resources.
 
@@ -53,7 +53,7 @@ The capability supports two optional features:
 - `listChanged`: whether the server will emit notifications when the list of available
   resources changes.
 
-Both `subscribe` and `listChanged` are optional&mdash;servers can support neither,
+Both `subscribe` and `listChanged` are optional—servers can support neither,
 either, or both:
 
 ```json
@@ -388,7 +388,7 @@ Clients can use these annotations to:
 ## Common URI Schemes
 
 The protocol defines several standard URI schemes. This list is not
-exhaustive&mdash;implementations are always free to use additional, custom URI schemes.
+exhaustive—implementations are always free to use additional, custom URI schemes.
 
 ### https://
 

--- a/docs/specification/draft/server/resources.mdx
+++ b/docs/specification/draft/server/resources.mdx
@@ -452,3 +452,9 @@ Example error:
 4. Resource permissions **SHOULD** be checked before operations
 5. Servers **MUST** sanitize file paths to prevent directory traversal attacks
    when serving `file://` resources
+6. When providing the model with a mechanism to read resources, clients **SHOULD**:
+   - Prompt for user confirmation before reading sensitive resources
+   - Show the requested URI to the user before reading, to avoid malicious or accidental
+     data exfiltration
+   - Validate resource contents before passing them to the LLM
+   - Log model-initiated resource reads for audit purposes

--- a/docs/specification/draft/server/resources.mdx
+++ b/docs/specification/draft/server/resources.mdx
@@ -27,10 +27,9 @@ However, implementations are free to expose resources through any interface patt
 suits their needs&mdash;the protocol itself does not mandate any specific user
 interaction model.
 
-Clients **SHOULD** provide a mechanism&mdash;such as a
-[tool](/specification/draft/server/tools)&mdash;for the language model to read a resource
-by URI. Clients **MAY** additionally provide a mechanism for the model to list available
-resources.
+Clients **SHOULD** provide a mechanism&mdash;such as a tool&mdash;for the language model
+to read a resource by URI. Clients **MAY** additionally provide a mechanism for the model
+to list available resources.
 
 ## Capabilities
 

--- a/docs/specification/draft/server/resources.mdx
+++ b/docs/specification/draft/server/resources.mdx
@@ -27,6 +27,11 @@ However, implementations are free to expose resources through any interface patt
 suits their needs&mdash;the protocol itself does not mandate any specific user
 interaction model.
 
+Clients **SHOULD** provide a mechanism&mdash;such as a
+[tool](/specification/draft/server/tools)&mdash;for the language model to read a resource
+by URI. Clients **MAY** additionally provide a mechanism for the model to list available
+resources.
+
 ## Capabilities
 
 Servers that support resources **MUST** declare the `resources` capability:


### PR DESCRIPTION
Adds a SHOULD to the draft Resources spec recommending that clients give the language model a way to read a resource by URI (with an optional MAY for listing).

## Rationale

Resources are currently described as application-driven, but the spec offers no guidance on whether the model itself should be able to pull resource content. In practice this leaves many clients without a model-facing read path, limiting how useful resources are once a URI shows up in context. This change provides clearer guidance on how resources should be implemented in clients to make them more broadly useful.

The recommendation is intentionally mechanism-agnostic ("such as a tool") rather than referencing MCP tools specifically, since the mechanism is typically a host-level LLM tool rather than an MCP server tool.