### PR TITLE
Expose MCP skills via .well-known/agent-skills/ discovery

### DIFF
--- a/docs/.mintlify/skills/search-mcp-github/SKILL.md
+++ b/docs/.mintlify/skills/search-mcp-github/SKILL.md
@@ -1,0 +1,1 @@
+../../../../plugins/mcp-spec/skills/search-mcp-github/SKILL.md

--- a/plugins/mcp-spec/skills/search-mcp-github/SKILL.md
+++ b/plugins/mcp-spec/skills/search-mcp-github/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: search-mcp-github
 description: Search MCP PRs, issues, and discussions across the modelcontextprotocol GitHub org
+license: Apache-2.0
 user_invocable: true
 arguments:
   - name: topic


### PR DESCRIPTION
Adds `.mintlify/skills/` with a symlink to the `search-mcp-github` skill so it's auto-served at `/.well-known/agent-skills/index.json`. Also adds `license: Apache-2.0` to the skill frontmatter per the agentskills.io spec.

Mintlify documentation: https://www.mintlify.com/docs/ai/skillmd#custom-skill-files

🦉 Generated with [Claude Code](https://claude.ai/claude-code)