### PR TITLE
SEP-2567: Sessionless MCP via Explicit State Handles

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -47,13 +47,7 @@
               "docs/develop/connect-remote-servers",
               "docs/develop/build-with-agent-skills",
               "docs/develop/build-server",
-              {
-                "group": "Clients",
-                "pages": [
-                  "docs/develop/build-client",
-                  "docs/develop/clients/client-best-practices"
-                ]
-              },
+              "docs/develop/build-client",
               "docs/sdk",
               {
                 "group": "Security",
@@ -324,8 +318,7 @@
                       "specification/draft/basic/utilities/cancellation",
                       "specification/draft/basic/utilities/ping",
                       "specification/draft/basic/utilities/progress",
-                      "specification/draft/basic/utilities/tasks",
-                      "specification/draft/basic/utilities/mrtr"
+                      "specification/draft/basic/utilities/tasks"
                     ]
                   }
                 ]
@@ -431,6 +424,12 @@
             ]
           },
           {
+            "group": "Draft",
+            "pages": [
+              "seps/2567-sessionless-mcp"
+            ]
+          },
+          {
             "group": "Approved",
             "pages": [
               "seps/2322-MRTR"
@@ -469,12 +468,8 @@
           {
             "group": "Working Group Charters",
             "pages": [
-              "community/file-uploads/charter",
               "community/inspector-v2/charter",
-              "community/interceptors/charter",
-              "community/sdk/charter",
               "community/server-card/charter",
-              "community/skills-over-mcp/charter",
               "community/triggers-events/charter"
             ]
           },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -47,7 +47,13 @@
               "docs/develop/connect-remote-servers",
               "docs/develop/build-with-agent-skills",
               "docs/develop/build-server",
-              "docs/develop/build-client",
+              {
+                "group": "Clients",
+                "pages": [
+                  "docs/develop/build-client",
+                  "docs/develop/clients/client-best-practices"
+                ]
+              },
               "docs/sdk",
               {
                 "group": "Security",
@@ -318,7 +324,8 @@
                       "specification/draft/basic/utilities/cancellation",
                       "specification/draft/basic/utilities/ping",
                       "specification/draft/basic/utilities/progress",
-                      "specification/draft/basic/utilities/tasks"
+                      "specification/draft/basic/utilities/tasks",
+                      "specification/draft/basic/utilities/mrtr"
                     ]
                   }
                 ]
@@ -420,12 +427,7 @@
             "group": "Accepted",
             "pages": [
               "seps/2207-oidc-refresh-token-guidance",
-              "seps/2260-Require-Server-requests-to-be-associated-with-Client-requests"
-            ]
-          },
-          {
-            "group": "Draft",
-            "pages": [
+              "seps/2260-Require-Server-requests-to-be-associated-with-Client-requests",
               "seps/2567-sessionless-mcp"
             ]
           },
@@ -468,8 +470,12 @@
           {
             "group": "Working Group Charters",
             "pages": [
+              "community/file-uploads/charter",
               "community/inspector-v2/charter",
+              "community/interceptors/charter",
+              "community/sdk/charter",
               "community/server-card/charter",
+              "community/skills-over-mcp/charter",
               "community/triggers-events/charter"
             ]
           },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -420,15 +420,15 @@
               "seps/2133-extensions",
               "seps/2148-contributor-ladder",
               "seps/2149-working-group-charter-template",
-              "seps/2243-http-standardization"
+              "seps/2243-http-standardization",
+              "seps/2567-sessionless-mcp"
             ]
           },
           {
             "group": "Accepted",
             "pages": [
               "seps/2207-oidc-refresh-token-guidance",
-              "seps/2260-Require-Server-requests-to-be-associated-with-Client-requests",
-              "seps/2567-sessionless-mcp"
+              "seps/2260-Require-Server-requests-to-be-associated-with-Client-requests"
             ]
           },
           {

--- a/docs/seps/2567-sessionless-mcp.mdx
+++ b/docs/seps/2567-sessionless-mcp.mdx
@@ -42,7 +42,7 @@ Under this proposal, a server that currently scopes a shopping cart (for example
 
 ### What sessions scope today
 
-The current spec is not fully precise about which behaviors are session-bound, but in practice five categories of things attach to a session's lifetime:
+The current spec is imprecise about which behaviors are session-bound, but in practice five categories of things attach to a session's lifetime:
 
 1. **Negotiated capabilities and protocol version.** The result of `initialize` — which protocol version is in use and which optional capabilities each side supports — is established once per session and assumed for its duration. [SEP-2575] resolves this by removing `initialize` and carrying version/capability information per-request, so this proposal treats it as already addressed.
 
@@ -50,7 +50,7 @@ The current spec is not fully precise about which behaviors are session-bound, b
 
 3. **Application state.** The canonical example is a shopping cart: `add_item()`, `add_item()`, `checkout()`, with the cart existing implicitly per-session. This generalizes to any stateful workflow — a Playwright browser instance, a database transaction, an open file descriptor.
 
-4. **Mutable list endpoints.** `tools/list` (and `resources/list`, `prompts/list`) can legally return different results over a session's lifetime. For example, a server could expose an `enable_admin_tools` tool that mutates what subsequent `tools/list` calls return.
+4. **Mutable list endpoints.** `tools/list` (and `resources/list`, `prompts/list`) can legally return different results over a session's lifetime. For example, a database server could expose a `connect_database` tool that, once called, makes `query` and `list_tables` appear in subsequent `tools/list` results.
 
 5. **Resource subscriptions.** Subscription lifetime is tied to session lifetime. ([SEP-2575] introduces `messages/listen` as the delivery channel for server-to-client notifications; subscription lifetime under that model is not re-examined here.)
 
@@ -177,7 +177,7 @@ With sessions removed, list endpoints no longer have a session to vary against. 
 
 How clients learn that a cached list has gone stale is the subject of [SEP-2549], which defines a server-advertised TTL on list responses and the interaction with `notifications/*/list_changed`. The two SEPs are complementary: this one removes the session as a source of variation, so there is a stable thing to cache; [SEP-2549] specifies how long to cache it and when to invalidate.
 
-One consequence of the constraint above is that servers can no longer mutate `tools/list` as a side effect of tool calls; the `enable_admin_tools()`-mutates-the-list pattern is no longer permitted. In practice this is rarely used. For the same effect, servers can expose all tools unconditionally at list time and enforce authorization at call time (which is already the common posture for auth-gated tools).
+One consequence of the constraint above is that servers can no longer mutate list results as a side effect of other requests; the pattern from the Motivation — where calling `connect_database()` makes `query` and `list_tables` appear in subsequent `tools/list` results — is no longer permitted. For the same effect, the server exposes `query` and `list_tables` unconditionally at list time and has them take a `connection_id` argument returned by `connect_database()`. A `query` call without a valid `connection_id` fails with an error directing the model to call `connect_database()` first; the dependency is expressed in the tool's input schema and description rather than in the list result.
 
 ### Consequential spec edits
 
@@ -249,7 +249,7 @@ The bolded rows are the repos that use the session ID for application semantics.
 
 This is a **breaking change** for servers that rely on protocol-level session state. The migration path depends on server category:
 
-**Stdio servers using process-lifetime state.** These are the most common stateful servers today and are not broken by this proposal in their default deployment: the process lifetime still exists, and a server that keeps a single in-memory browser instance per process continues to work with a stdio client that spawns one process. Stdio servers never had `Mcp-Session-Id`.
+**Stdio servers using process-lifetime state.** These are the most common stateful servers today. Mechanically they are not broken by this proposal in their default deployment — the process lifetime still exists, and a server that keeps a single in-memory browser instance per process continues to function with a stdio client that spawns one process. However, such servers SHOULD NOT rely on process-lifetime state and SHOULD migrate to explicit handles. Process lifetime has the same undefined-scope problem this SEP removes for HTTP (whether the process corresponds to one conversation, one application launch, or something else is up to the host), and a server that depends on it cannot offer equivalent behavior over HTTP, where there is no process per client. Stdio servers never had `Mcp-Session-Id`, so the header removal itself does not affect them.
 
 **HTTP servers using `Mcp-Session-Id`.** These are less common and must migrate to explicit handles. The migration is mechanical: replace the session-scoped state map with a handle-keyed state map, add a `create_*` tool, add the handle as a parameter to stateful tools.
 
@@ -282,3 +282,9 @@ This is guidance, not a protocol requirement, since the protocol has no handle c
 ## Reference Implementation
 
 All official SDKs except PHP already provide a stateless mode, implemented as not generating a session ID (e.g. `sessionIdGenerator: undefined` in the TypeScript SDK, `stateless_http=True` in the Python SDK). This SEP makes that mode the only option for servers speaking the new protocol version. SDKs that support multiple protocol versions retain the session-ID-generating code path for older versions; the change is that it is no longer reachable when the negotiated protocol version is the one this SEP introduces.
+
+## Future Work
+
+This SEP deliberately does not introduce a protocol-level concept of a handle: from the wire's perspective `basket_id` is an ordinary string. A consequence is that nothing marks `basket_id` as a state handle to the client or model — the relationship between `create_basket`'s output and `add_item`'s input is inferred from naming and tool descriptions, not declared.
+
+A follow-up proposal could make that relationship explicit, for example via shared JSON Schema `$defs` referenced across a server's tool input and output schemas, or via a tool annotation that marks a result field as a handle. That would let orchestrators identify which values are live state (for compaction, hand-off, or cleanup purposes) without parsing tool descriptions. It is left out of scope here to keep this SEP to the minimum needed to remove sessions.

--- a/docs/seps/2567-sessionless-mcp.mdx
+++ b/docs/seps/2567-sessionless-mcp.mdx
@@ -28,7 +28,7 @@ description: "Sessionless MCP via Explicit State Handles"
 
 ## Abstract
 
-This proposal removes the protocol-level session concept from MCP, replacing implicit session-scoped state with explicit, server-minted state handles that the model carries and threads through subsequent calls. [SEP-2575] makes sessions optional by defaulting to stateless operation; this proposal removes the opt-in as well.
+This proposal removes the protocol-level session concept from MCP, replacing implicit session-scoped state with explicit, server-minted state handles that the model carries and threads through subsequent calls. [SEP-2575] removes the `initialize` handshake and carries protocol version and capabilities per-request; this proposal is the complementary change that removes sessions and the `Mcp-Session-Id` header. Together they make MCP stateless at the protocol layer.
 
 After more than a year in the spec, sessions have not converged on a consistent meaning across clients: some scope them per tool call, some per application launch, some per page load, and almost none resume them. A server author cannot predict what scope or lifetime a session will have when their server is connected to an arbitrary client, which has made the session unreliable as a container for application state. This proposal holds that application state can be served by explicit identifiers, and that the session abstraction adds constraints (fixed cardinality, undefined lifetime, uncacheable list endpoints across session boundaries) without corresponding benefit.
 
@@ -52,13 +52,13 @@ The current spec is not fully precise about which behaviors are session-bound, b
 
 4. **Mutable list endpoints.** `tools/list` (and `resources/list`, `prompts/list`) can legally return different results over a session's lifetime. For example, a server could expose an `enable_admin_tools` tool that mutates what subsequent `tools/list` calls return.
 
-5. **Resource subscriptions.** Subscription lifetime is tied to session lifetime. ([SEP-2575] addresses this separately and it is not re-examined here.)
+5. **Resource subscriptions.** Subscription lifetime is tied to session lifetime. ([SEP-2575] introduces `messages/listen` as the delivery channel for server-to-client notifications; subscription lifetime under that model is not re-examined here.)
 
 With (1), (2), and (5) handled by other SEPs, this proposal addresses (3) and (4).
 
 ### Problems with session scoping
 
-The issues below apply whether sessions are mandatory (the current spec) or opt-in (the direction [SEP-2575] takes).
+The issues below apply whether sessions are mandatory (the current spec) or made optional.
 
 #### Session lifetime is undefined, and servers can't design around it
 
@@ -107,7 +107,7 @@ The same lack of an identifier also means session state is not addressable from 
 
 ### Summary of changes
 
-1. **Remove the session concept from the protocol.** The `Mcp-Session-Id` header is removed and the spec language describing session lifecycle and session-scoped behavior is deleted. The protocol is sessionless at every layer. (This supersedes the opt-in stateful path that [SEP-2575] retained.)
+1. **Remove the session concept from the protocol.** The `Mcp-Session-Id` header is removed and the spec language describing session lifecycle and session-scoped behavior is deleted. The protocol is sessionless at every layer. ([SEP-2575] removes the `initialize` handshake but explicitly defers session removal to this proposal.)
 
 2. **List endpoints are session-independent.** With no session, the results of `tools/list`, `resources/list`, and `prompts/list` have no per-session or per-connection scope to depend on. Lists can still change for other reasons (server deployment, auth changes); caching and invalidation mechanics for those are specified separately in [SEP-2549].
 
@@ -190,7 +190,7 @@ Two places in the current spec define behavior in terms of session scope and nee
 
 ### Why remove sessions rather than just default them off?
 
-[SEP-2575] already addresses making MCP work behind load balancers and without sticky routing. The reasons for going further are:
+[SEP-2575] already addresses making MCP work behind load balancers and without sticky routing by removing the `initialize` handshake. The reasons for also removing sessions, rather than retaining them as an opt-in capability, are:
 
 - **Opt-in sessions still prevent list caching.** A client cannot cache `tools/list` across session boundaries unless it knows the server does not opt into session-scoped mutation, and it cannot know that in advance. The client therefore re-fetches per session per server even though few servers opt in. The `O(subagents × servers)` cost from the Motivation section is caused by sessions being possible, not by sessions being used, so making them optional does not remove it.
 - **The primitive influences server design.** Offering session-scoped state in the spec leads server authors to use it for workflows that would be better served by explicit IDs.

--- a/docs/seps/2567-sessionless-mcp.mdx
+++ b/docs/seps/2567-sessionless-mcp.mdx
@@ -1,0 +1,284 @@
+---
+title: "SEP-2567: Sessionless MCP via Explicit State Handles"
+sidebarTitle: "SEP-2567: Sessionless MCP via Explicit State Hand…"
+description: "Sessionless MCP via Explicit State Handles"
+---
+
+<div className="flex items-center gap-2 mb-4">
+  <Badge color="gray" shape="pill">
+    Draft
+  </Badge>
+  <Badge color="gray" shape="pill">
+    Standards Track
+  </Badge>
+</div>
+
+| Field         | Value                                                                           |
+| ------------- | ------------------------------------------------------------------------------- |
+| **SEP**       | 2567                                                                            |
+| **Title**     | Sessionless MCP via Explicit State Handles                                      |
+| **Status**    | Draft                                                                           |
+| **Type**      | Standards Track                                                                 |
+| **Created**   | 2026-03-11                                                                      |
+| **Author(s)** | Peter Alexander ([@pja-ant](https://github.com/pja-ant))                        |
+| **Sponsor**   | Peter Alexander ([@pja-ant](https://github.com/pja-ant))                        |
+| **PR**        | [#2567](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567) |
+
+---
+
+## Abstract
+
+This proposal removes the protocol-level session concept from MCP, replacing implicit session-scoped state with explicit, server-minted state handles that the model carries and threads through subsequent calls. [SEP-1442] makes sessions optional by defaulting to stateless operation; this proposal removes the opt-in as well.
+
+After more than a year in the spec, sessions have not converged on a consistent meaning across clients: some scope them per tool call, some per application launch, some per page load, and almost none resume them. A server author cannot predict what scope or lifetime a session will have when their server is connected to an arbitrary client, which has made the session unreliable as a container for application state. This proposal holds that application state can be served by explicit identifiers, and that the session abstraction adds constraints (fixed cardinality, undefined lifetime, uncacheable list endpoints across session boundaries) without corresponding benefit.
+
+Under this proposal, a server that currently scopes a shopping cart (for example) to the session instead exposes a tool `create_basket()` that returns a `basket_id` and threads that ID through subsequent tool calls, e.g. `add_item(basket_id, ...)`. The model decides what is shared and what is isolated; list endpoints become cacheable across what used to be session boundaries; and agent orchestrators can freely share or not share application state as needed. Explicit state handles are not a new protocol construct — there is no schema or wire format for them. They are a tool-design pattern; the protocol change is the removal of sessions, which leaves handles as the way to express cross-call state.
+
+[SEP-1442]: https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1442
+[SEP-2322]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2322
+[SEP-2549]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549
+
+## Motivation
+
+### What sessions scope today
+
+The current spec is not fully precise about which behaviors are session-bound, but in practice five categories of things attach to a session's lifetime:
+
+1. **Negotiated capabilities and protocol version.** The result of `initialize` — which protocol version is in use and which optional capabilities each side supports — is established once per session and assumed for its duration. [SEP-1442] resolves this by removing `initialize` and carrying version/capability information per-request, so this proposal treats it as already addressed.
+
+2. **Elicitation and sampling intermediate state.** When a tool call triggers an `elicitation/create` or `sampling/createMessage` round-trip, the server has to correlate the eventual response with the original in-flight tool call — state that today lives implicitly in the session. [SEP-2322] (Multi Round-Trip Requests) resolves this by carrying the correlation state explicitly through the request/response cycle, so this proposal treats it as already addressed.
+
+3. **Application state.** The canonical example is a shopping cart: `add_item()`, `add_item()`, `checkout()`, with the cart existing implicitly per-session. This generalizes to any stateful workflow — a Playwright browser instance, a database transaction, an open file descriptor.
+
+4. **Mutable list endpoints.** `tools/list` (and `resources/list`, `prompts/list`) can legally return different results over a session's lifetime. For example, a server could expose an `enable_admin_tools` tool that mutates what subsequent `tools/list` calls return.
+
+5. **Resource subscriptions.** Subscription lifetime is tied to session lifetime. ([SEP-1442] addresses this separately and it is not re-examined here.)
+
+With (1), (2), and (5) handled by other SEPs, this proposal addresses (3) and (4).
+
+### Problems with session scoping
+
+The issues below apply whether sessions are mandatory (the current spec) or opt-in (the direction [SEP-1442] takes).
+
+#### Session lifetime is undefined, and servers can't design around it
+
+The spec does not say when a session begins or ends, because it depends on the host application. In practice, deployed clients vary widely and few scope sessions to a conversation: ChatGPT creates a fresh session for every individual tool call, and Claude.ai did the same until recently;[^per-call] most desktop and IDE clients create one at application launch and keep it for the process lifetime; web clients typically create one per page load. Almost no clients resume a prior session after a disconnect or restart, and on the server side the reference TypeScript SDK provides no public API for reconstructing a session on a different node, so multi-node deployments cannot honor resumption even when a client attempts it.[^ts-sdk-resume] A subagent might share its parent's session or get its own — there is no convention.
+
+[^per-call]: [microsoft/playwright-mcp#1045](https://github.com/microsoft/playwright-mcp/issues/1045), Sep 2025 — server author reports both ChatGPT and Claude.ai closing the session after each tool call, dropping browser state; ["Connector tool calls generating fresh MCP session each invocation"](https://community.openai.com/t/connector-tool-calls-generating-fresh-mcp-session-each-invocation/1364975), OpenAI Developer Community, Nov 2025.
+
+[^ts-sdk-resume]: [modelcontextprotocol/typescript-sdk#1658](https://github.com/modelcontextprotocol/typescript-sdk/issues/1658), Mar 2026 — `StreamableHTTPServerTransport` stores session state in private instance fields with no API to rehydrate from external storage.
+
+This matters because server authors are the ones deciding what to scope to the session, and they need to know what a session corresponds to in order to do that correctly. A Playwright server that ties a browser instance to the session needs to know whether that means one user turn, one agent process, or one long-lived chat. The spec does not specify this and different hosts give different answers, so the server is designing against an abstraction whose semantics it does not control.
+
+The practical consequence is that session-scoped application state often does not survive. Against a per-tool-call client it is destroyed before the next call; against a per-app-launch client it is shared across every conversation in the window and then lost on restart; against any client that does not resume, it is gone when the app restarts. Servers that appear to be using session state successfully are usually stdio servers relying on process lifetime, which is a property of the transport rather than the protocol.
+
+#### List endpoints cannot be cached across sessions
+
+Because `tools/list` may be session-dependent, a client cannot assume a result fetched in one session is valid in the next. Every new session must re-fetch, even when the server's tool set is fixed at build time and never changes, which is the common case.
+
+The Python SDK's own design issue for client-side list caching lists "what is the cache key — per-session or per-server-URL?" as an open question,[^py-sdk-cache] and gateway implementers have shipped per-session caching specifically because they could not assume cross-session validity from the spec.[^agentgateway-cache] Every list endpoint must be treated as potentially session-scoped, so each must be re-fetched per session to be safe.
+
+[^py-sdk-cache]: [modelcontextprotocol/python-sdk#2108](https://github.com/modelcontextprotocol/python-sdk/issues/2108), Feb 2026.
+
+[^agentgateway-cache]: [agentgateway/agentgateway#1510](https://github.com/agentgateway/agentgateway/issues/1510), Apr 2026.
+
+For hosts that regularly spawn subagents, this is a multiplier on the hot path. The possibility that a server is session-scoped forces `O(subagents × servers)` calls to `tools/list`: every subagent, for every server, every time, even if the underlying tool set has not changed since the orchestrator first connected. The client cannot skip the call because it cannot know in advance which servers are session-scoped. For an orchestrator spawning many short-lived subagents, this overhead can exceed the protocol traffic of the actual tool calls. Under this proposal the same workload is `O(servers)`: the orchestrator fetches each list once and every subagent reuses the cached result.
+
+If list endpoints were a function only of the server deployment and the authenticated principal, clients could cache them and invalidate on an explicit signal. [SEP-2549] specifies such a signal (a server-advertised TTL plus `notifications/*/list_changed`), but its caching model is only sound if the list does not also vary per session. Removing sessions makes that model safe; a subagent can then inherit its parent's cached lists at zero cost.
+
+#### Cardinality is fixed at one per session
+
+Session state has a cardinality of exactly one per session. The model gets one cart, one browser, one of whatever the server scopes to the session; it cannot have two, and it cannot have zero.
+
+This is a problem when different pieces of state need different scopes. Consider an orchestrator that spawns several subagents to independently research products to buy. The subagents should add to the same shopping cart (they are collaborating on one order) but each needs its own browser state (they are browsing different sites in parallel).
+
+No session boundary satisfies both:
+
+| Session model            | Cart (want: shared) | Browser (want: isolated) |
+| ------------------------ | :-----------------: | :----------------------: |
+| Subagents share parent's |      ✓ shared       |   ✗ shared (clobbers)    |
+| Subagents get their own  |     ✗ isolated      |        ✓ isolated        |
+
+With explicit IDs the orchestrator calls `create_basket()` once, passes the resulting `basket_id` to each subagent, and each subagent separately calls `create_browser()` for its own `browser_id`. The model decides what is shared and what is isolated per piece of state, rather than having one scope imposed on everything.
+
+The same lack of an identifier also means session state is not addressable from outside the session that created it. A cart created in one chat is invisible to another chat; if a user wants to resume work in a new conversation, hand something off to a different agent, or share state with a colleague, the session model provides nothing to refer to it by. An explicit `basket_id` can be passed to any of those.
+
+## Specification
+
+### Summary of changes
+
+1. **Remove the session concept from the protocol.** The `Mcp-Session-Id` header is removed and the spec language describing session lifecycle and session-scoped behavior is deleted. The protocol is sessionless at every layer. (This supersedes the opt-in stateful path that [SEP-1442] retained.)
+
+2. **List endpoints are session-independent.** With no session, the results of `tools/list`, `resources/list`, and `prompts/list` have no per-session or per-connection scope to depend on. Lists can still change for other reasons (server deployment, auth changes); caching and invalidation mechanics for those are specified separately in [SEP-2549].
+
+3. **Stateful workflows use explicit handles.** With sessions gone, servers that need to maintain state across tool calls do so by returning an identifier from a creation tool and accepting it as a parameter on subsequent calls.
+
+That third point is **not a protocol change**. There is no `handles/*` method, no handle type in the schema, no wire-level concept of a handle at all. From the protocol's perspective a handle is a string in a tool result and a string in a tool argument, indistinguishable from any other tool data. "Explicit state handles" is a tool-design pattern that the spec documents and recommends — in the same way it might document pagination or error-message conventions — not something it implements. The normative content of this SEP is the removal in (1); (2) follows from it, and (3) is the guidance that fills the gap.
+
+### Explicit state handles
+
+#### Pattern
+
+Where a server would previously have relied on implicit session-scoped state — `add_item` calls operating on a per-session cart — it instead exposes an explicit creation tool that returns a handle:
+
+```jsonc
+// → tools/call
+{ "name": "create_basket", "arguments": {} }
+
+// ← result
+{ "content": [{ "type": "text", "text": "Created basket bsk_a1b2c3" }],
+  "structuredContent": { "basket_id": "bsk_a1b2c3" } }
+```
+
+The model then threads that handle through subsequent calls as an ordinary argument:
+
+```jsonc
+// → tools/call
+{ "name": "add_item",
+  "arguments": { "basket_id": "bsk_a1b2c3", "sku": "shoes" } }
+
+// ← result
+{ "content": [{ "type": "text", "text": "Added shoes to bsk_a1b2c3 (1 item)" }] }
+
+// → tools/call
+{ "name": "checkout",
+  "arguments": { "basket_id": "bsk_a1b2c3" } }
+```
+
+Nothing here is a protocol extension: `basket_id` is an ordinary string field in `structuredContent` and an ordinary string argument to subsequent tools. This pattern is already the norm in widely-deployed remote MCP servers that manage durable resources:
+
+| Server (official, remote)                                   | Create tool → returned ID         | Operate tools taking that ID                                     |
+| ----------------------------------------------------------- | --------------------------------- | ---------------------------------------------------------------- |
+| [Linear](https://linear.app/docs/mcp)                       | `create_issue` → issue id         | `get_issue`, `update_issue`, `create_comment`                    |
+| [Notion](https://developers.notion.com/docs/mcp)            | `notion-create-pages` → page id   | `notion-update-page`, `notion-move-pages`                        |
+| [GitHub](https://github.com/github/github-mcp-server#tools) | `create_pull_request` → PR number | `pull_request_read`, `update_pull_request`, `merge_pull_request` |
+| [Stripe](https://docs.stripe.com/mcp)                       | `create_customer` → customer id   | `create_invoice`, `list_subscriptions`                           |
+
+The approach can be adopted for less-persistent objects (a browser context, an in-progress cart) by giving the created object a limited lifetime, and/or limiting its discoverability to the principal that created it. The server owns the state, the client holds a name for it, and authorization is checked on every call.
+
+#### Guidance for servers
+
+None of the following is normative. Handles are a tool-design pattern, not a protocol feature, and servers are free to shape them however fits their domain. The pattern works best when:
+
+- **Handles are opaque.** A handle that encodes internal structure (`cart_user42_2026-03-11`) invites clients to parse it or models to guess it; an opaque handle such as `bsk_a1b2c3` does not.
+- **Possession is not authorization (where auth exists).** For authenticated servers, validate `(handle, auth_context)` on every call; handles will end up in chat logs, copy-paste buffers, and subagent prompts. For unauthenticated servers, where the handle is necessarily a bearer token, generate it with at least 128 bits of cryptographically secure entropy and bound its lifetime. See [Security Implications](#security-implications).
+- **Durability is documented in the tool description.** Handles outlive connections by design, so "the state lasts until the connection closes" is no longer applicable. Put the policy in the `create_*` tool's description — "returns a basket_id; baskets expire after 24h idle" — so it is visible to the model when it decides to create state. A policy only in server documentation is not visible to the model.
+- **Expired handles return useful errors.** When a tool receives a handle for state that has expired or been destroyed, the error should say so — "basket `bsk_a1b2c3` has expired" rather than "invalid argument". A clear expiry error lets the model recover by calling `create_*` again; an opaque error typically leads to retries or failure.
+- **Creation takes parameters.** `create_context(cluster="staging")` is preferable to `create_context()` followed by `set_cluster(ctx, "staging")`: one round-trip instead of two, and the state cannot exist half-configured.
+- **Cleanup is available.** A `destroy_*(handle)` tool lets models release resources. A `list_*()` tool lets a model recover after losing track of what it created. Neither is required.
+
+#### Guidance for clients
+
+From the client's perspective, a handle is an ordinary string in a tool result. The main client responsibility is ensuring that string survives context compaction; if the conversation is summarized and the handle is in the discarded portion, the state is orphaned. Clients that track tool-call results across compaction boundaries handle this already.
+
+### Session-independent list endpoints
+
+With sessions removed, list endpoints no longer have a session to vary against. This is the only constraint this SEP places on `tools/list`, `resources/list`, and `prompts/list`: there is no longer a per-session or per-connection scope for their results to depend on. Lists can still change for other reasons — a server deploys a new version, a user's plan or granted scopes change — and this SEP does not enumerate or restrict those.
+
+How clients learn that a cached list has gone stale is the subject of [SEP-2549], which defines a server-advertised TTL on list responses and the interaction with `notifications/*/list_changed`. The two SEPs are complementary: this one removes the session as a source of variation, so there is a stable thing to cache; [SEP-2549] specifies how long to cache it and when to invalidate.
+
+One consequence of the constraint above is that servers can no longer mutate `tools/list` as a side effect of tool calls; the `enable_admin_tools()`-mutates-the-list pattern is no longer permitted. In practice this is rarely used. For the same effect, servers can expose all tools unconditionally at list time and enforce authorization at call time (which is already the common posture for auth-gated tools).
+
+### Consequential spec edits
+
+Two places in the current spec define behavior in terms of session scope and need re-scoping:
+
+- **JSON-RPC request ID uniqueness.** The spec currently requires that a request `id` "MUST NOT have been previously used by the requestor within the same session." The purpose of `id` is for the sender to correlate an incoming response with the request that produced it; the receiver only echoes it. With sessions removed, the constraint is re-scoped accordingly: a sender MUST NOT issue a request whose `id` matches that of another request it has sent and not yet received a response for. This is transport-agnostic, sufficient for correlation under every transport, and is what the TypeScript and Python SDKs already do via a monotonically increasing counter per client object. ([JSON-RPC 2.0 §4](https://www.jsonrpc.org/specification#request_object) itself imposes no uniqueness requirement — it only requires the receiver to echo the `id` — so this remains an MCP-level constraint.)
+- **Pagination cursor validity.** The spec currently advises clients not to "persist cursors across sessions." With sessions removed, this advice disappears. Cursor stability and snapshot consistency are outside the scope of this proposal.
+
+## Rationale
+
+### Why remove sessions rather than just default them off?
+
+[SEP-1442] already addresses making MCP work behind load balancers and without sticky routing. The reasons for going further are:
+
+- **Opt-in sessions still prevent list caching.** A client cannot cache `tools/list` across session boundaries unless it knows the server does not opt into session-scoped mutation, and it cannot know that in advance. The client therefore re-fetches per session per server even though few servers opt in. The `O(subagents × servers)` cost from the Motivation section is caused by sessions being possible, not by sessions being used, so making them optional does not remove it.
+- **The primitive influences server design.** Offering session-scoped state in the spec leads server authors to use it for workflows that would be better served by explicit IDs.
+- **Fewer primitives reduce implementation surface.** Every protocol concept must be implemented by SDK authors, documented, and learned by new users.
+
+### Expressiveness
+
+A session provides exactly one scope per connection. Explicit IDs provide as many scopes as the model creates, and each can be shared or isolated independently. Anything expressible with a session is expressible with a single ID the model creates at the start of the conversation; the converse does not hold.
+
+### Resumption
+
+Because handles appear in tool results, they are part of the chat transcript. Any client that persists its chats — which is most of them — therefore persists the handles automatically. Reopening a conversation after an app restart, a page reload, or on a different device puts the handle back in front of the model with no additional resumption machinery, and this behavior is consistent across clients. Session-based state, by contrast, requires the client to persist and resend `Mcp-Session-Id` out of band, which (as covered in the Motivation) almost no clients do.
+
+### Anticipated objections
+
+#### Garbage collection
+
+Sessions provide a lifecycle signal — when the session ends, state is freed. Without it, the model might forget to call `destroy_basket()`, and state leaks.
+
+However, sessions do not deliver this reliably in practice. As covered in the Motivation, real clients either never end the session (per-app-launch), end it constantly (per-tool-call), or end it at moments uncorrelated with the conversation (page reload, network blip). Stateless HTTP servers behind load balancers never see a connection-close. Servers already rely on TTL-based expiry today; the session boundary is not what performs cleanup.
+
+Explicit IDs with a documented durability policy ("baskets expire after 24h idle") is the same mechanism, made explicit.
+
+#### Models have to carry the IDs forward
+
+With implicit session state, the server tracks the identifier; with explicit IDs, the model is responsible for threading `basket_abc123` through every relevant call. The failure modes are hallucinating a slightly-wrong ID, or the ID falling out of context when the conversation is compacted.
+
+Models already carry opaque identifiers through conversations routinely — file paths, URLs, commit hashes, PR numbers, UUIDs returned from prior tool calls — and current models do this reliably. Compaction is the harder case, but it affects any long-horizon state: if the compactor drops live tool-call results, the model loses track of what is in the session-scoped cart as well, not just the cart's ID.
+
+#### IDs in chat history
+
+A `basket_id` that can be pasted anywhere could become an unauthenticated capability in the user's chat log.
+
+For authenticated servers, the ID should be a name, with the server checking `(id, auth_context)` on every call. Google Doc IDs sit in URLs and browser history; access is controlled by ACL, not ID secrecy. The same applies here.
+
+For servers without authentication, the ID is necessarily a bearer token — possession is the only thing the server can check. In that case the handle should follow standard practice for unguessable capability tokens: generated from a cryptographically secure random source with at least 128 bits of entropy (e.g. UUIDv4, or 22+ characters of URL-safe base64), never derived from predictable inputs, and given a bounded lifetime. This is the same posture as other ephemeral public IDs in common use — "anyone with the link" share URLs, password-reset tokens, Stripe Checkout session IDs — and carries the same tradeoff: convenient, but anyone who obtains the token has access for its lifetime.
+
+#### Breaking change
+
+Sessions are in the spec today; removing them breaks anyone relying on them.
+
+An automated survey of a 1000-repo random sample of open source MCP servers (classified by per-repo LLM analysis) found:
+
+| Category                                                      | Share | Migration                                            |
+| ------------------------------------------------------------- | ----: | ---------------------------------------------------- |
+| No application-level reference to MCP session ID              | 90.0% | None                                                 |
+| `Map<sessionId, Transport>` routing (TS SDK boilerplate)      |  3.5% | Removed by a sessionless SDK transport               |
+| Transport setup only (`sessionIdGenerator`, never read)       |  2.8% | Delete one constructor option                        |
+| **Session-keyed application state**                           |  2.5% | Migrate to explicit handles or auth principal        |
+| **Proxy / gateway sticky routing**                            |  0.7% | Needs designed replacement                           |
+| **Auth binding** (JWT claims, PKCE verifier keyed on session) |  0.5% | Replace with server-generated nonce or token subject |
+
+The bolded rows are the repos that use the session ID for application semantics. The hardest-hit category — gateways that spawn one upstream per session — needs a designed replacement rather than a mechanical edit; see [Backward Compatibility](#backward-compatibility).
+
+## Backward Compatibility
+
+This is a **breaking change** for servers that rely on protocol-level session state. The migration path depends on server category:
+
+**Stdio servers using process-lifetime state.** These are the most common stateful servers today and are not broken by this proposal in their default deployment: the process lifetime still exists, and a server that keeps a single in-memory browser instance per process continues to work with a stdio client that spawns one process. Stdio servers never had `Mcp-Session-Id`.
+
+**HTTP servers using `Mcp-Session-Id`.** These are less common and must migrate to explicit handles. The migration is mechanical: replace the session-scoped state map with a handle-keyed state map, add a `create_*` tool, add the handle as a parameter to stateful tools.
+
+**Servers using session ID as a telemetry key.** Some servers tag traces, logs, or rate-limit buckets with the session ID to correlate activity within a session. This already worked inconsistently across clients — against per-tool-call clients every event lands in its own bucket, and against clients that don't resume the correlation breaks at every restart. These use cases need to move to a different scoping mechanism, typically the authenticated principal (bearer token subject, API key) or a request-level correlation ID.
+
+**Proxies and gateways using session ID for sticky routing.** Gateways that route by `Mcp-Session-Id` lose their routing key — but they only needed one because their upstreams were stateful. If the upstream is stateless (or migrates to explicit handles, where the state key is in the tool arguments and any replica can serve it from shared storage), the gateway needs no sticky routing at all. The residual case is gateways that bridge HTTP to stdio by spawning one subprocess per session; those need a different correlation key, which is a transport-layer concern (route by authenticated principal, or a cookie / gateway-issued header) rather than something this SEP defines.
+
+**Servers binding auth artifacts to session ID.** A small number of servers store OAuth PKCE verifiers, session→user pinning maps, or JWT claims keyed on the session ID. In the PKCE case the server is already passing a correlation value through the OAuth `state` parameter (the browser callback is not an MCP request and never carried `Mcp-Session-Id`), so the change is to put a server-generated nonce in `state` instead of the session ID. Session→user pinning was a defense against the session-routing/auth decoupling described in [Security Implications](#security-implications) and is not needed once every request is independently authenticated. The migration is mostly mechanical, though worth a review since auth code is involved.
+
+**Clients.** Clients become simpler: they no longer track or resend session identifiers, or need to determine whether a given server is stateful. List-endpoint caching becomes safe.
+
+Rollout is a clean break: sessions are removed in the next spec version, with no deprecation window. Servers that currently rely on session-scoped state stay on the current protocol version until they have migrated to explicit handles. Protocol version negotiation already handles mixed-version deployments — a client that supports both versions speaks the old protocol to an unmigrated server and the new one to everyone else. This avoids shipping a version where clients support both modes simultaneously, which would prevent the caching benefit (a client cannot cache list endpoints if any connected server might be session-scoped).
+
+## Security Implications
+
+### Handle exposure
+
+The main security consideration introduced by this SEP is that handles will end up in places session IDs did not — chat logs, subagent prompts, copy-paste buffers, potentially other users' screens.
+
+This is a change in exposure surface, not a new class of vulnerability. Session IDs are already capability-bearing in practice: the Python SDK's stateful session manager, for example, routes by `Mcp-Session-Id` alone without verifying that the authenticated identity on the request matches the one that created the session, so a leaked session ID allows hijack by any other authenticated principal.[^py-sdk-hijack] The "validate `(id, auth_context)` on every call" guidance below applies equally to today's session IDs and to explicit handles; this SEP makes the requirement more visible because handles are more visible.
+
+[^py-sdk-hijack]: [modelcontextprotocol/python-sdk#2100](https://github.com/modelcontextprotocol/python-sdk/issues/2100).
+
+For authenticated servers, the recommended posture is the same one Google Doc IDs and GitHub PR numbers take: the ID identifies the resource, and the auth context on the request determines access. Servers that validate `(handle, auth_context)` on every call are unaffected by handle exposure.
+
+For unauthenticated servers there is no auth context to check, so the handle is a capability token. These should be generated with at least 128 bits of cryptographically secure entropy, never derived from predictable inputs, and given a bounded lifetime — the same practice as "anyone with the link" share URLs or password-reset tokens. Exposure of such a handle grants access for its lifetime; servers should size that lifetime accordingly.
+
+This is guidance, not a protocol requirement, since the protocol has no handle concept to enforce against.
+
+## Reference Implementation
+
+All official SDKs except PHP already provide a stateless mode, implemented as not generating a session ID (e.g. `sessionIdGenerator: undefined` in the TypeScript SDK, `stateless_http=True` in the Python SDK). This SEP makes that mode the only option for servers speaking the new protocol version. SDKs that support multiple protocol versions retain the session-ID-generating code path for older versions; the change is that it is no longer reachable when the negotiated protocol version is the one this SEP introduces.

--- a/docs/seps/2567-sessionless-mcp.mdx
+++ b/docs/seps/2567-sessionless-mcp.mdx
@@ -28,13 +28,13 @@ description: "Sessionless MCP via Explicit State Handles"
 
 ## Abstract
 
-This proposal removes the protocol-level session concept from MCP, replacing implicit session-scoped state with explicit, server-minted state handles that the model carries and threads through subsequent calls. [SEP-1442] makes sessions optional by defaulting to stateless operation; this proposal removes the opt-in as well.
+This proposal removes the protocol-level session concept from MCP, replacing implicit session-scoped state with explicit, server-minted state handles that the model carries and threads through subsequent calls. [SEP-2575] makes sessions optional by defaulting to stateless operation; this proposal removes the opt-in as well.
 
 After more than a year in the spec, sessions have not converged on a consistent meaning across clients: some scope them per tool call, some per application launch, some per page load, and almost none resume them. A server author cannot predict what scope or lifetime a session will have when their server is connected to an arbitrary client, which has made the session unreliable as a container for application state. This proposal holds that application state can be served by explicit identifiers, and that the session abstraction adds constraints (fixed cardinality, undefined lifetime, uncacheable list endpoints across session boundaries) without corresponding benefit.
 
 Under this proposal, a server that currently scopes a shopping cart (for example) to the session instead exposes a tool `create_basket()` that returns a `basket_id` and threads that ID through subsequent tool calls, e.g. `add_item(basket_id, ...)`. The model decides what is shared and what is isolated; list endpoints become cacheable across what used to be session boundaries; and agent orchestrators can freely share or not share application state as needed. Explicit state handles are not a new protocol construct — there is no schema or wire format for them. They are a tool-design pattern; the protocol change is the removal of sessions, which leaves handles as the way to express cross-call state.
 
-[SEP-1442]: https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1442
+[SEP-2575]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2575
 [SEP-2322]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2322
 [SEP-2549]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549
 
@@ -44,7 +44,7 @@ Under this proposal, a server that currently scopes a shopping cart (for example
 
 The current spec is not fully precise about which behaviors are session-bound, but in practice five categories of things attach to a session's lifetime:
 
-1. **Negotiated capabilities and protocol version.** The result of `initialize` — which protocol version is in use and which optional capabilities each side supports — is established once per session and assumed for its duration. [SEP-1442] resolves this by removing `initialize` and carrying version/capability information per-request, so this proposal treats it as already addressed.
+1. **Negotiated capabilities and protocol version.** The result of `initialize` — which protocol version is in use and which optional capabilities each side supports — is established once per session and assumed for its duration. [SEP-2575] resolves this by removing `initialize` and carrying version/capability information per-request, so this proposal treats it as already addressed.
 
 2. **Elicitation and sampling intermediate state.** When a tool call triggers an `elicitation/create` or `sampling/createMessage` round-trip, the server has to correlate the eventual response with the original in-flight tool call — state that today lives implicitly in the session. [SEP-2322] (Multi Round-Trip Requests) resolves this by carrying the correlation state explicitly through the request/response cycle, so this proposal treats it as already addressed.
 
@@ -52,13 +52,13 @@ The current spec is not fully precise about which behaviors are session-bound, b
 
 4. **Mutable list endpoints.** `tools/list` (and `resources/list`, `prompts/list`) can legally return different results over a session's lifetime. For example, a server could expose an `enable_admin_tools` tool that mutates what subsequent `tools/list` calls return.
 
-5. **Resource subscriptions.** Subscription lifetime is tied to session lifetime. ([SEP-1442] addresses this separately and it is not re-examined here.)
+5. **Resource subscriptions.** Subscription lifetime is tied to session lifetime. ([SEP-2575] addresses this separately and it is not re-examined here.)
 
 With (1), (2), and (5) handled by other SEPs, this proposal addresses (3) and (4).
 
 ### Problems with session scoping
 
-The issues below apply whether sessions are mandatory (the current spec) or opt-in (the direction [SEP-1442] takes).
+The issues below apply whether sessions are mandatory (the current spec) or opt-in (the direction [SEP-2575] takes).
 
 #### Session lifetime is undefined, and servers can't design around it
 
@@ -107,7 +107,7 @@ The same lack of an identifier also means session state is not addressable from 
 
 ### Summary of changes
 
-1. **Remove the session concept from the protocol.** The `Mcp-Session-Id` header is removed and the spec language describing session lifecycle and session-scoped behavior is deleted. The protocol is sessionless at every layer. (This supersedes the opt-in stateful path that [SEP-1442] retained.)
+1. **Remove the session concept from the protocol.** The `Mcp-Session-Id` header is removed and the spec language describing session lifecycle and session-scoped behavior is deleted. The protocol is sessionless at every layer. (This supersedes the opt-in stateful path that [SEP-2575] retained.)
 
 2. **List endpoints are session-independent.** With no session, the results of `tools/list`, `resources/list`, and `prompts/list` have no per-session or per-connection scope to depend on. Lists can still change for other reasons (server deployment, auth changes); caching and invalidation mechanics for those are specified separately in [SEP-2549].
 
@@ -190,7 +190,7 @@ Two places in the current spec define behavior in terms of session scope and nee
 
 ### Why remove sessions rather than just default them off?
 
-[SEP-1442] already addresses making MCP work behind load balancers and without sticky routing. The reasons for going further are:
+[SEP-2575] already addresses making MCP work behind load balancers and without sticky routing. The reasons for going further are:
 
 - **Opt-in sessions still prevent list caching.** A client cannot cache `tools/list` across session boundaries unless it knows the server does not opt into session-scoped mutation, and it cannot know that in advance. The client therefore re-fetches per session per server even though few servers opt in. The `O(subagents × servers)` cost from the Motivation section is caused by sessions being possible, not by sessions being used, so making them optional does not remove it.
 - **The primitive influences server design.** Offering session-scoped state in the spec leads server authors to use it for workflows that would be better served by explicit IDs.

--- a/docs/seps/2567-sessionless-mcp.mdx
+++ b/docs/seps/2567-sessionless-mcp.mdx
@@ -181,10 +181,13 @@ One consequence of the constraint above is that servers can no longer mutate lis
 
 ### Consequential spec edits
 
-Two places in the current spec define behavior in terms of session scope and need re-scoping:
+Beyond removing the §Session Management section itself, several other places in the current spec define behavior in terms of session scope and need re-scoping:
 
 - **JSON-RPC request ID uniqueness.** The spec currently requires that a request `id` "MUST NOT have been previously used by the requestor within the same session." The purpose of `id` is for the sender to correlate an incoming response with the request that produced it; the receiver only echoes it. With sessions removed, the constraint is re-scoped accordingly: a sender MUST NOT issue a request whose `id` matches that of another request it has sent and not yet received a response for. This is transport-agnostic, sufficient for correlation under every transport, and is what the TypeScript and Python SDKs already do via a monotonically increasing counter per client object. ([JSON-RPC 2.0 §4](https://www.jsonrpc.org/specification#request_object) itself imposes no uniqueness requirement — it only requires the receiver to echo the `id` — so this remains an MCP-level constraint.)
+- **SSE event ID uniqueness.** The spec currently scopes SSE event IDs as "globally unique across all streams within that session." With sessions removed, the constraint is simply that the ID is globally unique across all streams the server manages, so that a `Last-Event-ID` resolves to a single stream. The existing guidance that event IDs encode the originating stream already implies this.
 - **Pagination cursor validity.** The spec currently advises clients not to "persist cursors across sessions." With sessions removed, this advice disappears. Cursor stability and snapshot consistency are outside the scope of this proposal.
+- **List-endpoint variability.** The `tools/list`, `resources/list`, and `prompts/list` pages each say results "MAY change over the lifetime of the connection." These are re-scoped per [§Session-independent list endpoints](#session-independent-list-endpoints): results MAY change over time but MUST NOT vary per-connection or as a side effect of other requests on the connection.
+- **Wording.** A handful of phrases that use "session" descriptively — "stateful session protocol" in the architecture overview, "available during the session" in capability negotiation, "same logical session" in authorization, the elicitation prohibition on associating state "with session IDs alone," and similar — are reworded or removed. These carry no semantic change beyond the session removal itself.
 
 ## Rationale
 

--- a/docs/seps/2567-sessionless-mcp.mdx
+++ b/docs/seps/2567-sessionless-mcp.mdx
@@ -5,8 +5,8 @@ description: "Sessionless MCP via Explicit State Handles"
 ---
 
 <div className="flex items-center gap-2 mb-4">
-  <Badge color="gray" shape="pill">
-    Draft
+  <Badge color="blue" shape="pill">
+    Accepted
   </Badge>
   <Badge color="gray" shape="pill">
     Standards Track
@@ -17,7 +17,7 @@ description: "Sessionless MCP via Explicit State Handles"
 | ------------- | ------------------------------------------------------------------------------- |
 | **SEP**       | 2567                                                                            |
 | **Title**     | Sessionless MCP via Explicit State Handles                                      |
-| **Status**    | Draft                                                                           |
+| **Status**    | Accepted                                                                        |
 | **Type**      | Standards Track                                                                 |
 | **Created**   | 2026-03-11                                                                      |
 | **Author(s)** | Peter Alexander ([@pja-ant](https://github.com/pja-ant))                        |

--- a/docs/seps/2567-sessionless-mcp.mdx
+++ b/docs/seps/2567-sessionless-mcp.mdx
@@ -5,8 +5,8 @@ description: "Sessionless MCP via Explicit State Handles"
 ---
 
 <div className="flex items-center gap-2 mb-4">
-  <Badge color="blue" shape="pill">
-    Accepted
+  <Badge color="green" shape="pill">
+    Final
   </Badge>
   <Badge color="gray" shape="pill">
     Standards Track
@@ -17,7 +17,7 @@ description: "Sessionless MCP via Explicit State Handles"
 | ------------- | ------------------------------------------------------------------------------- |
 | **SEP**       | 2567                                                                            |
 | **Title**     | Sessionless MCP via Explicit State Handles                                      |
-| **Status**    | Accepted                                                                        |
+| **Status**    | Final                                                                           |
 | **Type**      | Standards Track                                                                 |
 | **Created**   | 2026-03-11                                                                      |
 | **Author(s)** | Peter Alexander ([@pja-ant](https://github.com/pja-ant))                        |

--- a/docs/seps/2567-sessionless-mcp.mdx
+++ b/docs/seps/2567-sessionless-mcp.mdx
@@ -173,7 +173,7 @@ From the client's perspective, a handle is an ordinary string in a tool result. 
 
 ### Session-independent list endpoints
 
-With sessions removed, list endpoints no longer have a session to vary against. This is the only constraint this SEP places on `tools/list`, `resources/list`, and `prompts/list`: there is no longer a per-session or per-connection scope for their results to depend on. Lists can still change for other reasons — a server deploys a new version, a user's plan or granted scopes change — and this SEP does not enumerate or restrict those.
+With sessions removed, list endpoints no longer have a session to vary against. This is the only constraint this SEP places on `tools/list`, `resources/list`, and `prompts/list`: there is no longer a per-session or per-connection scope for their results to depend on. This does not preclude varying the list by the authorization presented on the request: credentials are carried on each request, so a server returning different tool sets to different principals or scopes is relying on per-request input, not connection state. Lists can also still change over time for other reasons — a server deploys a new version, a user's plan or granted scopes change — and this SEP does not enumerate or restrict those.
 
 How clients learn that a cached list has gone stale is the subject of [SEP-2549], which defines a server-advertised TTL on list responses and the interaction with `notifications/*/list_changed`. The two SEPs are complementary: this one removes the session as a source of variation, so there is a stable thing to cache; [SEP-2549] specifies how long to cache it and when to invalidate.
 

--- a/docs/seps/index.mdx
+++ b/docs/seps/index.mdx
@@ -12,6 +12,7 @@ Specification Enhancement Proposals (SEPs) are the primary mechanism for proposi
 
 ## Summary
 
+- **Draft**: 1
 - **Approved**: 1
 - **Accepted**: 2
 - **Final**: 28
@@ -20,6 +21,7 @@ Specification Enhancement Proposals (SEPs) are the primary mechanism for proposi
 
 | SEP                                                                                  | Title                                                                         | Status                                            | Type             | Created    |
 | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- | ------------------------------------------------- | ---------------- | ---------- |
+| [SEP-2567](/seps/2567-sessionless-mcp)                                               | Sessionless MCP via Explicit State Handles                                    | <Badge color="gray" shape="pill">Draft</Badge>    | Standards Track  | 2026-03-11 |
 | [SEP-2322](/seps/2322-MRTR)                                                          | Multi Round-Trip Requests                                                     | <Badge color="gray" shape="pill">Approved</Badge> | Standards Track  | 2026-02-03 |
 | [SEP-2260](/seps/2260-Require-Server-requests-to-be-associated-with-Client-requests) | Require Server requests to be associated with a Client request.               | <Badge color="blue" shape="pill">Accepted</Badge> | Standards Track  | 2026-02-16 |
 | [SEP-2243](/seps/2243-http-standardization)                                          | HTTP Header Standardization for Streamable HTTP Transport                     | <Badge color="green" shape="pill">Final</Badge>   | Standards Track  | 2026-02-04 |

--- a/docs/seps/index.mdx
+++ b/docs/seps/index.mdx
@@ -12,15 +12,15 @@ Specification Enhancement Proposals (SEPs) are the primary mechanism for proposi
 
 ## Summary
 
-- **Accepted**: 3
+- **Final**: 29
 - **Approved**: 1
-- **Final**: 28
+- **Accepted**: 2
 
 ## All SEPs
 
 | SEP                                                                                  | Title                                                                         | Status                                            | Type             | Created    |
 | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- | ------------------------------------------------- | ---------------- | ---------- |
-| [SEP-2567](/seps/2567-sessionless-mcp)                                               | Sessionless MCP via Explicit State Handles                                    | <Badge color="blue" shape="pill">Accepted</Badge> | Standards Track  | 2026-03-11 |
+| [SEP-2567](/seps/2567-sessionless-mcp)                                               | Sessionless MCP via Explicit State Handles                                    | <Badge color="green" shape="pill">Final</Badge>   | Standards Track  | 2026-03-11 |
 | [SEP-2322](/seps/2322-MRTR)                                                          | Multi Round-Trip Requests                                                     | <Badge color="gray" shape="pill">Approved</Badge> | Standards Track  | 2026-02-03 |
 | [SEP-2260](/seps/2260-Require-Server-requests-to-be-associated-with-Client-requests) | Require Server requests to be associated with a Client request.               | <Badge color="blue" shape="pill">Accepted</Badge> | Standards Track  | 2026-02-16 |
 | [SEP-2243](/seps/2243-http-standardization)                                          | HTTP Header Standardization for Streamable HTTP Transport                     | <Badge color="green" shape="pill">Final</Badge>   | Standards Track  | 2026-02-04 |

--- a/docs/seps/index.mdx
+++ b/docs/seps/index.mdx
@@ -12,16 +12,15 @@ Specification Enhancement Proposals (SEPs) are the primary mechanism for proposi
 
 ## Summary
 
-- **Draft**: 1
+- **Accepted**: 3
 - **Approved**: 1
-- **Accepted**: 2
 - **Final**: 28
 
 ## All SEPs
 
 | SEP                                                                                  | Title                                                                         | Status                                            | Type             | Created    |
 | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- | ------------------------------------------------- | ---------------- | ---------- |
-| [SEP-2567](/seps/2567-sessionless-mcp)                                               | Sessionless MCP via Explicit State Handles                                    | <Badge color="gray" shape="pill">Draft</Badge>    | Standards Track  | 2026-03-11 |
+| [SEP-2567](/seps/2567-sessionless-mcp)                                               | Sessionless MCP via Explicit State Handles                                    | <Badge color="blue" shape="pill">Accepted</Badge> | Standards Track  | 2026-03-11 |
 | [SEP-2322](/seps/2322-MRTR)                                                          | Multi Round-Trip Requests                                                     | <Badge color="gray" shape="pill">Approved</Badge> | Standards Track  | 2026-02-03 |
 | [SEP-2260](/seps/2260-Require-Server-requests-to-be-associated-with-Client-requests) | Require Server requests to be associated with a Client request.               | <Badge color="blue" shape="pill">Accepted</Badge> | Standards Track  | 2026-02-16 |
 | [SEP-2243](/seps/2243-http-standardization)                                          | HTTP Header Standardization for Streamable HTTP Transport                     | <Badge color="green" shape="pill">Final</Badge>   | Standards Track  | 2026-02-04 |

--- a/docs/specification/draft/architecture/index.mdx
+++ b/docs/specification/draft/architecture/index.mdx
@@ -7,8 +7,8 @@ title: Architecture
 The Model Context Protocol (MCP) follows a client-host-server architecture where each
 host can run multiple client instances. This architecture enables users to integrate AI
 capabilities across applications while maintaining clear security boundaries and
-isolating concerns. Built on JSON-RPC, MCP provides a stateful session protocol focused
-on context exchange and sampling coordination between clients and servers.
+isolating concerns. Built on JSON-RPC, MCP provides a protocol focused on context
+exchange and sampling coordination between clients and servers.
 
 ## Core Components
 
@@ -60,7 +60,7 @@ The host process acts as the container and coordinator:
 
 Each client is created by the host and maintains an isolated server connection:
 
-- Establishes one stateful session per server
+- Establishes one connection per server
 - Handles protocol negotiation and capability exchange
 - Routes protocol messages bidirectionally
 - Manages subscriptions and notifications
@@ -115,12 +115,12 @@ implementation:
 
 The Model Context Protocol uses a capability-based negotiation system where clients and
 servers explicitly declare their supported features during initialization. Capabilities
-determine which protocol features and primitives are available during a session.
+determine which protocol features and primitives are available during a connection.
 
 - Servers declare capabilities like resource subscriptions, tool support, and prompt
   templates
 - Clients declare capabilities like sampling support and notification handling
-- Both parties must respect declared capabilities throughout the session
+- Both parties must respect declared capabilities throughout the connection
 - Additional capabilities can be negotiated through extensions to the protocol
 
 ```mermaid
@@ -130,10 +130,10 @@ sequenceDiagram
     participant Server
 
     Host->>+Client: Initialize client
-    Client->>+Server: Initialize session with capabilities
+    Client->>+Server: Initialize with capabilities
     Server-->>Client: Respond with supported capabilities
 
-    Note over Host,Server: Active Session with Negotiated Features
+    Note over Host,Server: Active Connection with Negotiated Features
 
     loop Client Requests
         Host->>Client: User- or model-initiated action
@@ -155,11 +155,11 @@ sequenceDiagram
     end
 
     Host->>Client: Terminate
-    Client->>-Server: End session
+    Client->>-Server: End connection
     deactivate Server
 ```
 
-Each capability unlocks specific protocol features for use during the session. For
+Each capability unlocks specific protocol features for use during the connection. For
 example:
 
 - Implemented [server features](/specification/draft/server) must be advertised in the

--- a/docs/specification/draft/basic/authorization.mdx
+++ b/docs/specification/draft/basic/authorization.mdx
@@ -539,8 +539,7 @@ Specifically:
 Authorization: Bearer <access-token>
 ```
 
-Note that authorization **MUST** be included in every HTTP request from client to server,
-even if they are part of the same logical session.
+Note that authorization **MUST** be included in every HTTP request from client to server.
 
 2. Access tokens **MUST NOT** be included in the URI query string
 

--- a/docs/specification/draft/basic/index.mdx
+++ b/docs/specification/draft/basic/index.mdx
@@ -7,8 +7,7 @@ title: Overview
 The Model Context Protocol consists of several key components that work together:
 
 - **Base Protocol**: Core JSON-RPC message types
-- **Lifecycle Management**: Connection initialization, capability negotiation, and
-  session control
+- **Lifecycle Management**: Connection initialization and capability negotiation
 - **Authorization**: Authentication and authorization framework for HTTP-based transports
 - **Server Features**: Resources, prompts, and tools exposed by servers
 - **Client Features**: Sampling and root directory lists provided by clients
@@ -45,8 +44,8 @@ these types of messages:
 
 - Requests **MUST** include a string or integer ID.
 - Unlike base JSON-RPC, the ID **MUST NOT** be `null`.
-- The request ID **MUST NOT** have been previously used by the requestor within the same
-  session.
+- The request ID **MUST NOT** match the ID of any other request the sender has issued and
+  not yet received a response for.
 
 ### Responses
 

--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -189,7 +189,7 @@ For details, see [the Protocol Version Header section in Transports](/specificat
 #### Capability Negotiation
 
 Client and server capabilities establish which optional protocol features will be
-available during the session.
+available during the connection.
 
 Key capabilities include:
 

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -121,8 +121,6 @@ MCP endpoint.
    - The server **MAY** send JSON-RPC _requests_ and _notifications_ before sending the
      JSON-RPC _response_. These messages **MUST** relate to the originating client
      _request_.
-   - The server **MAY** terminate the SSE stream if the [session](#session-management)
-     expires.
    - After the JSON-RPC _response_ has been sent, the server **SHOULD** terminate the
      SSE stream.
    - Disconnection **MAY** occur at any time (e.g., due to network conditions).
@@ -174,9 +172,7 @@ lost:
 
 1. Servers **MAY** attach an `id` field to their SSE events, as described in the
    [SSE standard](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation).
-   - If present, the ID **MUST** be globally unique across all streams within that
-     [session](#session-management)—or all streams with that specific client, if session
-     management is not in use.
+   - If present, the ID **MUST** be globally unique across all streams.
    - Event IDs **SHOULD** encode sufficient information to identify the originating
      stream, enabling the server to correlate a `Last-Event-ID` to the correct stream.
 2. If the client wishes to resume after a disconnection (whether due to network failure
@@ -195,38 +191,6 @@ lost:
 In other words, these event IDs should be assigned by servers on a _per-stream_ basis, to
 act as a cursor within that particular stream.
 
-### Session Management
-
-An MCP "session" consists of logically related interactions between a client and a
-server, beginning with the [initialization phase](/specification/draft/basic/lifecycle). To support
-servers which want to establish stateful sessions:
-
-1. A server using the Streamable HTTP transport **MAY** assign a session ID at
-   initialization time, by including it in an `MCP-Session-Id` header on the HTTP
-   response containing the `InitializeResult`.
-   - The session ID **SHOULD** be globally unique and cryptographically secure (e.g., a
-     securely generated UUID, a JWT, or a cryptographic hash).
-   - The session ID **MUST** only contain visible ASCII characters (ranging from 0x21 to
-     0x7E).
-   - The client **MUST** handle the session ID in a secure manner, see [Session Hijacking mitigations](/specification/draft/basic/security_best_practices#session-hijacking) for more details.
-2. If an `MCP-Session-Id` is returned by the server during initialization, clients using
-   the Streamable HTTP transport **MUST** include it in the `MCP-Session-Id` header on
-   all of their subsequent HTTP requests.
-   - Servers that require a session ID **SHOULD** respond to requests without an
-     `MCP-Session-Id` header (other than initialization) with HTTP 400 Bad Request.
-3. The server **MAY** terminate the session at any time, after which it **MUST** respond
-   to requests containing that session ID with HTTP 404 Not Found.
-4. When a client receives HTTP 404 in response to a request containing an
-   `MCP-Session-Id`, it **MUST** start a new session by sending a new `InitializeRequest`
-   without a session ID attached.
-5. Clients that no longer need a particular session (e.g., because the user is leaving
-   the client application) **SHOULD** send an HTTP DELETE to the MCP endpoint with the
-   `MCP-Session-Id` header, to explicitly terminate the session.
-   - The server **MAY** respond to this request with HTTP 405 Method Not Allowed,
-     indicating that the server does not allow clients to terminate sessions. If the
-     server returns HTTP 405, it **MUST** include an `Allow` header listing the methods
-     it does support.
-
 ### Sequence Diagram
 
 ```mermaid
@@ -237,13 +201,13 @@ sequenceDiagram
     note over Client, Server: initialization
 
     Client->>+Server: POST InitializeRequest
-    Server->>-Client: InitializeResponse<br>MCP-Session-Id: 1868a90c...
+    Server->>-Client: InitializeResponse
 
-    Client->>+Server: POST InitializedNotification<br>MCP-Session-Id: 1868a90c...
+    Client->>+Server: POST InitializedNotification
     Server->>-Client: 202 Accepted
 
     note over Client, Server: client requests
-    Client->>+Server: POST ... request ...<br>MCP-Session-Id: 1868a90c...
+    Client->>+Server: POST ... request ...
 
     alt single HTTP response
       Server->>Client: ... response ...
@@ -256,11 +220,11 @@ sequenceDiagram
     deactivate Server
 
     note over Client, Server: client notifications/responses
-    Client->>+Server: POST ... notification/response ...<br>MCP-Session-Id: 1868a90c...
+    Client->>+Server: POST ... notification/response ...
     Server->>-Client: 202 Accepted
 
     note over Client, Server: server requests
-    Client->>+Server: GET<br>MCP-Session-Id: 1868a90c...
+    Client->>+Server: GET
     loop while connection remains open
         Server-)Client: ... SSE messages from server ...
     end
@@ -306,7 +270,6 @@ These headers are **REQUIRED** for compliance.
 ```http
 POST /mcp HTTP/1.1
 Content-Type: application/json
-Mcp-Session-Id: 1f3a4b5c-6d7e-8f9a-0b1c-2d3e4f5a6b7c
 Mcp-Method: tools/call
 Mcp-Name: get_weather
 
@@ -328,7 +291,6 @@ Mcp-Name: get_weather
 ```http
 POST /mcp HTTP/1.1
 Content-Type: application/json
-Mcp-Session-Id: 1f3a4b5c-6d7e-8f9a-0b1c-2d3e4f5a6b7c
 Mcp-Method: resources/read
 Mcp-Name: file:///projects/myapp/config.json
 
@@ -369,7 +331,6 @@ Mcp-Method: initialize
 ```http
 POST /mcp HTTP/1.1
 Content-Type: application/json
-Mcp-Session-Id: 1f3a4b5c-6d7e-8f9a-0b1c-2d3e4f5a6b7c
 Mcp-Method: notifications/initialized
 
 {
@@ -486,7 +447,6 @@ including the tool name and the reason for rejection.
 ```http
 POST /mcp HTTP/1.1
 Content-Type: application/json
-Mcp-Session-Id: 1f3a4b5c-6d7e-8f9a-0b1c-2d3e4f5a6b7c
 Mcp-Method: tools/call
 Mcp-Name: execute_sql
 Mcp-Param-Region: us-west1

--- a/docs/specification/draft/basic/utilities/ping.mdx
+++ b/docs/specification/draft/basic/utilities/ping.mdx
@@ -15,7 +15,7 @@ the client or server can initiate a ping by sending a `ping` request.
 <Warning>
 
 `ping` is an MCP-level liveness check and **MAY** be sent by either party at any
-time on an established session/connection.
+time on an established connection.
 
 In Streamable HTTP, implementations **SHOULD** prefer transport-level SSE
 keepalive mechanisms for idle-connection maintenance; `ping` remains available

--- a/docs/specification/draft/changelog.mdx
+++ b/docs/specification/draft/changelog.mdx
@@ -9,7 +9,7 @@ the previous revision, [2025-11-25](/specification/2025-11-25).
 
 ## Major changes
 
-N/A
+1. Remove protocol-level sessions and the `Mcp-Session-Id` header from the Streamable HTTP transport. List endpoints (`tools/list`, `resources/list`, `prompts/list`) no longer vary per-connection. Servers that need cross-call state use explicit, server-minted handles passed as ordinary tool arguments ([SEP-2567](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567)).
 
 ## Minor changes
 

--- a/docs/specification/draft/client/elicitation.mdx
+++ b/docs/specification/draft/client/elicitation.mdx
@@ -531,7 +531,6 @@ Elicitations do not require that the server maintain state about users with the 
 
 However, if state is stored, servers implementing elicitation **MUST** securely associate this state with individual users following the guidelines in the [security best practices](/docs/tutorials/security/security_best_practices) document. Specifically:
 
-- State **MUST NOT** be associated with session IDs alone
 - State storage **MUST** be protected against unauthorized access
 - For remote MCP servers, user identification **MUST** be derived from credentials acquired via [MCP authorization](../basic/authorization) when possible (e.g. `sub` claim)
 

--- a/docs/specification/draft/server/prompts.mdx
+++ b/docs/specification/draft/server/prompts.mdx
@@ -47,8 +47,9 @@ available prompts changes.
 
 Servers that declare the `prompts` capability **MUST** respond to `prompts/list` requests
 with the set of prompts currently available to the requesting client. This set **MAY** be
-empty and **MAY** change over the lifetime of the connection (see
-[List Changed Notification](#list-changed-notification)).
+empty and **MAY** change over time (see
+[List Changed Notification](#list-changed-notification)), but **MUST NOT** vary
+per-connection or as a side effect of other requests on the connection.
 
 ## Protocol Messages
 

--- a/docs/specification/draft/server/prompts.mdx
+++ b/docs/specification/draft/server/prompts.mdx
@@ -49,7 +49,10 @@ Servers that declare the `prompts` capability **MUST** respond to `prompts/list`
 with the set of prompts currently available to the requesting client. This set **MAY** be
 empty and **MAY** change over time (see
 [List Changed Notification](#list-changed-notification)), but **MUST NOT** vary
-per-connection or as a side effect of other requests on the connection.
+per-connection or as a side effect of other requests on the connection. The set
+**MAY** vary by the authorization presented on the request — for example, returning
+only the prompts the caller's granted scopes permit — since credentials are
+per-request input, not connection state.
 
 ## Protocol Messages
 

--- a/docs/specification/draft/server/resources.mdx
+++ b/docs/specification/draft/server/resources.mdx
@@ -82,8 +82,9 @@ either, or both:
 
 Servers that declare the `resources` capability **MUST** respond to `resources/list`
 requests with the set of resources currently available to the requesting client. This set
-**MAY** be empty and **MAY** change over the lifetime of the connection (see
-[List Changed Notification](#list-changed-notification)).
+**MAY** be empty and **MAY** change over time (see
+[List Changed Notification](#list-changed-notification)), but **MUST NOT** vary
+per-connection or as a side effect of other requests on the connection.
 
 ## Protocol Messages
 

--- a/docs/specification/draft/server/resources.mdx
+++ b/docs/specification/draft/server/resources.mdx
@@ -84,7 +84,10 @@ Servers that declare the `resources` capability **MUST** respond to `resources/l
 requests with the set of resources currently available to the requesting client. This set
 **MAY** be empty and **MAY** change over time (see
 [List Changed Notification](#list-changed-notification)), but **MUST NOT** vary
-per-connection or as a side effect of other requests on the connection.
+per-connection or as a side effect of other requests on the connection. The set
+**MAY** vary by the authorization presented on the request — for example, returning
+only the resources the caller's granted scopes permit — since credentials are
+per-request input, not connection state.
 
 ## Protocol Messages
 

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -52,8 +52,9 @@ available tools changes.
 
 Servers that declare the `tools` capability **MUST** respond to `tools/list` requests
 with the set of tools currently available to the requesting client. This set **MAY** be
-empty and **MAY** change over the lifetime of the connection (see
-[List Changed Notification](#list-changed-notification)).
+empty and **MAY** change over time (see
+[List Changed Notification](#list-changed-notification)), but **MUST NOT** vary
+per-connection or as a side effect of other requests on the connection.
 
 Servers **SHOULD** return tools in a deterministic order (i.e., the same ordering across
 requests when the underlying set of tools has not changed). Deterministic ordering enables
@@ -598,6 +599,61 @@ Providing an output schema helps clients and LLMs understand and properly handle
   }
 }
 ```
+
+## Stateful Tools
+
+<Note>
+
+This section is non-normative guidance for tool design. The protocol has no
+concept of a state handle; from the wire's perspective a handle is an ordinary
+string in a tool result and an ordinary argument to subsequent tool calls.
+
+</Note>
+
+MCP has no protocol-level session, so a server cannot rely on implicit
+per-connection state to relate one tool call to the next. Servers that need to
+maintain state across calls — a shopping cart, an open browser context, a
+database transaction — should do so by returning an explicit handle from a
+creation tool and accepting that handle as an argument on subsequent calls.
+
+For example, a server that manages a shopping cart might expose:
+
+```jsonc
+// → tools/call
+{ "name": "create_basket", "arguments": {} }
+
+// ← result
+{
+  "content": [{ "type": "text", "text": "Created basket bsk_a1b2c3" }],
+  "structuredContent": { "basket_id": "bsk_a1b2c3" }
+}
+
+// → tools/call
+{
+  "name": "add_item",
+  "arguments": { "basket_id": "bsk_a1b2c3", "sku": "..." }
+}
+```
+
+The model is responsible for carrying `basket_id` forward; the server stores
+the cart contents under that key and looks them up on each call.
+
+When designing handles, servers should consider:
+
+- **Authorization.** For authenticated servers, a handle is a name, not a
+  capability. The server should validate the caller's authorization against the
+  handle on every call. For unauthenticated servers, where the handle is
+  necessarily a bearer token, it should be generated with sufficient entropy
+  (e.g., a UUIDv4) and given a bounded lifetime.
+- **Opacity.** Handles that encode internal structure invite parsing or
+  guessing; opaque identifiers do not.
+- **Lifetime.** Because handles outlive any single connection, the server's
+  retention policy should be stated in the creation tool's description (e.g.,
+  "baskets expire after 24 hours of inactivity") so the model can see it when
+  deciding to create state.
+- **Expiry errors.** A call against an expired or unknown handle should return
+  a tool execution error that says so, so the model can recover by creating a
+  new one.
 
 ## Error Handling
 

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -54,7 +54,10 @@ Servers that declare the `tools` capability **MUST** respond to `tools/list` req
 with the set of tools currently available to the requesting client. This set **MAY** be
 empty and **MAY** change over time (see
 [List Changed Notification](#list-changed-notification)), but **MUST NOT** vary
-per-connection or as a side effect of other requests on the connection.
+per-connection or as a side effect of other requests on the connection. The set
+**MAY** vary by the authorization presented on the request — for example, returning
+only the tools the caller's granted scopes permit — since credentials are
+per-request input, not connection state.
 
 Servers **SHOULD** return tools in a deterministic order (i.e., the same ordering across
 requests when the underlying set of tools has not changed). Deterministic ordering enables

--- a/docs/specification/draft/server/utilities/pagination.mdx
+++ b/docs/specification/draft/server/utilities/pagination.mdx
@@ -93,7 +93,6 @@ The following MCP operations support pagination:
    - Don't make any determination based on cursor value other than whether a
      non-null value was provided (e.g. an empty string is a valid cursor and
      thus **MUST NOT** be treated as the end of results)
-   - Don't persist cursors across sessions
 
 ## Error Handling
 

--- a/seps/2567-sessionless-mcp.md
+++ b/seps/2567-sessionless-mcp.md
@@ -163,10 +163,13 @@ One consequence of the constraint above is that servers can no longer mutate lis
 
 ### Consequential spec edits
 
-Two places in the current spec define behavior in terms of session scope and need re-scoping:
+Beyond removing the §Session Management section itself, several other places in the current spec define behavior in terms of session scope and need re-scoping:
 
 - **JSON-RPC request ID uniqueness.** The spec currently requires that a request `id` "MUST NOT have been previously used by the requestor within the same session." The purpose of `id` is for the sender to correlate an incoming response with the request that produced it; the receiver only echoes it. With sessions removed, the constraint is re-scoped accordingly: a sender MUST NOT issue a request whose `id` matches that of another request it has sent and not yet received a response for. This is transport-agnostic, sufficient for correlation under every transport, and is what the TypeScript and Python SDKs already do via a monotonically increasing counter per client object. ([JSON-RPC 2.0 §4](https://www.jsonrpc.org/specification#request_object) itself imposes no uniqueness requirement — it only requires the receiver to echo the `id` — so this remains an MCP-level constraint.)
+- **SSE event ID uniqueness.** The spec currently scopes SSE event IDs as "globally unique across all streams within that session." With sessions removed, the constraint is simply that the ID is globally unique across all streams the server manages, so that a `Last-Event-ID` resolves to a single stream. The existing guidance that event IDs encode the originating stream already implies this.
 - **Pagination cursor validity.** The spec currently advises clients not to "persist cursors across sessions." With sessions removed, this advice disappears. Cursor stability and snapshot consistency are outside the scope of this proposal.
+- **List-endpoint variability.** The `tools/list`, `resources/list`, and `prompts/list` pages each say results "MAY change over the lifetime of the connection." These are re-scoped per [§Session-independent list endpoints](#session-independent-list-endpoints): results MAY change over time but MUST NOT vary per-connection or as a side effect of other requests on the connection.
+- **Wording.** A handful of phrases that use "session" descriptively — "stateful session protocol" in the architecture overview, "available during the session" in capability negotiation, "same logical session" in authorization, the elicitation prohibition on associating state "with session IDs alone," and similar — are reworded or removed. These carry no semantic change beyond the session removal itself.
 
 ## Rationale
 

--- a/seps/2567-sessionless-mcp.md
+++ b/seps/2567-sessionless-mcp.md
@@ -24,7 +24,7 @@ Under this proposal, a server that currently scopes a shopping cart (for example
 
 ### What sessions scope today
 
-The current spec is not fully precise about which behaviors are session-bound, but in practice five categories of things attach to a session's lifetime:
+The current spec is imprecise about which behaviors are session-bound, but in practice five categories of things attach to a session's lifetime:
 
 1. **Negotiated capabilities and protocol version.** The result of `initialize` — which protocol version is in use and which optional capabilities each side supports — is established once per session and assumed for its duration. [SEP-2575] resolves this by removing `initialize` and carrying version/capability information per-request, so this proposal treats it as already addressed.
 
@@ -32,7 +32,7 @@ The current spec is not fully precise about which behaviors are session-bound, b
 
 3. **Application state.** The canonical example is a shopping cart: `add_item()`, `add_item()`, `checkout()`, with the cart existing implicitly per-session. This generalizes to any stateful workflow — a Playwright browser instance, a database transaction, an open file descriptor.
 
-4. **Mutable list endpoints.** `tools/list` (and `resources/list`, `prompts/list`) can legally return different results over a session's lifetime. For example, a server could expose an `enable_admin_tools` tool that mutates what subsequent `tools/list` calls return.
+4. **Mutable list endpoints.** `tools/list` (and `resources/list`, `prompts/list`) can legally return different results over a session's lifetime. For example, a database server could expose a `connect_database` tool that, once called, makes `query` and `list_tables` appear in subsequent `tools/list` results.
 
 5. **Resource subscriptions.** Subscription lifetime is tied to session lifetime. ([SEP-2575] introduces `messages/listen` as the delivery channel for server-to-client notifications; subscription lifetime under that model is not re-examined here.)
 
@@ -159,7 +159,7 @@ With sessions removed, list endpoints no longer have a session to vary against. 
 
 How clients learn that a cached list has gone stale is the subject of [SEP-2549], which defines a server-advertised TTL on list responses and the interaction with `notifications/*/list_changed`. The two SEPs are complementary: this one removes the session as a source of variation, so there is a stable thing to cache; [SEP-2549] specifies how long to cache it and when to invalidate.
 
-One consequence of the constraint above is that servers can no longer mutate `tools/list` as a side effect of tool calls; the `enable_admin_tools()`-mutates-the-list pattern is no longer permitted. In practice this is rarely used. For the same effect, servers can expose all tools unconditionally at list time and enforce authorization at call time (which is already the common posture for auth-gated tools).
+One consequence of the constraint above is that servers can no longer mutate list results as a side effect of other requests; the pattern from the Motivation — where calling `connect_database()` makes `query` and `list_tables` appear in subsequent `tools/list` results — is no longer permitted. For the same effect, the server exposes `query` and `list_tables` unconditionally at list time and has them take a `connection_id` argument returned by `connect_database()`. A `query` call without a valid `connection_id` fails with an error directing the model to call `connect_database()` first; the dependency is expressed in the tool's input schema and description rather than in the list result.
 
 ### Consequential spec edits
 
@@ -231,7 +231,7 @@ The bolded rows are the repos that use the session ID for application semantics.
 
 This is a **breaking change** for servers that rely on protocol-level session state. The migration path depends on server category:
 
-**Stdio servers using process-lifetime state.** These are the most common stateful servers today and are not broken by this proposal in their default deployment: the process lifetime still exists, and a server that keeps a single in-memory browser instance per process continues to work with a stdio client that spawns one process. Stdio servers never had `Mcp-Session-Id`.
+**Stdio servers using process-lifetime state.** These are the most common stateful servers today. Mechanically they are not broken by this proposal in their default deployment — the process lifetime still exists, and a server that keeps a single in-memory browser instance per process continues to function with a stdio client that spawns one process. However, such servers SHOULD NOT rely on process-lifetime state and SHOULD migrate to explicit handles. Process lifetime has the same undefined-scope problem this SEP removes for HTTP (whether the process corresponds to one conversation, one application launch, or something else is up to the host), and a server that depends on it cannot offer equivalent behavior over HTTP, where there is no process per client. Stdio servers never had `Mcp-Session-Id`, so the header removal itself does not affect them.
 
 **HTTP servers using `Mcp-Session-Id`.** These are less common and must migrate to explicit handles. The migration is mechanical: replace the session-scoped state map with a handle-keyed state map, add a `create_*` tool, add the handle as a parameter to stateful tools.
 
@@ -264,3 +264,9 @@ This is guidance, not a protocol requirement, since the protocol has no handle c
 ## Reference Implementation
 
 All official SDKs except PHP already provide a stateless mode, implemented as not generating a session ID (e.g. `sessionIdGenerator: undefined` in the TypeScript SDK, `stateless_http=True` in the Python SDK). This SEP makes that mode the only option for servers speaking the new protocol version. SDKs that support multiple protocol versions retain the session-ID-generating code path for older versions; the change is that it is no longer reachable when the negotiated protocol version is the one this SEP introduces.
+
+## Future Work
+
+This SEP deliberately does not introduce a protocol-level concept of a handle: from the wire's perspective `basket_id` is an ordinary string. A consequence is that nothing marks `basket_id` as a state handle to the client or model — the relationship between `create_basket`'s output and `add_item`'s input is inferred from naming and tool descriptions, not declared.
+
+A follow-up proposal could make that relationship explicit, for example via shared JSON Schema `$defs` referenced across a server's tool input and output schemas, or via a tool annotation that marks a result field as a handle. That would let orchestrators identify which values are live state (for compaction, hand-off, or cleanup purposes) without parsing tool descriptions. It is left out of scope here to keep this SEP to the minimum needed to remove sessions.

--- a/seps/2567-sessionless-mcp.md
+++ b/seps/2567-sessionless-mcp.md
@@ -1,11 +1,11 @@
-# SEP-XXXX: Sessionless MCP via Explicit State Handles
+# SEP-2567: Sessionless MCP via Explicit State Handles
 
 - **Status**: Draft
 - **Type**: Standards Track
 - **Created**: 2026-03-11
 - **Author(s)**: Peter Alexander (@pja-ant)
 - **Sponsor**: Peter Alexander (@pja-ant)
-- **PR**: https://github.com/modelcontextprotocol/specification/pull/{NUMBER}
+- **PR**: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567
 - **Related**: [SEP-1442](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1442) (Stateless-by-default MCP), [SEP-2322](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2322) (Multi Round-Trip Requests), [SEP-2549](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549) (TTL for List Results)
 
 ## Abstract

--- a/seps/2567-sessionless-mcp.md
+++ b/seps/2567-sessionless-mcp.md
@@ -6,17 +6,17 @@
 - **Author(s)**: Peter Alexander (@pja-ant)
 - **Sponsor**: Peter Alexander (@pja-ant)
 - **PR**: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567
-- **Related**: [SEP-1442](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1442) (Stateless-by-default MCP), [SEP-2322](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2322) (Multi Round-Trip Requests), [SEP-2549](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549) (TTL for List Results)
+- **Related**: [SEP-2575](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2575) (Make MCP Stateless), [SEP-2322](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2322) (Multi Round-Trip Requests), [SEP-2549](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549) (TTL for List Results)
 
 ## Abstract
 
-This proposal removes the protocol-level session concept from MCP, replacing implicit session-scoped state with explicit, server-minted state handles that the model carries and threads through subsequent calls. [SEP-1442] makes sessions optional by defaulting to stateless operation; this proposal removes the opt-in as well.
+This proposal removes the protocol-level session concept from MCP, replacing implicit session-scoped state with explicit, server-minted state handles that the model carries and threads through subsequent calls. [SEP-2575] makes sessions optional by defaulting to stateless operation; this proposal removes the opt-in as well.
 
 After more than a year in the spec, sessions have not converged on a consistent meaning across clients: some scope them per tool call, some per application launch, some per page load, and almost none resume them. A server author cannot predict what scope or lifetime a session will have when their server is connected to an arbitrary client, which has made the session unreliable as a container for application state. This proposal holds that application state can be served by explicit identifiers, and that the session abstraction adds constraints (fixed cardinality, undefined lifetime, uncacheable list endpoints across session boundaries) without corresponding benefit.
 
 Under this proposal, a server that currently scopes a shopping cart (for example) to the session instead exposes a tool `create_basket()` that returns a `basket_id` and threads that ID through subsequent tool calls, e.g. `add_item(basket_id, ...)`. The model decides what is shared and what is isolated; list endpoints become cacheable across what used to be session boundaries; and agent orchestrators can freely share or not share application state as needed. Explicit state handles are not a new protocol construct — there is no schema or wire format for them. They are a tool-design pattern; the protocol change is the removal of sessions, which leaves handles as the way to express cross-call state.
 
-[SEP-1442]: https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1442
+[SEP-2575]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2575
 [SEP-2322]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2322
 [SEP-2549]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549
 
@@ -26,7 +26,7 @@ Under this proposal, a server that currently scopes a shopping cart (for example
 
 The current spec is not fully precise about which behaviors are session-bound, but in practice five categories of things attach to a session's lifetime:
 
-1. **Negotiated capabilities and protocol version.** The result of `initialize` — which protocol version is in use and which optional capabilities each side supports — is established once per session and assumed for its duration. [SEP-1442] resolves this by removing `initialize` and carrying version/capability information per-request, so this proposal treats it as already addressed.
+1. **Negotiated capabilities and protocol version.** The result of `initialize` — which protocol version is in use and which optional capabilities each side supports — is established once per session and assumed for its duration. [SEP-2575] resolves this by removing `initialize` and carrying version/capability information per-request, so this proposal treats it as already addressed.
 
 2. **Elicitation and sampling intermediate state.** When a tool call triggers an `elicitation/create` or `sampling/createMessage` round-trip, the server has to correlate the eventual response with the original in-flight tool call — state that today lives implicitly in the session. [SEP-2322] (Multi Round-Trip Requests) resolves this by carrying the correlation state explicitly through the request/response cycle, so this proposal treats it as already addressed.
 
@@ -34,13 +34,13 @@ The current spec is not fully precise about which behaviors are session-bound, b
 
 4. **Mutable list endpoints.** `tools/list` (and `resources/list`, `prompts/list`) can legally return different results over a session's lifetime. For example, a server could expose an `enable_admin_tools` tool that mutates what subsequent `tools/list` calls return.
 
-5. **Resource subscriptions.** Subscription lifetime is tied to session lifetime. ([SEP-1442] addresses this separately and it is not re-examined here.)
+5. **Resource subscriptions.** Subscription lifetime is tied to session lifetime. ([SEP-2575] addresses this separately and it is not re-examined here.)
 
 With (1), (2), and (5) handled by other SEPs, this proposal addresses (3) and (4).
 
 ### Problems with session scoping
 
-The issues below apply whether sessions are mandatory (the current spec) or opt-in (the direction [SEP-1442] takes).
+The issues below apply whether sessions are mandatory (the current spec) or opt-in (the direction [SEP-2575] takes).
 
 #### Session lifetime is undefined, and servers can't design around it
 
@@ -89,7 +89,7 @@ The same lack of an identifier also means session state is not addressable from 
 
 ### Summary of changes
 
-1. **Remove the session concept from the protocol.** The `Mcp-Session-Id` header is removed and the spec language describing session lifecycle and session-scoped behavior is deleted. The protocol is sessionless at every layer. (This supersedes the opt-in stateful path that [SEP-1442] retained.)
+1. **Remove the session concept from the protocol.** The `Mcp-Session-Id` header is removed and the spec language describing session lifecycle and session-scoped behavior is deleted. The protocol is sessionless at every layer. (This supersedes the opt-in stateful path that [SEP-2575] retained.)
 
 2. **List endpoints are session-independent.** With no session, the results of `tools/list`, `resources/list`, and `prompts/list` have no per-session or per-connection scope to depend on. Lists can still change for other reasons (server deployment, auth changes); caching and invalidation mechanics for those are specified separately in [SEP-2549].
 
@@ -172,7 +172,7 @@ Two places in the current spec define behavior in terms of session scope and nee
 
 ### Why remove sessions rather than just default them off?
 
-[SEP-1442] already addresses making MCP work behind load balancers and without sticky routing. The reasons for going further are:
+[SEP-2575] already addresses making MCP work behind load balancers and without sticky routing. The reasons for going further are:
 
 - **Opt-in sessions still prevent list caching.** A client cannot cache `tools/list` across session boundaries unless it knows the server does not opt into session-scoped mutation, and it cannot know that in advance. The client therefore re-fetches per session per server even though few servers opt in. The `O(subagents × servers)` cost from the Motivation section is caused by sessions being possible, not by sessions being used, so making them optional does not remove it.
 - **The primitive influences server design.** Offering session-scoped state in the spec leads server authors to use it for workflows that would be better served by explicit IDs.

--- a/seps/2567-sessionless-mcp.md
+++ b/seps/2567-sessionless-mcp.md
@@ -10,7 +10,7 @@
 
 ## Abstract
 
-This proposal removes the protocol-level session concept from MCP, replacing implicit session-scoped state with explicit, server-minted state handles that the model carries and threads through subsequent calls. [SEP-2575] makes sessions optional by defaulting to stateless operation; this proposal removes the opt-in as well.
+This proposal removes the protocol-level session concept from MCP, replacing implicit session-scoped state with explicit, server-minted state handles that the model carries and threads through subsequent calls. [SEP-2575] removes the `initialize` handshake and carries protocol version and capabilities per-request; this proposal is the complementary change that removes sessions and the `Mcp-Session-Id` header. Together they make MCP stateless at the protocol layer.
 
 After more than a year in the spec, sessions have not converged on a consistent meaning across clients: some scope them per tool call, some per application launch, some per page load, and almost none resume them. A server author cannot predict what scope or lifetime a session will have when their server is connected to an arbitrary client, which has made the session unreliable as a container for application state. This proposal holds that application state can be served by explicit identifiers, and that the session abstraction adds constraints (fixed cardinality, undefined lifetime, uncacheable list endpoints across session boundaries) without corresponding benefit.
 
@@ -34,13 +34,13 @@ The current spec is not fully precise about which behaviors are session-bound, b
 
 4. **Mutable list endpoints.** `tools/list` (and `resources/list`, `prompts/list`) can legally return different results over a session's lifetime. For example, a server could expose an `enable_admin_tools` tool that mutates what subsequent `tools/list` calls return.
 
-5. **Resource subscriptions.** Subscription lifetime is tied to session lifetime. ([SEP-2575] addresses this separately and it is not re-examined here.)
+5. **Resource subscriptions.** Subscription lifetime is tied to session lifetime. ([SEP-2575] introduces `messages/listen` as the delivery channel for server-to-client notifications; subscription lifetime under that model is not re-examined here.)
 
 With (1), (2), and (5) handled by other SEPs, this proposal addresses (3) and (4).
 
 ### Problems with session scoping
 
-The issues below apply whether sessions are mandatory (the current spec) or opt-in (the direction [SEP-2575] takes).
+The issues below apply whether sessions are mandatory (the current spec) or made optional.
 
 #### Session lifetime is undefined, and servers can't design around it
 
@@ -89,7 +89,7 @@ The same lack of an identifier also means session state is not addressable from 
 
 ### Summary of changes
 
-1. **Remove the session concept from the protocol.** The `Mcp-Session-Id` header is removed and the spec language describing session lifecycle and session-scoped behavior is deleted. The protocol is sessionless at every layer. (This supersedes the opt-in stateful path that [SEP-2575] retained.)
+1. **Remove the session concept from the protocol.** The `Mcp-Session-Id` header is removed and the spec language describing session lifecycle and session-scoped behavior is deleted. The protocol is sessionless at every layer. ([SEP-2575] removes the `initialize` handshake but explicitly defers session removal to this proposal.)
 
 2. **List endpoints are session-independent.** With no session, the results of `tools/list`, `resources/list`, and `prompts/list` have no per-session or per-connection scope to depend on. Lists can still change for other reasons (server deployment, auth changes); caching and invalidation mechanics for those are specified separately in [SEP-2549].
 
@@ -172,7 +172,7 @@ Two places in the current spec define behavior in terms of session scope and nee
 
 ### Why remove sessions rather than just default them off?
 
-[SEP-2575] already addresses making MCP work behind load balancers and without sticky routing. The reasons for going further are:
+[SEP-2575] already addresses making MCP work behind load balancers and without sticky routing by removing the `initialize` handshake. The reasons for also removing sessions, rather than retaining them as an opt-in capability, are:
 
 - **Opt-in sessions still prevent list caching.** A client cannot cache `tools/list` across session boundaries unless it knows the server does not opt into session-scoped mutation, and it cannot know that in advance. The client therefore re-fetches per session per server even though few servers opt in. The `O(subagents × servers)` cost from the Motivation section is caused by sessions being possible, not by sessions being used, so making them optional does not remove it.
 - **The primitive influences server design.** Offering session-scoped state in the spec leads server authors to use it for workflows that would be better served by explicit IDs.

--- a/seps/2567-sessionless-mcp.md
+++ b/seps/2567-sessionless-mcp.md
@@ -1,6 +1,6 @@
 # SEP-2567: Sessionless MCP via Explicit State Handles
 
-- **Status**: Draft
+- **Status**: Accepted
 - **Type**: Standards Track
 - **Created**: 2026-03-11
 - **Author(s)**: Peter Alexander (@pja-ant)

--- a/seps/2567-sessionless-mcp.md
+++ b/seps/2567-sessionless-mcp.md
@@ -155,7 +155,7 @@ From the client's perspective, a handle is an ordinary string in a tool result. 
 
 ### Session-independent list endpoints
 
-With sessions removed, list endpoints no longer have a session to vary against. This is the only constraint this SEP places on `tools/list`, `resources/list`, and `prompts/list`: there is no longer a per-session or per-connection scope for their results to depend on. Lists can still change for other reasons — a server deploys a new version, a user's plan or granted scopes change — and this SEP does not enumerate or restrict those.
+With sessions removed, list endpoints no longer have a session to vary against. This is the only constraint this SEP places on `tools/list`, `resources/list`, and `prompts/list`: there is no longer a per-session or per-connection scope for their results to depend on. This does not preclude varying the list by the authorization presented on the request: credentials are carried on each request, so a server returning different tool sets to different principals or scopes is relying on per-request input, not connection state. Lists can also still change over time for other reasons — a server deploys a new version, a user's plan or granted scopes change — and this SEP does not enumerate or restrict those.
 
 How clients learn that a cached list has gone stale is the subject of [SEP-2549], which defines a server-advertised TTL on list responses and the interaction with `notifications/*/list_changed`. The two SEPs are complementary: this one removes the session as a source of variation, so there is a stable thing to cache; [SEP-2549] specifies how long to cache it and when to invalidate.
 

--- a/seps/2567-sessionless-mcp.md
+++ b/seps/2567-sessionless-mcp.md
@@ -1,6 +1,6 @@
 # SEP-2567: Sessionless MCP via Explicit State Handles
 
-- **Status**: Accepted
+- **Status**: Final
 - **Type**: Standards Track
 - **Created**: 2026-03-11
 - **Author(s)**: Peter Alexander (@pja-ant)

--- a/seps/XXXX-sessionless-mcp.md
+++ b/seps/XXXX-sessionless-mcp.md
@@ -1,0 +1,265 @@
+# SEP-XXXX: Sessionless MCP via Explicit State Handles
+
+- **Status**: Draft
+- **Type**: Standards Track
+- **Created**: 2026-03-11
+- **Author(s)**: Peter Alexander (@pja-ant)
+- **Sponsor**: Peter Alexander (@pja-ant)
+- **PR**: https://github.com/modelcontextprotocol/specification/pull/{NUMBER}
+- **Related**: [SEP-1442](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1442) (Stateless-by-default MCP), [SEP-2322](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2322) (Multi Round-Trip Requests), [SEP-2549](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549) (TTL for List Results)
+
+## Abstract
+
+This proposal removes the protocol-level session concept from MCP, replacing implicit session-scoped state with explicit, server-minted state handles that the model carries and threads through subsequent calls. [SEP-1442] makes sessions optional by defaulting to stateless operation; this proposal removes the opt-in as well.
+
+After more than a year in the spec, sessions have not converged on a consistent meaning across clients: some scope them per tool call, some per application launch, some per page load, and almost none resume them. A server author cannot predict what scope or lifetime a session will have when their server is connected to an arbitrary client, which has made the session unreliable as a container for application state. This proposal holds that application state can be served by explicit identifiers, and that the session abstraction adds constraints (fixed cardinality, undefined lifetime, uncacheable list endpoints across session boundaries) without corresponding benefit.
+
+Under this proposal, a server that currently scopes a shopping cart (for example) to the session instead exposes a tool `create_basket()` that returns a `basket_id` and threads that ID through subsequent tool calls, e.g. `add_item(basket_id, ...)`. The model decides what is shared and what is isolated; list endpoints become cacheable across what used to be session boundaries; and agent orchestrators can freely share or not share application state as needed. Explicit state handles are not a new protocol construct — there is no schema or wire format for them. They are a tool-design pattern; the protocol change is the removal of sessions, which leaves handles as the way to express cross-call state.
+
+[SEP-1442]: https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1442
+[SEP-2322]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2322
+[SEP-2549]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549
+
+## Motivation
+
+### What sessions scope today
+
+The current spec is not fully precise about which behaviors are session-bound, but in practice five categories of things attach to a session's lifetime:
+
+1. **Negotiated capabilities and protocol version.** The result of `initialize` — which protocol version is in use and which optional capabilities each side supports — is established once per session and assumed for its duration. [SEP-1442] resolves this by removing `initialize` and carrying version/capability information per-request, so this proposal treats it as already addressed.
+
+2. **Elicitation and sampling intermediate state.** When a tool call triggers an `elicitation/create` or `sampling/createMessage` round-trip, the server has to correlate the eventual response with the original in-flight tool call — state that today lives implicitly in the session. [SEP-2322] (Multi Round-Trip Requests) resolves this by carrying the correlation state explicitly through the request/response cycle, so this proposal treats it as already addressed.
+
+3. **Application state.** The canonical example is a shopping cart: `add_item()`, `add_item()`, `checkout()`, with the cart existing implicitly per-session. This generalizes to any stateful workflow — a Playwright browser instance, a database transaction, an open file descriptor.
+
+4. **Mutable list endpoints.** `tools/list` (and `resources/list`, `prompts/list`) can legally return different results over a session's lifetime. For example, a server could expose an `enable_admin_tools` tool that mutates what subsequent `tools/list` calls return.
+
+5. **Resource subscriptions.** Subscription lifetime is tied to session lifetime. ([SEP-1442] addresses this separately and it is not re-examined here.)
+
+With (1), (2), and (5) handled by other SEPs, this proposal addresses (3) and (4).
+
+### Problems with session scoping
+
+The issues below apply whether sessions are mandatory (the current spec) or opt-in (the direction [SEP-1442] takes).
+
+#### Session lifetime is undefined, and servers can't design around it
+
+The spec does not say when a session begins or ends, because it depends on the host application. In practice, deployed clients vary widely and few scope sessions to a conversation: ChatGPT creates a fresh session for every individual tool call, and Claude.ai did the same until recently;[^per-call] most desktop and IDE clients create one at application launch and keep it for the process lifetime; web clients typically create one per page load. Almost no clients resume a prior session after a disconnect or restart, and on the server side the reference TypeScript SDK provides no public API for reconstructing a session on a different node, so multi-node deployments cannot honor resumption even when a client attempts it.[^ts-sdk-resume] A subagent might share its parent's session or get its own — there is no convention.
+
+[^per-call]: [microsoft/playwright-mcp#1045](https://github.com/microsoft/playwright-mcp/issues/1045), Sep 2025 — server author reports both ChatGPT and Claude.ai closing the session after each tool call, dropping browser state; ["Connector tool calls generating fresh MCP session each invocation"](https://community.openai.com/t/connector-tool-calls-generating-fresh-mcp-session-each-invocation/1364975), OpenAI Developer Community, Nov 2025.
+[^ts-sdk-resume]: [modelcontextprotocol/typescript-sdk#1658](https://github.com/modelcontextprotocol/typescript-sdk/issues/1658), Mar 2026 — `StreamableHTTPServerTransport` stores session state in private instance fields with no API to rehydrate from external storage.
+
+This matters because server authors are the ones deciding what to scope to the session, and they need to know what a session corresponds to in order to do that correctly. A Playwright server that ties a browser instance to the session needs to know whether that means one user turn, one agent process, or one long-lived chat. The spec does not specify this and different hosts give different answers, so the server is designing against an abstraction whose semantics it does not control.
+
+The practical consequence is that session-scoped application state often does not survive. Against a per-tool-call client it is destroyed before the next call; against a per-app-launch client it is shared across every conversation in the window and then lost on restart; against any client that does not resume, it is gone when the app restarts. Servers that appear to be using session state successfully are usually stdio servers relying on process lifetime, which is a property of the transport rather than the protocol.
+
+#### List endpoints cannot be cached across sessions
+
+Because `tools/list` may be session-dependent, a client cannot assume a result fetched in one session is valid in the next. Every new session must re-fetch, even when the server's tool set is fixed at build time and never changes, which is the common case.
+
+The Python SDK's own design issue for client-side list caching lists "what is the cache key — per-session or per-server-URL?" as an open question,[^py-sdk-cache] and gateway implementers have shipped per-session caching specifically because they could not assume cross-session validity from the spec.[^agentgateway-cache] Every list endpoint must be treated as potentially session-scoped, so each must be re-fetched per session to be safe.
+
+[^py-sdk-cache]: [modelcontextprotocol/python-sdk#2108](https://github.com/modelcontextprotocol/python-sdk/issues/2108), Feb 2026.
+[^agentgateway-cache]: [agentgateway/agentgateway#1510](https://github.com/agentgateway/agentgateway/issues/1510), Apr 2026.
+
+For hosts that regularly spawn subagents, this is a multiplier on the hot path. The possibility that a server is session-scoped forces `O(subagents × servers)` calls to `tools/list`: every subagent, for every server, every time, even if the underlying tool set has not changed since the orchestrator first connected. The client cannot skip the call because it cannot know in advance which servers are session-scoped. For an orchestrator spawning many short-lived subagents, this overhead can exceed the protocol traffic of the actual tool calls. Under this proposal the same workload is `O(servers)`: the orchestrator fetches each list once and every subagent reuses the cached result.
+
+If list endpoints were a function only of the server deployment and the authenticated principal, clients could cache them and invalidate on an explicit signal. [SEP-2549] specifies such a signal (a server-advertised TTL plus `notifications/*/list_changed`), but its caching model is only sound if the list does not also vary per session. Removing sessions makes that model safe; a subagent can then inherit its parent's cached lists at zero cost.
+
+#### Cardinality is fixed at one per session
+
+Session state has a cardinality of exactly one per session. The model gets one cart, one browser, one of whatever the server scopes to the session; it cannot have two, and it cannot have zero.
+
+This is a problem when different pieces of state need different scopes. Consider an orchestrator that spawns several subagents to independently research products to buy. The subagents should add to the same shopping cart (they are collaborating on one order) but each needs its own browser state (they are browsing different sites in parallel).
+
+No session boundary satisfies both:
+
+| Session model               | Cart (want: shared) | Browser (want: isolated) |
+|-----------------------------|:-------------------:|:------------------------:|
+| Subagents share parent's    | ✓ shared           | ✗ shared (clobbers)     |
+| Subagents get their own     | ✗ isolated         | ✓ isolated              |
+
+With explicit IDs the orchestrator calls `create_basket()` once, passes the resulting `basket_id` to each subagent, and each subagent separately calls `create_browser()` for its own `browser_id`. The model decides what is shared and what is isolated per piece of state, rather than having one scope imposed on everything.
+
+The same lack of an identifier also means session state is not addressable from outside the session that created it. A cart created in one chat is invisible to another chat; if a user wants to resume work in a new conversation, hand something off to a different agent, or share state with a colleague, the session model provides nothing to refer to it by. An explicit `basket_id` can be passed to any of those.
+
+## Specification
+
+### Summary of changes
+
+1. **Remove the session concept from the protocol.** The `Mcp-Session-Id` header is removed and the spec language describing session lifecycle and session-scoped behavior is deleted. The protocol is sessionless at every layer. (This supersedes the opt-in stateful path that [SEP-1442] retained.)
+
+2. **List endpoints are session-independent.** With no session, the results of `tools/list`, `resources/list`, and `prompts/list` have no per-session or per-connection scope to depend on. Lists can still change for other reasons (server deployment, auth changes); caching and invalidation mechanics for those are specified separately in [SEP-2549].
+
+3. **Stateful workflows use explicit handles.** With sessions gone, servers that need to maintain state across tool calls do so by returning an identifier from a creation tool and accepting it as a parameter on subsequent calls.
+
+That third point is **not a protocol change**. There is no `handles/*` method, no handle type in the schema, no wire-level concept of a handle at all. From the protocol's perspective a handle is a string in a tool result and a string in a tool argument, indistinguishable from any other tool data. "Explicit state handles" is a tool-design pattern that the spec documents and recommends — in the same way it might document pagination or error-message conventions — not something it implements. The normative content of this SEP is the removal in (1); (2) follows from it, and (3) is the guidance that fills the gap.
+
+### Explicit state handles
+
+#### Pattern
+
+Where a server would previously have relied on implicit session-scoped state — `add_item` calls operating on a per-session cart — it instead exposes an explicit creation tool that returns a handle:
+
+```jsonc
+// → tools/call
+{ "name": "create_basket", "arguments": {} }
+
+// ← result
+{ "content": [{ "type": "text", "text": "Created basket bsk_a1b2c3" }],
+  "structuredContent": { "basket_id": "bsk_a1b2c3" } }
+```
+
+The model then threads that handle through subsequent calls as an ordinary argument:
+
+```jsonc
+// → tools/call
+{ "name": "add_item",
+  "arguments": { "basket_id": "bsk_a1b2c3", "sku": "shoes" } }
+
+// ← result
+{ "content": [{ "type": "text", "text": "Added shoes to bsk_a1b2c3 (1 item)" }] }
+
+// → tools/call
+{ "name": "checkout",
+  "arguments": { "basket_id": "bsk_a1b2c3" } }
+```
+
+Nothing here is a protocol extension: `basket_id` is an ordinary string field in `structuredContent` and an ordinary string argument to subsequent tools. This pattern is already the norm in widely-deployed remote MCP servers that manage durable resources:
+
+| Server (official, remote)                                       | Create tool → returned ID         | Operate tools taking that ID                            |
+|-----------------------------------------------------------------|-----------------------------------|---------------------------------------------------------|
+| [Linear](https://linear.app/docs/mcp)                           | `create_issue` → issue id         | `get_issue`, `update_issue`, `create_comment`           |
+| [Notion](https://developers.notion.com/docs/mcp)                | `notion-create-pages` → page id   | `notion-update-page`, `notion-move-pages`               |
+| [GitHub](https://github.com/github/github-mcp-server#tools)     | `create_pull_request` → PR number | `pull_request_read`, `update_pull_request`, `merge_pull_request` |
+| [Stripe](https://docs.stripe.com/mcp)                           | `create_customer` → customer id   | `create_invoice`, `list_subscriptions`                  |
+
+The approach can be adopted for less-persistent objects (a browser context, an in-progress cart) by giving the created object a limited lifetime, and/or limiting its discoverability to the principal that created it. The server owns the state, the client holds a name for it, and authorization is checked on every call.
+
+#### Guidance for servers
+
+None of the following is normative. Handles are a tool-design pattern, not a protocol feature, and servers are free to shape them however fits their domain. The pattern works best when:
+
+- **Handles are opaque.** A handle that encodes internal structure (`cart_user42_2026-03-11`) invites clients to parse it or models to guess it; an opaque handle such as `bsk_a1b2c3` does not.
+- **Possession is not authorization (where auth exists).** For authenticated servers, validate `(handle, auth_context)` on every call; handles will end up in chat logs, copy-paste buffers, and subagent prompts. For unauthenticated servers, where the handle is necessarily a bearer token, generate it with at least 128 bits of cryptographically secure entropy and bound its lifetime. See [Security Implications](#security-implications).
+- **Durability is documented in the tool description.** Handles outlive connections by design, so "the state lasts until the connection closes" is no longer applicable. Put the policy in the `create_*` tool's description — "returns a basket_id; baskets expire after 24h idle" — so it is visible to the model when it decides to create state. A policy only in server documentation is not visible to the model.
+- **Expired handles return useful errors.** When a tool receives a handle for state that has expired or been destroyed, the error should say so — "basket bsk_a1b2c3 has expired" rather than "invalid argument". A clear expiry error lets the model recover by calling `create_*` again; an opaque error typically leads to retries or failure.
+- **Creation takes parameters.** `create_context(cluster="staging")` is preferable to `create_context()` followed by `set_cluster(ctx, "staging")`: one round-trip instead of two, and the state cannot exist half-configured.
+- **Cleanup is available.** A `destroy_*(handle)` tool lets models release resources. A `list_*()` tool lets a model recover after losing track of what it created. Neither is required.
+
+#### Guidance for clients
+
+From the client's perspective, a handle is an ordinary string in a tool result. The main client responsibility is ensuring that string survives context compaction; if the conversation is summarized and the handle is in the discarded portion, the state is orphaned. Clients that track tool-call results across compaction boundaries handle this already.
+
+### Session-independent list endpoints
+
+With sessions removed, list endpoints no longer have a session to vary against. This is the only constraint this SEP places on `tools/list`, `resources/list`, and `prompts/list`: there is no longer a per-session or per-connection scope for their results to depend on. Lists can still change for other reasons — a server deploys a new version, a user's plan or granted scopes change — and this SEP does not enumerate or restrict those.
+
+How clients learn that a cached list has gone stale is the subject of [SEP-2549], which defines a server-advertised TTL on list responses and the interaction with `notifications/*/list_changed`. The two SEPs are complementary: this one removes the session as a source of variation, so there is a stable thing to cache; [SEP-2549] specifies how long to cache it and when to invalidate.
+
+One consequence of the constraint above is that servers can no longer mutate `tools/list` as a side effect of tool calls; the `enable_admin_tools()`-mutates-the-list pattern is no longer permitted. In practice this is rarely used. For the same effect, servers can expose all tools unconditionally at list time and enforce authorization at call time (which is already the common posture for auth-gated tools).
+
+### Consequential spec edits
+
+Two places in the current spec define behavior in terms of session scope and need re-scoping:
+
+- **JSON-RPC request ID uniqueness.** The spec currently requires that a request `id` "MUST NOT have been previously used by the requestor within the same session." The purpose of `id` is for the sender to correlate an incoming response with the request that produced it; the receiver only echoes it. With sessions removed, the constraint is re-scoped accordingly: a sender MUST NOT issue a request whose `id` matches that of another request it has sent and not yet received a response for. This is transport-agnostic, sufficient for correlation under every transport, and is what the TypeScript and Python SDKs already do via a monotonically increasing counter per client object. ([JSON-RPC 2.0 §4](https://www.jsonrpc.org/specification#request_object) itself imposes no uniqueness requirement — it only requires the receiver to echo the `id` — so this remains an MCP-level constraint.)
+- **Pagination cursor validity.** The spec currently advises clients not to "persist cursors across sessions." With sessions removed, this advice disappears. Cursor stability and snapshot consistency are outside the scope of this proposal.
+
+## Rationale
+
+### Why remove sessions rather than just default them off?
+
+[SEP-1442] already addresses making MCP work behind load balancers and without sticky routing. The reasons for going further are:
+
+- **Opt-in sessions still prevent list caching.** A client cannot cache `tools/list` across session boundaries unless it knows the server does not opt into session-scoped mutation, and it cannot know that in advance. The client therefore re-fetches per session per server even though few servers opt in. The `O(subagents × servers)` cost from the Motivation section is caused by sessions being possible, not by sessions being used, so making them optional does not remove it.
+- **The primitive influences server design.** Offering session-scoped state in the spec leads server authors to use it for workflows that would be better served by explicit IDs.
+- **Fewer primitives reduce implementation surface.** Every protocol concept must be implemented by SDK authors, documented, and learned by new users.
+
+### Expressiveness
+
+A session provides exactly one scope per connection. Explicit IDs provide as many scopes as the model creates, and each can be shared or isolated independently. Anything expressible with a session is expressible with a single ID the model creates at the start of the conversation; the converse does not hold.
+
+### Resumption
+
+Because handles appear in tool results, they are part of the chat transcript. Any client that persists its chats — which is most of them — therefore persists the handles automatically. Reopening a conversation after an app restart, a page reload, or on a different device puts the handle back in front of the model with no additional resumption machinery, and this behavior is consistent across clients. Session-based state, by contrast, requires the client to persist and resend `Mcp-Session-Id` out of band, which (as covered in the Motivation) almost no clients do.
+
+### Anticipated objections
+
+#### Garbage collection
+
+Sessions provide a lifecycle signal — when the session ends, state is freed. Without it, the model might forget to call `destroy_basket()`, and state leaks.
+
+However, sessions do not deliver this reliably in practice. As covered in the Motivation, real clients either never end the session (per-app-launch), end it constantly (per-tool-call), or end it at moments uncorrelated with the conversation (page reload, network blip). Stateless HTTP servers behind load balancers never see a connection-close. Servers already rely on TTL-based expiry today; the session boundary is not what performs cleanup.
+
+Explicit IDs with a documented durability policy ("baskets expire after 24h idle") is the same mechanism, made explicit.
+
+#### Models have to carry the IDs forward
+
+With implicit session state, the server tracks the identifier; with explicit IDs, the model is responsible for threading `basket_abc123` through every relevant call. The failure modes are hallucinating a slightly-wrong ID, or the ID falling out of context when the conversation is compacted.
+
+Models already carry opaque identifiers through conversations routinely — file paths, URLs, commit hashes, PR numbers, UUIDs returned from prior tool calls — and current models do this reliably. Compaction is the harder case, but it affects any long-horizon state: if the compactor drops live tool-call results, the model loses track of what is in the session-scoped cart as well, not just the cart's ID.
+
+#### IDs in chat history
+
+A `basket_id` that can be pasted anywhere could become an unauthenticated capability in the user's chat log.
+
+For authenticated servers, the ID should be a name, with the server checking `(id, auth_context)` on every call. Google Doc IDs sit in URLs and browser history; access is controlled by ACL, not ID secrecy. The same applies here.
+
+For servers without authentication, the ID is necessarily a bearer token — possession is the only thing the server can check. In that case the handle should follow standard practice for unguessable capability tokens: generated from a cryptographically secure random source with at least 128 bits of entropy (e.g. UUIDv4, or 22+ characters of URL-safe base64), never derived from predictable inputs, and given a bounded lifetime. This is the same posture as other ephemeral public IDs in common use — "anyone with the link" share URLs, password-reset tokens, Stripe Checkout session IDs — and carries the same tradeoff: convenient, but anyone who obtains the token has access for its lifetime.
+
+#### Breaking change
+
+Sessions are in the spec today; removing them breaks anyone relying on them.
+
+An automated survey of a 1000-repo random sample of open source MCP servers (classified by per-repo LLM analysis) found:
+
+| Category                                                     | Share | Migration                                     |
+|--------------------------------------------------------------|------:|-----------------------------------------------|
+| No application-level reference to MCP session ID             | 90.0% | None                                          |
+| `Map<sessionId, Transport>` routing (TS SDK boilerplate)     |  3.5% | Removed by a sessionless SDK transport        |
+| Transport setup only (`sessionIdGenerator`, never read)      |  2.8% | Delete one constructor option                 |
+| **Session-keyed application state**                          |  2.5% | Migrate to explicit handles or auth principal |
+| **Proxy / gateway sticky routing**                           |  0.7% | Needs designed replacement                    |
+| **Auth binding** (JWT claims, PKCE verifier keyed on session)|  0.5% | Replace with server-generated nonce or token subject |
+
+The bolded rows are the repos that use the session ID for application semantics. The hardest-hit category — gateways that spawn one upstream per session — needs a designed replacement rather than a mechanical edit; see [Backward Compatibility](#backward-compatibility).
+
+## Backward Compatibility
+
+This is a **breaking change** for servers that rely on protocol-level session state. The migration path depends on server category:
+
+**Stdio servers using process-lifetime state.** These are the most common stateful servers today and are not broken by this proposal in their default deployment: the process lifetime still exists, and a server that keeps a single in-memory browser instance per process continues to work with a stdio client that spawns one process. Stdio servers never had `Mcp-Session-Id`.
+
+**HTTP servers using `Mcp-Session-Id`.** These are less common and must migrate to explicit handles. The migration is mechanical: replace the session-scoped state map with a handle-keyed state map, add a `create_*` tool, add the handle as a parameter to stateful tools.
+
+**Servers using session ID as a telemetry key.** Some servers tag traces, logs, or rate-limit buckets with the session ID to correlate activity within a session. This already worked inconsistently across clients — against per-tool-call clients every event lands in its own bucket, and against clients that don't resume the correlation breaks at every restart. These use cases need to move to a different scoping mechanism, typically the authenticated principal (bearer token subject, API key) or a request-level correlation ID.
+
+**Proxies and gateways using session ID for sticky routing.** Gateways that route by `Mcp-Session-Id` lose their routing key — but they only needed one because their upstreams were stateful. If the upstream is stateless (or migrates to explicit handles, where the state key is in the tool arguments and any replica can serve it from shared storage), the gateway needs no sticky routing at all. The residual case is gateways that bridge HTTP to stdio by spawning one subprocess per session; those need a different correlation key, which is a transport-layer concern (route by authenticated principal, or a cookie / gateway-issued header) rather than something this SEP defines.
+
+**Servers binding auth artifacts to session ID.** A small number of servers store OAuth PKCE verifiers, session→user pinning maps, or JWT claims keyed on the session ID. In the PKCE case the server is already passing a correlation value through the OAuth `state` parameter (the browser callback is not an MCP request and never carried `Mcp-Session-Id`), so the change is to put a server-generated nonce in `state` instead of the session ID. Session→user pinning was a defense against the session-routing/auth decoupling described in [Security Implications](#security-implications) and is not needed once every request is independently authenticated. The migration is mostly mechanical, though worth a review since auth code is involved.
+
+**Clients.** Clients become simpler: they no longer track or resend session identifiers, or need to determine whether a given server is stateful. List-endpoint caching becomes safe.
+
+Rollout is a clean break: sessions are removed in the next spec version, with no deprecation window. Servers that currently rely on session-scoped state stay on the current protocol version until they have migrated to explicit handles. Protocol version negotiation already handles mixed-version deployments — a client that supports both versions speaks the old protocol to an unmigrated server and the new one to everyone else. This avoids shipping a version where clients support both modes simultaneously, which would prevent the caching benefit (a client cannot cache list endpoints if any connected server might be session-scoped).
+
+## Security Implications
+
+### Handle exposure
+
+The main security consideration introduced by this SEP is that handles will end up in places session IDs did not — chat logs, subagent prompts, copy-paste buffers, potentially other users' screens.
+
+This is a change in exposure surface, not a new class of vulnerability. Session IDs are already capability-bearing in practice: the Python SDK's stateful session manager, for example, routes by `Mcp-Session-Id` alone without verifying that the authenticated identity on the request matches the one that created the session, so a leaked session ID allows hijack by any other authenticated principal.[^py-sdk-hijack] The "validate `(id, auth_context)` on every call" guidance below applies equally to today's session IDs and to explicit handles; this SEP makes the requirement more visible because handles are more visible.
+
+[^py-sdk-hijack]: [modelcontextprotocol/python-sdk#2100](https://github.com/modelcontextprotocol/python-sdk/issues/2100).
+
+For authenticated servers, the recommended posture is the same one Google Doc IDs and GitHub PR numbers take: the ID identifies the resource, and the auth context on the request determines access. Servers that validate `(handle, auth_context)` on every call are unaffected by handle exposure.
+
+For unauthenticated servers there is no auth context to check, so the handle is a capability token. These should be generated with at least 128 bits of cryptographically secure entropy, never derived from predictable inputs, and given a bounded lifetime — the same practice as "anyone with the link" share URLs or password-reset tokens. Exposure of such a handle grants access for its lifetime; servers should size that lifetime accordingly.
+
+This is guidance, not a protocol requirement, since the protocol has no handle concept to enforce against.
+
+## Reference Implementation
+
+All official SDKs except PHP already provide a stateless mode, implemented as not generating a session ID (e.g. `sessionIdGenerator: undefined` in the TypeScript SDK, `stateless_http=True` in the Python SDK). This SEP makes that mode the only option for servers speaking the new protocol version. SDKs that support multiple protocol versions retain the session-ID-generating code path for older versions; the change is that it is no longer reachable when the negotiated protocol version is the one this SEP introduces.
+

--- a/seps/XXXX-sessionless-mcp.md
+++ b/seps/XXXX-sessionless-mcp.md
@@ -47,6 +47,7 @@ The issues below apply whether sessions are mandatory (the current spec) or opt-
 The spec does not say when a session begins or ends, because it depends on the host application. In practice, deployed clients vary widely and few scope sessions to a conversation: ChatGPT creates a fresh session for every individual tool call, and Claude.ai did the same until recently;[^per-call] most desktop and IDE clients create one at application launch and keep it for the process lifetime; web clients typically create one per page load. Almost no clients resume a prior session after a disconnect or restart, and on the server side the reference TypeScript SDK provides no public API for reconstructing a session on a different node, so multi-node deployments cannot honor resumption even when a client attempts it.[^ts-sdk-resume] A subagent might share its parent's session or get its own — there is no convention.
 
 [^per-call]: [microsoft/playwright-mcp#1045](https://github.com/microsoft/playwright-mcp/issues/1045), Sep 2025 — server author reports both ChatGPT and Claude.ai closing the session after each tool call, dropping browser state; ["Connector tool calls generating fresh MCP session each invocation"](https://community.openai.com/t/connector-tool-calls-generating-fresh-mcp-session-each-invocation/1364975), OpenAI Developer Community, Nov 2025.
+
 [^ts-sdk-resume]: [modelcontextprotocol/typescript-sdk#1658](https://github.com/modelcontextprotocol/typescript-sdk/issues/1658), Mar 2026 — `StreamableHTTPServerTransport` stores session state in private instance fields with no API to rehydrate from external storage.
 
 This matters because server authors are the ones deciding what to scope to the session, and they need to know what a session corresponds to in order to do that correctly. A Playwright server that ties a browser instance to the session needs to know whether that means one user turn, one agent process, or one long-lived chat. The spec does not specify this and different hosts give different answers, so the server is designing against an abstraction whose semantics it does not control.
@@ -60,6 +61,7 @@ Because `tools/list` may be session-dependent, a client cannot assume a result f
 The Python SDK's own design issue for client-side list caching lists "what is the cache key — per-session or per-server-URL?" as an open question,[^py-sdk-cache] and gateway implementers have shipped per-session caching specifically because they could not assume cross-session validity from the spec.[^agentgateway-cache] Every list endpoint must be treated as potentially session-scoped, so each must be re-fetched per session to be safe.
 
 [^py-sdk-cache]: [modelcontextprotocol/python-sdk#2108](https://github.com/modelcontextprotocol/python-sdk/issues/2108), Feb 2026.
+
 [^agentgateway-cache]: [agentgateway/agentgateway#1510](https://github.com/agentgateway/agentgateway/issues/1510), Apr 2026.
 
 For hosts that regularly spawn subagents, this is a multiplier on the hot path. The possibility that a server is session-scoped forces `O(subagents × servers)` calls to `tools/list`: every subagent, for every server, every time, even if the underlying tool set has not changed since the orchestrator first connected. The client cannot skip the call because it cannot know in advance which servers are session-scoped. For an orchestrator spawning many short-lived subagents, this overhead can exceed the protocol traffic of the actual tool calls. Under this proposal the same workload is `O(servers)`: the orchestrator fetches each list once and every subagent reuses the cached result.
@@ -74,10 +76,10 @@ This is a problem when different pieces of state need different scopes. Consider
 
 No session boundary satisfies both:
 
-| Session model               | Cart (want: shared) | Browser (want: isolated) |
-|-----------------------------|:-------------------:|:------------------------:|
-| Subagents share parent's    | ✓ shared           | ✗ shared (clobbers)     |
-| Subagents get their own     | ✗ isolated         | ✓ isolated              |
+| Session model            | Cart (want: shared) | Browser (want: isolated) |
+| ------------------------ | :-----------------: | :----------------------: |
+| Subagents share parent's |      ✓ shared       |   ✗ shared (clobbers)    |
+| Subagents get their own  |     ✗ isolated      |        ✓ isolated        |
 
 With explicit IDs the orchestrator calls `create_basket()` once, passes the resulting `basket_id` to each subagent, and each subagent separately calls `create_browser()` for its own `browser_id`. The model decides what is shared and what is isolated per piece of state, rather than having one scope imposed on everything.
 
@@ -127,12 +129,12 @@ The model then threads that handle through subsequent calls as an ordinary argum
 
 Nothing here is a protocol extension: `basket_id` is an ordinary string field in `structuredContent` and an ordinary string argument to subsequent tools. This pattern is already the norm in widely-deployed remote MCP servers that manage durable resources:
 
-| Server (official, remote)                                       | Create tool → returned ID         | Operate tools taking that ID                            |
-|-----------------------------------------------------------------|-----------------------------------|---------------------------------------------------------|
-| [Linear](https://linear.app/docs/mcp)                           | `create_issue` → issue id         | `get_issue`, `update_issue`, `create_comment`           |
-| [Notion](https://developers.notion.com/docs/mcp)                | `notion-create-pages` → page id   | `notion-update-page`, `notion-move-pages`               |
-| [GitHub](https://github.com/github/github-mcp-server#tools)     | `create_pull_request` → PR number | `pull_request_read`, `update_pull_request`, `merge_pull_request` |
-| [Stripe](https://docs.stripe.com/mcp)                           | `create_customer` → customer id   | `create_invoice`, `list_subscriptions`                  |
+| Server (official, remote)                                   | Create tool → returned ID         | Operate tools taking that ID                                     |
+| ----------------------------------------------------------- | --------------------------------- | ---------------------------------------------------------------- |
+| [Linear](https://linear.app/docs/mcp)                       | `create_issue` → issue id         | `get_issue`, `update_issue`, `create_comment`                    |
+| [Notion](https://developers.notion.com/docs/mcp)            | `notion-create-pages` → page id   | `notion-update-page`, `notion-move-pages`                        |
+| [GitHub](https://github.com/github/github-mcp-server#tools) | `create_pull_request` → PR number | `pull_request_read`, `update_pull_request`, `merge_pull_request` |
+| [Stripe](https://docs.stripe.com/mcp)                       | `create_customer` → customer id   | `create_invoice`, `list_subscriptions`                           |
 
 The approach can be adopted for less-persistent objects (a browser context, an in-progress cart) by giving the created object a limited lifetime, and/or limiting its discoverability to the principal that created it. The server owns the state, the client holds a name for it, and authorization is checked on every call.
 
@@ -143,7 +145,7 @@ None of the following is normative. Handles are a tool-design pattern, not a pro
 - **Handles are opaque.** A handle that encodes internal structure (`cart_user42_2026-03-11`) invites clients to parse it or models to guess it; an opaque handle such as `bsk_a1b2c3` does not.
 - **Possession is not authorization (where auth exists).** For authenticated servers, validate `(handle, auth_context)` on every call; handles will end up in chat logs, copy-paste buffers, and subagent prompts. For unauthenticated servers, where the handle is necessarily a bearer token, generate it with at least 128 bits of cryptographically secure entropy and bound its lifetime. See [Security Implications](#security-implications).
 - **Durability is documented in the tool description.** Handles outlive connections by design, so "the state lasts until the connection closes" is no longer applicable. Put the policy in the `create_*` tool's description — "returns a basket_id; baskets expire after 24h idle" — so it is visible to the model when it decides to create state. A policy only in server documentation is not visible to the model.
-- **Expired handles return useful errors.** When a tool receives a handle for state that has expired or been destroyed, the error should say so — "basket bsk_a1b2c3 has expired" rather than "invalid argument". A clear expiry error lets the model recover by calling `create_*` again; an opaque error typically leads to retries or failure.
+- **Expired handles return useful errors.** When a tool receives a handle for state that has expired or been destroyed, the error should say so — "basket `bsk_a1b2c3` has expired" rather than "invalid argument". A clear expiry error lets the model recover by calling `create_*` again; an opaque error typically leads to retries or failure.
 - **Creation takes parameters.** `create_context(cluster="staging")` is preferable to `create_context()` followed by `set_cluster(ctx, "staging")`: one round-trip instead of two, and the state cannot exist half-configured.
 - **Cleanup is available.** A `destroy_*(handle)` tool lets models release resources. A `list_*()` tool lets a model recover after losing track of what it created. Neither is required.
 
@@ -214,14 +216,14 @@ Sessions are in the spec today; removing them breaks anyone relying on them.
 
 An automated survey of a 1000-repo random sample of open source MCP servers (classified by per-repo LLM analysis) found:
 
-| Category                                                     | Share | Migration                                     |
-|--------------------------------------------------------------|------:|-----------------------------------------------|
-| No application-level reference to MCP session ID             | 90.0% | None                                          |
-| `Map<sessionId, Transport>` routing (TS SDK boilerplate)     |  3.5% | Removed by a sessionless SDK transport        |
-| Transport setup only (`sessionIdGenerator`, never read)      |  2.8% | Delete one constructor option                 |
-| **Session-keyed application state**                          |  2.5% | Migrate to explicit handles or auth principal |
-| **Proxy / gateway sticky routing**                           |  0.7% | Needs designed replacement                    |
-| **Auth binding** (JWT claims, PKCE verifier keyed on session)|  0.5% | Replace with server-generated nonce or token subject |
+| Category                                                      | Share | Migration                                            |
+| ------------------------------------------------------------- | ----: | ---------------------------------------------------- |
+| No application-level reference to MCP session ID              | 90.0% | None                                                 |
+| `Map<sessionId, Transport>` routing (TS SDK boilerplate)      |  3.5% | Removed by a sessionless SDK transport               |
+| Transport setup only (`sessionIdGenerator`, never read)       |  2.8% | Delete one constructor option                        |
+| **Session-keyed application state**                           |  2.5% | Migrate to explicit handles or auth principal        |
+| **Proxy / gateway sticky routing**                            |  0.7% | Needs designed replacement                           |
+| **Auth binding** (JWT claims, PKCE verifier keyed on session) |  0.5% | Replace with server-generated nonce or token subject |
 
 The bolded rows are the repos that use the session ID for application semantics. The hardest-hit category — gateways that spawn one upstream per session — needs a designed replacement rather than a mechanical edit; see [Backward Compatibility](#backward-compatibility).
 
@@ -262,4 +264,3 @@ This is guidance, not a protocol requirement, since the protocol has no handle c
 ## Reference Implementation
 
 All official SDKs except PHP already provide a stateless mode, implemented as not generating a session ID (e.g. `sessionIdGenerator: undefined` in the TypeScript SDK, `stateless_http=True` in the Python SDK). This SEP makes that mode the only option for servers speaking the new protocol version. SDKs that support multiple protocol versions retain the session-ID-generating code path for older versions; the change is that it is no longer reachable when the negotiated protocol version is the one this SEP introduces.
-


### PR DESCRIPTION
## Summary

Draft SEP proposing the removal of protocol-level sessions from MCP, replacing implicit session-scoped state with explicit, server-minted state handles. Builds on [SEP-1442](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1442) (stateless-by-default) but argues the opt-in stateful path should not exist at all.

**Core claims:**
- Application state is better served by explicit identifiers
- The *mere possibility* of session-scoped `tools/list` forces `O(subagents × servers)` re-fetches on everyone, even when ~zero servers actually use it
- Session cardinality of exactly-one prevents mixed shared/isolated state (e.g., subagents sharing a cart but isolating browser state)
- Explicit handles are strictly more expressive and make list endpoints cacheable at `(deployment, auth)` granularity

**What changes:**
- No `session/create`, `session/destroy`, or `Mcp-Session-Id` header
- `tools/list` / `resources/list` / `prompts/list` MUST NOT depend on per-connection or prior-tool-call state
- Stateful workflows use `create_*() -> handle` + threaded parameters (guidance, not a protocol construct)

Imported from modelcontextprotocol/transports-wg#25.