### PR TITLE
docs(governance): clarify WG/IG formation needs no Core Maintainer vote

### DIFF
--- a/docs/community/working-interest-groups.mdx
+++ b/docs/community/working-interest-groups.mdx
@@ -234,7 +234,7 @@ informing the rest of the Core Maintainer group that the new group has been crea
 
 - There must be a widely acknowledged concern requiring coordination
 - PR for creation of WG into `docs/community/<name>/overview.mdx`, gated by CODEOWNERS requiring approval by Maintainers
-- PR for charter into `docs/community/<name>/charter.mdx`, gated by CODEOWNERS requiring approval from Core Maintainers
+- PR for charter into `docs/community/<name>/charter.mdx`, gated by CODEOWNERS requiring approval from a sponsoring Core Maintainer
 - Initial member list approved by WG Lead
 
 **Interest Group Formation:**
@@ -254,7 +254,7 @@ informing the rest of the Core Maintainer group that the new group has been crea
 Changes to a group's charter (WG or IG) require:
 
 - Proposal by Lead/Facilitator or Core Maintainer
-- Approval by Core Maintainers
+- Approval by a sponsoring Core Maintainer
 
 ## Charters
 

--- a/docs/community/working-interest-groups.mdx
+++ b/docs/community/working-interest-groups.mdx
@@ -225,6 +225,11 @@ The quarterly updates are provided as a document posted in the [GitHub Discussio
 
 ### Lifecycle
 
+Forming a Working Group or Interest Group does not require a formal vote of the Core Maintainer
+group. Formation is sponsorship-based: once the sponsorship requirement above is met and the steps
+below are complete, the group is formed. The sponsoring Core Maintainer(s) are responsible for
+informing the rest of the Core Maintainer group that the new group has been created.
+
 **Working Group Formation:**
 
 - There must be a widely acknowledged concern requiring coordination


### PR DESCRIPTION
The Working/Interest Groups doc currently describes formation through sponsorship (two Core Maintainers or one Lead Maintainer) plus the PR/Discord steps, but it never states whether the Core Maintainer group as a whole has to vote on a new group. In practice it does not, and that ambiguity has come up enough times to be worth writing down.

This adds a short paragraph at the top of the Lifecycle section making two things explicit: forming a WG or IG does not require a formal vote of the Core Maintainer group, and the sponsoring Core Maintainer(s) are responsible for informing the rest of the Core Maintainers once the group is created. Nothing else about the formation steps changes.