### PR TITLE
SEP-2571: Resource Submission for Agent Coordination

### DIFF
--- a/seps/2571-resource-submission.md
+++ b/seps/2571-resource-submission.md
@@ -19,16 +19,21 @@ The current MCP resources spec is read-only from the client's perspective. Serve
 
 Consider an orchestrator MCP server that accepts job definitions — configs, prompt templates, data payloads — from clients. When a job is registered, its associated resources must be stored server-side so the job can execute later, independently of the submitting client. Today this requires a custom tool (e.g. `upload_prompt`, `store_config`). This works but forces every orchestration system to reinvent the same pattern with a different interface.
 
-### The broader pattern: agent-to-agent coordination
+### Concrete use case: agent handoff
 
-Multi-agent systems frequently need to pass content between agents via a shared server:
+A research agent completes a web scraping run and needs to pass a large document corpus to a synthesis agent. Today it must either keep running (holding the connection open) or serialize the data through a custom tool. With `resources/create`, the research agent deposits its output and returns a set of URIs. The synthesis agent reads those URIs independently, on its own schedule, with no coupling to the producer's lifecycle.
 
-- Agent A submits a document for Agent B to process
-- An orchestrator stores prompt templates that worker agents will use at runtime
-- A client pre-loads context that a long-running job will need after the client disconnects
-- A pipeline stage deposits output for the next stage to consume
+### Concrete use case: async pipeline stages
 
-In all these cases, the client is the *source* of a resource, not just a consumer. The current spec has no standard way to express this.
+A multi-step data pipeline runs each stage as a separate agent invocation: extract → transform → load. Each stage needs to deposit its output for the next stage to consume. Without `resources/create`, every pipeline operator builds a custom handoff mechanism — a tool, a file path, a database row. With `resources/create`, stage output is a URI. The next stage reads it with `resources/read`. The pipeline becomes composable across different server implementations.
+
+### Concrete use case: pre-loaded context for long-running jobs
+
+A client registers a background job that will run hours later. The job needs a large prompt template and a dataset that exist only on the client at registration time. With `resources/create`, the client submits both at registration and hands the server stable URIs. When the job executes — long after the client has disconnected — it retrieves its inputs via `resources/read` with no dependency on the original client.
+
+### Why a standard primitive matters
+
+Custom tools work. But they push a general coordination primitive into application-specific territory. Every orchestrator, every async job runner, every agent handoff system ends up building the same thing with slightly different interfaces, none of which compose. `resources/create` is the natural complement to `resources/read`. The concept of a URI-addressable resource already exists in the spec — this proposal makes it writable.
 
 ### Why a standard primitive matters
 
@@ -138,6 +143,20 @@ Custom tools work for single implementations but do not compose. If resource sub
 ### Why allow `metadata`?
 
 Servers have legitimate reasons to accept hints — TTL, tags, access scope — without the spec needing to enumerate them. Making `metadata` an open object with defined ignore-unknown semantics follows the same pattern as `_meta` elsewhere in the spec.
+
+### Prior art: the industry already agrees on this pattern
+
+Every major storage and content API converges on the same shape: submit content, receive a stable reference back.
+
+| System | Submit | Reference returned |
+|---|---|---|
+| HTTP | `POST /resources` | `Location:` header URI |
+| AWS S3 | `PutObject` | S3 URI / presigned URL |
+| Google Cloud Storage | `insert` (resumable upload) | Object URI |
+| Cloudflare R2 | `PutObject` | R2 URI |
+| GitHub Gists / Pastebin | `POST` | Stable URL |
+
+MCP already has `resources/read`. The absence of `resources/create` is the anomaly. This proposal brings MCP into alignment with a pattern the industry has considered settled for decades.
 
 ### Alternatives considered
 

--- a/seps/2571-resource-submission.md
+++ b/seps/2571-resource-submission.md
@@ -163,7 +163,9 @@ This proposal adds new methods; it does not modify existing ones. Clients that d
 
 ## Reference Implementation
 
-The `resources/create` pattern is already implemented in practice by job orchestration systems that require prompt and config payloads to be stored server-side before a job executes. The interface proposed here generalizes what those systems do with custom tools today. A reference implementation against a ZeroMCP server will be linked here once published.
+The `resources/create` pattern is already implemented in practice by job orchestration systems that require prompt and config payloads to be stored server-side before a job executes. The interface proposed here generalizes what those systems do with custom tools today.
+
+A reference implementation will be built on [ZeroMCP](https://github.com/probeo-io/antidrift/tree/main/zeromcp) (`@antidrift/zeromcp`, npm), a zero-config MCP runtime that already supports HTTP transport and pluggable tool handlers. ZeroMCP is MIT-licensed and in active use. The implementation will be linked here once published.
 
 ## Open Questions
 

--- a/seps/2571-resource-submission.md
+++ b/seps/2571-resource-submission.md
@@ -157,7 +157,7 @@ This proposal adds new methods; it does not modify existing ones. Clients that d
 
 **Access control.** Resources created by one client should not be readable by arbitrary other clients unless the server explicitly allows it. The spec does not prescribe the access model but SHOULD require that the URI returned is not trivially guessable (e.g. no sequential IDs).
 
-**Content injection.** Servers that later serve submitted content to other agents should treat it as untrusted input.
+**Content injection.** Servers that later serve submitted content to other agents should treat it as untrusted input. This is particularly relevant in agentic pipelines where a submitted resource may be read directly into an LLM context — a malicious submission could attempt prompt injection against a downstream agent. Servers SHOULD surface the submitting client's identity alongside the resource when serving it, so consumers can apply appropriate trust levels.
 
 **Deletion scope.** `resources/delete` MUST be scoped so a client can only delete resources it created, unless the server explicitly grants broader permissions.
 

--- a/seps/2571-resource-submission.md
+++ b/seps/2571-resource-submission.md
@@ -1,11 +1,11 @@
-# SEP-{NUMBER}: Resource Submission — Client-to-Server Resource Creation
+# SEP-2571: Resource Submission — Client-to-Server Resource Creation
 
 - **Status**: Draft
 - **Type**: Standards Track
 - **Created**: 2026-04-14
 - **Author(s)**: Chris Welker (@cswelker)
 - **Sponsor**: None (seeking sponsor)
-- **PR**: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/{NUMBER}
+- **PR**: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2571
 
 ## Abstract
 

--- a/seps/2571-resource-submission.md
+++ b/seps/2571-resource-submission.md
@@ -165,7 +165,7 @@ This proposal adds new methods; it does not modify existing ones. Clients that d
 
 The `resources/create` pattern is already implemented in practice by job orchestration systems that require prompt and config payloads to be stored server-side before a job executes. The interface proposed here generalizes what those systems do with custom tools today.
 
-A reference implementation will be built on [ZeroMCP](https://github.com/probeo-io/antidrift/tree/main/zeromcp) (`@antidrift/zeromcp`, npm), a zero-config MCP runtime that already supports HTTP transport and pluggable tool handlers. ZeroMCP is MIT-licensed and in active use. The implementation will be linked here once published.
+A reference implementation is being built into [ZeroMCP](https://github.com/probeo-io/antidrift/tree/main/zeromcp) (`@antidrift/zeromcp`, npm) by the author of this SEP. ZeroMCP is a zero-config MCP runtime supporting HTTP transport across 10 languages, MIT-licensed and in active use. The implementation link will be added here once the feature is published.
 
 ## Open Questions
 

--- a/seps/resource-submission.md
+++ b/seps/resource-submission.md
@@ -1,0 +1,172 @@
+# SEP-{NUMBER}: Resource Submission — Client-to-Server Resource Creation
+
+- **Status**: Draft
+- **Type**: Standards Track
+- **Created**: 2026-04-14
+- **Author(s)**: Chris Welker (@cswelker)
+- **Sponsor**: None (seeking sponsor)
+- **PR**: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/{NUMBER}
+
+## Abstract
+
+This SEP proposes adding `resources/create` and `resources/delete` methods to the MCP specification, allowing clients to submit resources to a server and receive a URI back. The current resources API is read-only from the client's perspective — servers expose resources, clients consume them. This proposal makes the interface bidirectional, enabling agents to deliver content (prompts, configs, data) to a server without requiring custom tools. This unlocks a class of coordination patterns — multi-agent handoffs, job orchestration, async pipelines — that the current spec cannot address with a standard interface.
+
+## Motivation
+
+The current MCP resources spec is read-only from the client's perspective. Servers expose resources; clients list and read them. This works well for static, server-owned content but breaks down in agentic and multi-step orchestration scenarios where a client needs to *deliver* content to a server for later use.
+
+### Concrete use case: job orchestration
+
+Consider an orchestrator MCP server that accepts job definitions — configs, prompt templates, data payloads — from clients. When a job is registered, its associated resources must be stored server-side so the job can execute later, independently of the submitting client. Today this requires a custom tool (e.g. `upload_prompt`, `store_config`). This works but forces every orchestration system to reinvent the same pattern with a different interface.
+
+### The broader pattern: agent-to-agent coordination
+
+Multi-agent systems frequently need to pass content between agents via a shared server:
+
+- Agent A submits a document for Agent B to process
+- An orchestrator stores prompt templates that worker agents will use at runtime
+- A client pre-loads context that a long-running job will need after the client disconnects
+- A pipeline stage deposits output for the next stage to consume
+
+In all these cases, the client is the *source* of a resource, not just a consumer. The current spec has no standard way to express this.
+
+### Why a standard primitive matters
+
+Custom tools work. But they push a general coordination primitive into application-specific territory. Every orchestrator, every async job runner, every agent handoff system ends up building the same thing with slightly different interfaces, none of which compose. `resources/create` is the natural complement to `resources/read`. The concept of a URI-addressable resource already exists in the spec — this proposal makes it writable.
+
+## Specification
+
+### `resources/create`
+
+Submits a resource to the server. The server stores it and returns a URI that can be used in any subsequent context where a resource URI is accepted.
+
+#### Request
+
+```json
+{
+  "method": "resources/create",
+  "params": {
+    "name": "prospect-research-prompt",
+    "mimeType": "text/plain",
+    "content": "Research the following company and extract...",
+    "metadata": {
+      "ttl": 3600,
+      "tags": ["prompts", "prospecting"]
+    }
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Human-readable name for the resource |
+| `mimeType` | string | yes | MIME type of the content (`text/plain`, `application/json`, `application/octet-stream`, etc.) |
+| `content` | string | yes | Resource content. UTF-8 text, or base64-encoded binary when `mimeType` is not a text type |
+| `metadata` | object | no | Arbitrary key-value pairs. Servers may define well-known keys (e.g. `ttl`, `tags`). Servers that do not recognize a key MUST ignore it |
+
+#### Response
+
+```json
+{
+  "uri": "resource://prompts/prospect-research-prompt/abc123",
+  "name": "prospect-research-prompt",
+  "mimeType": "text/plain",
+  "createdAt": "2026-04-14T00:00:00Z"
+}
+```
+
+The returned `uri` is the canonical reference for this resource. It MUST be stable for at least the duration of the server session. Servers MAY expire resources after the TTL specified in metadata, if provided.
+
+### `resources/delete`
+
+Deletes a resource previously created by the client.
+
+#### Request
+
+```json
+{
+  "method": "resources/delete",
+  "params": {
+    "uri": "resource://prompts/prospect-research-prompt/abc123"
+  }
+}
+```
+
+#### Response
+
+Empty result on success. Servers MUST return an error if the URI does not exist or the client does not have permission to delete it.
+
+### Capability negotiation
+
+Servers that support resource submission MUST advertise this in their capabilities:
+
+```json
+{
+  "capabilities": {
+    "resources": {
+      "create": true,
+      "delete": true
+    }
+  }
+}
+```
+
+Clients MUST check for these capabilities before issuing `resources/create` or `resources/delete`.
+
+### Binary content
+
+When submitting binary content, the client MUST base64-encode the `content` field and set `mimeType` to a non-text type. Servers MUST decode it accordingly. This follows the same convention as the existing `BlobResourceContents` type.
+
+### Error handling
+
+Servers SHOULD return standard JSON-RPC error codes:
+
+- `-32602` (Invalid params) — missing required fields or malformed content
+- `-32000` (Server error) — storage failure or quota exceeded
+- A server-defined code for permission errors on `resources/delete`
+
+## Rationale
+
+### Why not a custom tool?
+
+Custom tools work for single implementations but do not compose. If resource submission is part of the spec, any compliant client can submit resources to any compliant server without prior coordination. This is the same argument that justified standardizing `tools/call` rather than leaving every server to define its own invocation convention.
+
+### Why `resources/create` rather than `resources/write` or `resources/upload`?
+
+`create` is consistent with the HTTP/REST pattern (`POST` to create a new resource, receive a reference back). `write` implies updating an existing resource at a known URI, which is a different operation. `upload` is informal. `create` is unambiguous.
+
+### Why allow `metadata`?
+
+Servers have legitimate reasons to accept hints — TTL, tags, access scope — without the spec needing to enumerate them. Making `metadata` an open object with defined ignore-unknown semantics follows the same pattern as `_meta` elsewhere in the spec.
+
+### Alternatives considered
+
+**Reuse the `prompts` primitive.** The `prompts` primitive is close but is server-defined — servers publish named prompt templates, clients fill them in. It does not support client-submitted content. Extending it to handle arbitrary client submissions would distort its semantics.
+
+**Use a tool.** Works today, but produces N incompatible interfaces. Ruled out as a standard approach for the reasons above.
+
+**Server-defined upload endpoints outside MCP.** Breaks the single-transport model and requires clients to discover and authenticate against a separate channel.
+
+## Backward Compatibility
+
+This proposal adds new methods; it does not modify existing ones. Clients that do not use `resources/create` or `resources/delete` are unaffected. The capability negotiation mechanism ensures clients can detect whether a server supports the new methods before using them. No breaking changes.
+
+## Security Implications
+
+**Storage limits.** Servers accepting arbitrary client-submitted content must enforce size and quota limits. The spec should require servers to return an appropriate error (suggest `-32000`) when limits are exceeded.
+
+**Access control.** Resources created by one client should not be readable by arbitrary other clients unless the server explicitly allows it. The spec does not prescribe the access model but SHOULD require that the URI returned is not trivially guessable (e.g. no sequential IDs).
+
+**Content injection.** Servers that later serve submitted content to other agents should treat it as untrusted input.
+
+**Deletion scope.** `resources/delete` MUST be scoped so a client can only delete resources it created, unless the server explicitly grants broader permissions.
+
+## Reference Implementation
+
+The `resources/create` pattern is already implemented in practice by job orchestration systems that require prompt and config payloads to be stored server-side before a job executes. The interface proposed here generalizes what those systems do with custom tools today. A reference implementation against a ZeroMCP server will be linked here once published.
+
+## Open Questions
+
+1. Should `resources/create` support updating an existing resource (idempotent re-submission by name), or should each call always create a new URI? The current proposal always creates a new URI; an `upsert` variant could be a follow-on.
+2. Should `resources/list` return client-created resources alongside server-defined ones, or should there be a filter? The current proposal does not modify `resources/list` behavior — servers may include or exclude submitted resources at their discretion.
+3. Should TTL be a first-class field rather than buried in `metadata`? Open to community input.


### PR DESCRIPTION
## Summary

This SEP proposes `resources/create` and `resources/delete` — making the MCP resources interface bidirectional. The current spec is read-only from the client's perspective. This proposal adds a standard way for clients to submit resources to a server and receive a URI back.

## Motivation

Multi-agent and job orchestration systems repeatedly build the same pattern with custom tools: submit a payload (prompt, config, data), get a reference back, use that reference later when the job runs. Standardizing this as `resources/create` makes it composable across any compliant client and server.

Concrete use cases covered in the SEP:
- Job orchestration: storing prompt templates and configs server-side before a job executes
- Agent handoff: Agent A deposits content for Agent B via a shared server
- Async pipelines: a client pre-loads context a long-running job will need after the client disconnects

## What's in the SEP

- `resources/create` — submit content, receive a stable URI
- `resources/delete` — cleanup, scoped to resources the client created
- Capability negotiation via `capabilities.resources.create/delete`
- Binary content via base64 (consistent with `BlobResourceContents`)
- Open `metadata` field for hints (TTL, tags) with ignore-unknown semantics
- Security considerations: storage limits, access control, content injection, deletion scope
- Three open questions for community input

## Closes

Supersedes issue #2570 (submitted incorrectly as an issue rather than a PR — apologies for the noise).