### PR TITLE
SEP-2149: clarify single Core Maintainer approval for WG charter

### DIFF
--- a/docs/seps/2149-working-group-charter-template.mdx
+++ b/docs/seps/2149-working-group-charter-template.mdx
@@ -228,7 +228,7 @@ with the Core Maintainers in a core maintainer meeting.
 
 - There must be a widely acknowledged concern requiring coordination
 - PR for creation of WG into `docs/community/<name>/overview.mdx`, gated by CODEOWNERS requiring approval by Maintainers
-- PR for charter into `docs/community/<name>/charter.mdx`, gated by CODEOWNERS requiring approval from Core Maintainers
+- PR for charter into `docs/community/<name>/charter.mdx`, gated by CODEOWNERS requiring approval from a single Core Maintainer (who should notify all Core Maintainers)
 - Initial member list approved by WG Lead
 
 **Interest Group Formation:**

--- a/seps/2149-working-group-charter-template.md
+++ b/seps/2149-working-group-charter-template.md
@@ -209,7 +209,7 @@ with the Core Maintainers in a core maintainer meeting.
 
 - There must be a widely acknowledged concern requiring coordination
 - PR for creation of WG into `docs/community/<name>/overview.mdx`, gated by CODEOWNERS requiring approval by Maintainers
-- PR for charter into `docs/community/<name>/charter.mdx`, gated by CODEOWNERS requiring approval from Core Maintainers
+- PR for charter into `docs/community/<name>/charter.mdx`, gated by CODEOWNERS requiring approval from a single Core Maintainer (who should notify all Core Maintainers)
 - Initial member list approved by WG Lead
 
 **Interest Group Formation:**


### PR DESCRIPTION
## Summary
- Clarifies that Working Group charter PRs require approval from a single Core Maintainer (not a vote), with notification to all Core Maintainers
- Updates both the SEP source (`seps/2149-...md`) and the regenerated docs (`docs/seps/2149-...mdx`)

## Test plan
- [ ] `npm run check:seps` passes
- [ ] Rendered SEP page reflects the clarified wording