### PR TITLE
docs(community): convert Skills Over MCP IG to Working Group

### DIFF
--- a/docs/community/skills-over-mcp/charter.mdx
+++ b/docs/community/skills-over-mcp/charter.mdx
@@ -129,8 +129,8 @@ Full live tracking is on the [Skills Over MCP WG project board](https://github.c
 
 ## Changelog
 
-| Date       | Change                                         |
-| ---------- | ---------------------------------------------- |
-| 2026-04-16 | Converted from Interest Group to Working Group |
+| Date       | Change                                                                                                                                                                                                                                                                                                           |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-16 | Converted from Interest Group to Working Group                                                                                                                                                                                                                                                                   |
 | 2026-04-14 | Initial charter (formalized from [experimental-ext-skills](https://github.com/modelcontextprotocol/experimental-ext-skills) repo README, which served as the de facto charter before the charter process was established via [SEP-2149](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2149)) |
-| 2026-02-01 | IG formed; experimental repo created            |
+| 2026-02-01 | IG formed; experimental repo created                                                                                                                                                                                                                                                                             |

--- a/docs/community/skills-over-mcp/charter.mdx
+++ b/docs/community/skills-over-mcp/charter.mdx
@@ -1,42 +1,43 @@
 ---
 title: Skills Over MCP Charter
-description: Charter for the MCP Skills Over MCP Interest Group.
+description: Charter for the MCP Skills Over MCP Working Group.
 ---
 
 ## Group Type
 
-**Interest Group**
+**Working Group**
 
 ## Mission Statement
 
-The Skills Over MCP Interest Group explores how "agent skills" — rich, structured
-instructions for agent workflows — can be discovered and consumed through MCP. Native
-skills support in host applications demonstrates strong demand, and the IG emerged from
-discussion on [SEP-2076 — Agent Skills as a First-Class MCP Primitive](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2076),
+The Skills Over MCP Working Group defines how "agent skills" — rich, structured
+instructions for agent workflows — are discovered, distributed, and consumed through MCP.
+Native skills support in host applications demonstrates strong demand, and the group
+emerged from discussion on [SEP-2076 — Agent Skills as a First-Class MCP Primitive](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2076),
 which raised open questions about whether existing MCP primitives suffice or what
-conventions to standardize. Cross-cutting collaboration is needed because solutions touch
-the protocol spec, registry schema, SDK implementations, and client behavior.
+conventions to standardize. The WG produces specification extensions, reference
+implementations, and coordination artifacts because solutions touch the protocol spec,
+registry schema, SDK implementations, and client behavior.
 
 ## Scope
 
 ### In Scope
 
-- **Requirements gathering**: Documenting use cases, constraints, and gaps in current
-  MCP primitives for skill distribution
-- **Pattern exploration**: Testing and evaluating approaches (skills as tools, resources,
-  registry metadata, protocol primitives) and discovery mechanisms (runtime via MCP,
-  domain-level via well-known URIs, ecosystem-level via registry)
-- **Coordination**: Bridging discussions across Registry WG, Agents WG, and external
-  projects including the [Agent Skills](https://agentskills.io/) spec (content format
-  and well-known URI discovery), FastMCP, and PydanticAI
-- **Proof of concepts**: Maintaining a shared repo of reference implementations and
-  experimental findings
+- **Specification Work**: SEPs defining how skills are represented, discovered, and
+  consumed within MCP — including the Skills Extension (Extensions Track) and related
+  protocol changes
+- **Reference Implementations**: SDK components and reference servers demonstrating
+  skill discovery and consumption patterns
+- **Cross-Cutting Concerns**: Coordination with Registry WG (skills discovery/distribution,
+  registry schema changes), Agents WG (skill activation, server metadata consumption),
+  Primitive Grouping WG (progressive disclosure patterns), and external projects including
+  the [Agent Skills](https://agentskills.io/) spec (content format and well-known URI
+  discovery), FastMCP, and PydanticAI
+- **Documentation**: Specification sections and guidance covering skill authoring,
+  discovery, and consumption
 
 ### Out of Scope
 
-- **Approving spec changes**: This IG does not have authority to approve protocol
-  changes; recommendations flow through the SEP process
-- **Registry schema decisions**: Schema ownership belongs to the Registry WG; this IG
+- **Registry schema decisions**: Schema ownership belongs to the Registry WG; this WG
   contributes requirements but does not own the schema
 - **Client implementation mandates**: We can document patterns but not require specific
   client behavior
@@ -50,64 +51,86 @@ the protocol spec, registry schema, SDK implementations, and client behavior.
 - **Registry WG** — Skills discovery/distribution, registry schema changes
 - **Primitive Grouping WG** — Progressive disclosure patterns
 
+## Leadership
+
+| Role | Name            | Organization                | GitHub                                   | Term    |
+| ---- | --------------- | --------------------------- | ---------------------------------------- | ------- |
+| Lead | Ola Hungerford  | Nordstrom / MCP Maintainer  | [@olaservo](https://github.com/olaservo) | Initial |
+| Lead | Peter Alexander | Anthropic / Core Maintainer | [@pja-ant](https://github.com/pja-ant)   | Initial |
+
+## Authority & Decision Rights
+
+| Decision Type                       | Authority Level                                        |
+| ----------------------------------- | ------------------------------------------------------ |
+| Meeting logistics & scheduling      | WG Leads (autonomous)                                  |
+| Proposal prioritization within WG   | WG Leads (autonomous)                                  |
+| SEP triage & closure (in scope)     | WG Leads (autonomous, with documented rationale)       |
+| Technical design within scope       | WG consensus                                           |
+| Spec changes (additive)             | WG consensus → Core Maintainer approval                |
+| Spec changes (breaking/fundamental) | WG consensus → Core Maintainer approval + wider review |
+| Scope expansion                     | Core Maintainer approval required                      |
+| WG Member approval                  | WG Member sponsors                                     |
+
 ## Membership
 
-| Name                     | Organization                    | GitHub                                                 | Level       |
-| ------------------------ | ------------------------------- | ------------------------------------------------------ | ----------- |
-| Ola Hungerford           | Nordstrom / MCP Maintainer      | [@olaservo](https://github.com/olaservo)               | Facilitator |
-| Peter Alexander          | Anthropic / Core Maintainer     | [@pja-ant](https://github.com/pja-ant)                 | Facilitator |
-| Yu Yi                    | Google                          | [@erain](https://github.com/erain)                     | Participant |
-| Sunish Sheth             | Databricks                      | [@sunishsheth2009](https://github.com/sunishsheth2009) | Participant |
-| Keith A Groves           | Hyix                            | [@keithagroves](https://github.com/keithagroves)       | Participant |
-| Peder Holdgaard Pedersen | Saxo Bank / MCP Maintainer      | [@pederhp](https://github.com/pederhp)                 | Participant |
-| Sam Morrow               | GitHub                          | [@SamMorrowDrums](https://github.com/SamMorrowDrums)   | Participant |
-| Jacob MacDonald          | Google                          | [@jakemac53](https://github.com/jakemac53)             | Participant |
-| Jonathan Hefner          | Independent / MCP Maintainer    | [@jonathanhefner](https://github.com/jonathanhefner)   | Participant |
-| Luca Chang               | AWS / MCP Maintainer            | [@LucaButBoring](https://github.com/LucaButBoring)     | Participant |
-| Bob Dickinson            | TeamSpark.ai / MCP Maintainer   | [@BobDickinson](https://github.com/BobDickinson)       | Participant |
-| Radoslav Dimitrov        | Stacklok / MCP Maintainer       | [@rdimitrov](https://github.com/rdimitrov)             | Participant |
-| Juan Antonio Osorio      | Stacklok                        | [@JAORMX](https://github.com/JAORMX)                   | Participant |
-| Kaxil Naik               | Astronomer / Apache Airflow PMC | [@kaxil](https://github.com/kaxil)                     | Participant |
-| Cliff Hall               | Futurescale                     | [@cliffhall](https://github.com/cliffhall)             | Participant |
+| Name                     | Organization                    | GitHub                                                 | Discord | Level       |
+| ------------------------ | ------------------------------- | ------------------------------------------------------ | ------- | ----------- |
+| Ola Hungerford           | Nordstrom / MCP Maintainer      | [@olaservo](https://github.com/olaservo)               |         | Lead        |
+| Peter Alexander          | Anthropic / Core Maintainer     | [@pja-ant](https://github.com/pja-ant)                 |         | Lead        |
+| Yu Yi                    | Google                          | [@erain](https://github.com/erain)                     |         | Participant |
+| Sunish Sheth             | Databricks                      | [@sunishsheth2009](https://github.com/sunishsheth2009) |         | Participant |
+| Keith A Groves           | Hyix                            | [@keithagroves](https://github.com/keithagroves)       |         | Participant |
+| Peder Holdgaard Pedersen | Saxo Bank / MCP Maintainer      | [@pederhp](https://github.com/pederhp)                 |         | Participant |
+| Sam Morrow               | GitHub                          | [@SamMorrowDrums](https://github.com/SamMorrowDrums)   |         | Participant |
+| Jacob MacDonald          | Google                          | [@jakemac53](https://github.com/jakemac53)             |         | Participant |
+| Jonathan Hefner          | Independent / MCP Maintainer    | [@jonathanhefner](https://github.com/jonathanhefner)   |         | Participant |
+| Luca Chang               | AWS / MCP Maintainer            | [@LucaButBoring](https://github.com/LucaButBoring)     |         | Participant |
+| Bob Dickinson            | TeamSpark.ai / MCP Maintainer   | [@BobDickinson](https://github.com/BobDickinson)       |         | Participant |
+| Radoslav Dimitrov        | Stacklok / MCP Maintainer       | [@rdimitrov](https://github.com/rdimitrov)             |         | Participant |
+| Juan Antonio Osorio      | Stacklok                        | [@JAORMX](https://github.com/JAORMX)                   |         | Participant |
+| Kaxil Naik               | Astronomer / Apache Airflow PMC | [@kaxil](https://github.com/kaxil)                     |         | Participant |
+| Cliff Hall               | Futurescale                     | [@cliffhall](https://github.com/cliffhall)             |         | Participant |
 
 ## Operations
 
-| Meeting      | Frequency         | Duration   | Purpose                                                                             |
-| ------------ | ----------------- | ---------- | ----------------------------------------------------------------------------------- |
-| Office Hours | Weekly (Tuesdays) | 60 minutes | Technical discussion, pattern evaluation, proposal review; open to all participants |
+| Meeting         | Frequency         | Duration   | Purpose                                                                             |
+| --------------- | ----------------- | ---------- | ----------------------------------------------------------------------------------- |
+| Working Session | Weekly (Tuesdays) | 60 minutes | Technical discussion, pattern evaluation, proposal review; open to all participants |
 
 Default start time is 9:00 AM Pacific. Sessions may occasionally be scheduled earlier to better accommodate non-US time zones.
 
-Meetings are published at [meet.modelcontextprotocol.io](https://meet.modelcontextprotocol.io). Agendas are posted in advance per MCP meeting policy. Meeting notes are published to [Meeting Notes — Skills Over MCP IG](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/categories/meeting-notes-skills-over-mcp-ig).
+Meetings are published at [meet.modelcontextprotocol.io](https://meet.modelcontextprotocol.io). Agendas are posted in advance per MCP meeting policy. Meeting notes are published to [Meeting Notes — Skills Over MCP WG](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/categories/meeting-notes-skills-over-mcp-wg).
 
-Discord: [#skills-over-mcp-ig](https://discord.com/channels/1358869848138059966/1464745826629976084)
+Discord: [#skills-over-mcp-wg](https://discord.com/channels/1358869848138059966/1464745826629976084)
 
 ## Resources
 
 - Experimental findings and reference implementations: [modelcontextprotocol/experimental-ext-skills](https://github.com/modelcontextprotocol/experimental-ext-skills)
-- Project board: [Skills Over MCP IG](https://github.com/orgs/modelcontextprotocol/projects/38/views/1)
+- Project board: [Skills Over MCP WG](https://github.com/orgs/modelcontextprotocol/projects/38/views/1)
 
 ## Deliverables & Success Metrics
 
 ### Active Work Items
 
-Full live tracking is on the [Skills Over MCP IG project board](https://github.com/orgs/modelcontextprotocol/projects/38/views/1). Headline workstreams:
+Full live tracking is on the [Skills Over MCP WG project board](https://github.com/orgs/modelcontextprotocol/projects/38/views/1). Headline workstreams:
 
-| Item                                           | Status      | Champion                                                                                     |
-| ---------------------------------------------- | ----------- | -------------------------------------------------------------------------------------------- |
-| Skills Extension SEP (draft, Extensions Track) | In Review   | [@pja-ant](https://github.com/pja-ant)                                                       |
-| Skills Extension reference implementation      | In Review   | [@olaservo](https://github.com/olaservo)                                                     |
-| Agent Skills spec coordination                 | In Progress | [@jonathanhefner](https://github.com/jonathanhefner), [@pja-ant](https://github.com/pja-ant) |
-| Registry skills.json proposal                  | In Progress | [@JAORMX](https://github.com/JAORMX)                                                         |
+| Item                                           | Status      | Target Date | Champion                                                                                     |
+| ---------------------------------------------- | ----------- | ----------- | -------------------------------------------------------------------------------------------- |
+| Skills Extension SEP (draft, Extensions Track) | In Review   |             | [@pja-ant](https://github.com/pja-ant)                                                       |
+| Skills Extension reference implementation      | In Review   |             | [@olaservo](https://github.com/olaservo)                                                     |
+| Agent Skills spec coordination                 | In Progress |             | [@jonathanhefner](https://github.com/jonathanhefner), [@pja-ant](https://github.com/pja-ant) |
+| Registry skills.json proposal                  | In Progress |             | [@JAORMX](https://github.com/JAORMX)                                                         |
 
 ### Success Criteria
 
 - **Short-term**: Documented consensus on requirements and evaluation of existing approaches
-- **Medium-term**: Clear recommendation (convention vs. protocol extension vs. both) — the draft Skills Extension SEP represents the IG's current direction: a formal extension using existing Resources primitives
+- **Medium-term**: Clear recommendation (convention vs. protocol extension vs. both) — the draft Skills Extension SEP represents the WG's current direction: a formal extension using existing Resources primitives
 - **Long-term**: Interoperable skill distribution across MCP servers and clients
 
 ## Changelog
 
-| Date       | Change          |
-| ---------- | --------------- |
-| 2026-04-14 | Initial charter |
+| Date       | Change                                         |
+| ---------- | ---------------------------------------------- |
+| 2026-04-16 | Converted from Interest Group to Working Group |
+| 2026-04-14 | Initial charter (formalized from [experimental-ext-skills](https://github.com/modelcontextprotocol/experimental-ext-skills) repo README, which served as the de facto charter before the charter process was established via [SEP-2149](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2149)) |
+| 2026-02-01 | IG formed; experimental repo created            |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -463,13 +463,8 @@
             "pages": [
               "community/inspector-v2/charter",
               "community/server-card/charter",
+              "community/skills-over-mcp/charter",
               "community/triggers-events/charter"
-            ]
-          },
-          {
-            "group": "Interest Group Charters",
-            "pages": [
-              "community/skills-over-mcp/charter"
             ]
           },
           {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -27,9 +27,7 @@
         "pages": [
           {
             "group": "Get started",
-            "pages": [
-              "docs/getting-started/intro"
-            ]
+            "pages": ["docs/getting-started/intro"]
           },
           {
             "group": "About MCP",
@@ -60,17 +58,11 @@
           },
           {
             "group": "Developer tools",
-            "pages": [
-              "docs/tools/inspector",
-              "docs/tools/debugging"
-            ]
+            "pages": ["docs/tools/inspector", "docs/tools/debugging"]
           },
           {
             "group": "Examples",
-            "pages": [
-              "clients",
-              "examples"
-            ]
+            "pages": ["clients", "examples"]
           }
         ]
       },
@@ -81,10 +73,7 @@
           "extensions/client-matrix",
           {
             "group": "MCP Apps",
-            "pages": [
-              "extensions/apps/overview",
-              "extensions/apps/build"
-            ]
+            "pages": ["extensions/apps/overview", "extensions/apps/build"]
           },
           {
             "group": "Authorization Extensions",
@@ -372,9 +361,7 @@
           },
           {
             "group": "Consuming",
-            "pages": [
-              "registry/registry-aggregators"
-            ]
+            "pages": ["registry/registry-aggregators"]
           },
           "registry/terms-of-service"
         ]
@@ -424,9 +411,7 @@
           },
           {
             "group": "Draft",
-            "pages": [
-              "seps/2243-http-standardization"
-            ]
+            "pages": ["seps/2243-http-standardization"]
           }
         ]
       },
@@ -444,10 +429,7 @@
           },
           {
             "group": "Propose Changes",
-            "pages": [
-              "community/design-principles",
-              "community/sep-guidelines"
-            ]
+            "pages": ["community/design-principles", "community/sep-guidelines"]
           },
           {
             "group": "Governance",
@@ -469,9 +451,7 @@
           },
           {
             "group": "Roadmap",
-            "pages": [
-              "development/roadmap"
-            ]
+            "pages": ["development/roadmap"]
           }
         ]
       }
@@ -665,9 +645,6 @@
     }
   ],
   "contextual": {
-    "options": [
-      "copy",
-      "view"
-    ]
+    "options": ["copy", "view"]
   }
 }


### PR DESCRIPTION
## Summary

Converts the Skills Over MCP Interest Group to a Working Group. The group has moved beyond exploration into producing concrete deliverables (Skills Extension SEP, reference implementations, Agent Skills spec coordination), warranting the WG structure and authority.

### Charter changes
- Group Type: Interest Group → Working Group
- Mission statement reframed from exploration to concrete deliverables
- In Scope restructured to WG categories (Specification Work, Reference Implementations, Cross-Cutting Concerns, Documentation)
- Removed "Approving spec changes" from Out of Scope (WGs own this via SEP process)
- Added Leadership section (Ola Hungerford + Peter Alexander as Leads)
- Added Authority & Decision Rights table
- Membership table: Facilitator → Lead, added Discord column per template
- Operations: Office Hours → Working Session
- Deliverables table: added Target Date column per WG template
- All `-ig` references updated to `-wg`
- Changelog: added IG formation date (2026-02-01) and note that the formal charter was derived from the [experimental-ext-skills](https://github.com/modelcontextprotocol/experimental-ext-skills) repo README, which predated the charter process (SEP-2149)

### Navigation
- Moved `community/skills-over-mcp/charter` from "Interest Group Charters" to "Working Group Charters" in `docs.json`
- Removed the now-empty "Interest Group Charters" group

## Follow-up items

- [ ] Confirm membership participation levels (Participant vs WG Member)
- [ ] Update [access repo](https://github.com/modelcontextprotocol/access) — move `SKILLS_OVER_MCP_IG` to Working Groups section as `SKILLS_OVER_MCP_WG` in `roleIds.ts`, `roles.ts`, `users.ts`
- [ ] Rename Discord channel `#skills-over-mcp-ig` → `#skills-over-mcp-wg`
- [ ] Rename GitHub Discussions category `meeting-notes-skills-over-mcp-ig` → `meeting-notes-skills-over-mcp-wg`
- [ ] Update [experimental-ext-skills](https://github.com/modelcontextprotocol/experimental-ext-skills) README (still references "Interest Group" and `-ig` channels)

🦉 Generated with [Claude Code](https://claude.com/claude-code)