### PR TITLE
docs(spec): restore tool-name disambiguation note dropped in #2243

### DIFF
--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -239,6 +239,20 @@ A tool definition includes:
   - `DATA_EXPORT_v2`
   - `admin.tools.list`
 
+<Note>
+
+Tool name uniqueness is scoped to a single server. Clients or proxies that
+aggregate tools from multiple servers **MAY** encounter naming collisions (for
+example, two servers each exposing a `search` tool) and **SHOULD** implement a
+disambiguation strategy such as prefixing tool names with a server identifier.
+
+The server `name` returned during
+[initialization](/specification/draft/basic/lifecycle#initialization) is not
+guaranteed to be unique across servers and **SHOULD NOT** be relied upon for
+disambiguation.
+
+</Note>
+
 #### x-mcp-header
 
 The `x-mcp-header` extension property allows servers to designate specific tool


### PR DESCRIPTION
PR #2243 (SEP-2243 HTTP Standardization) inserted the new `#### x-mcp-header` subsection into `draft/server/tools.mdx`, but the rebase resolved a conflict by overwriting the existing `<Note>` under **Tool Names** rather than inserting after it. That Note covers per-server tool name scope, the SHOULD for aggregating clients to prefix tool names, and the warning that `serverInfo.name` is not a reliable disambiguation key.

This restores the Note verbatim from `828bd471` (where it was originally added) in its prior position, immediately after the tool name examples and before the new `x-mcp-header` heading. No wording changes.

Relates to #2580, where the reporter notes the spec is silent on this; restoring the dropped text is a prerequisite to discussing any further guidance there.