### PR TITLE
Fix `linguist-generated` paths for rendered SEP docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,5 +2,5 @@ package-lock.json linguist-generated=true
 schema/*/schema.json linguist-generated=true
 docs/specification/*/schema.md linguist-generated=true
 docs/specification/*/schema.mdx linguist-generated=true
-docs/community/seps/index.mdx linguist-generated=true
-docs/community/seps/[0-9]*.mdx linguist-generated=true
+docs/seps/index.mdx linguist-generated=true
+docs/seps/[0-9]*.mdx linguist-generated=true


### PR DESCRIPTION
PR #2364 moved `docs/community/seps/` to `docs/seps/`, but the corresponding patterns in `.gitattributes` were not updated to match. Fix the paths so GitHub continues to collapse these generated files in diffs.
