### PR TITLE
ci: pin main workflow actions to immutable SHAs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: 24
           cache: npm


### PR DESCRIPTION
## Summary
- pin ctions/checkout in .github/workflows/main.yml to its current immutable 6 commit
- pin ctions/setup-node in .github/workflows/main.yml to its current immutable 6 commit
- keep the change workflow-only and behavior-preserving

## Validation
- git diff --check
- python -c "import pathlib, yaml; p=pathlib.Path(r'.github/workflows/main.yml'); yaml.safe_load(p.read_text(encoding='utf-8')); print('yaml_ok', p)"

## Notes
- exact-file overlap recheck found no open PR already touching .github/workflows/main.yml
- local clone had unrelated .serena/ dirt, so this was prepared in an isolated worktree

## AI Disclosure
This PR was written with AI assistance using Codex. I verified the scope, rationale, and local validation results before submission.