### PR TITLE
Add Runbear to Example Clients list

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -1961,6 +1961,24 @@ Roo Code enables AI coding assistance via MCP.
 </McpClient>
 
 <McpClient
+  name="Runbear"
+  homepage="https://runbear.io"
+  supports="Resources, Tools"
+  instructions="https://docs.runbear.io/team-agent/custom-mcp"
+>
+
+[Runbear](https://runbear.io) is an AI agent platform for Slack and Microsoft Teams that acts as a managed MCP host. It enables teams to connect 2,000+ tools (HubSpot, Linear, NetSuite, etc.) to their chat workspace using the Model Context Protocol.
+
+**Key features:**
+
+- **Managed MCP Servers**: Out-of-the-box support for HubSpot, Linear, and more.
+- **Secure Hosting**: SOC 2 Type II compliant environment for MCP operations.
+- **Cross-Platform**: Access your MCP tools from Slack, Teams, and HubSpot.
+- **Vast Integration Library**: Connect to 2,000+ tools via native integrations and custom MCP servers.
+
+</McpClient>
+
+<McpClient
   name="rtrvr.ai"
   homepage="https://rtrvr.ai"
   supports="Tools"


### PR DESCRIPTION
Add Runbear to the Example Clients list. Runbear is a managed MCP host that brings Model Context Protocol capabilities to Slack and Microsoft Teams, allowing teams to interact with their tech stack through a collaborative AI agent.