### PR TITLE
fix: use directory symlink so search-mcp-github skill is indexed

### DIFF
--- a/docs/.mintlify/skills/search-mcp-github
+++ b/docs/.mintlify/skills/search-mcp-github
@@ -1,0 +1,1 @@
+../../../plugins/mcp-spec/skills/search-mcp-github

--- a/docs/.mintlify/skills/search-mcp-github/SKILL.md
+++ b/docs/.mintlify/skills/search-mcp-github/SKILL.md
@@ -1,1 +1,0 @@
-../../../../plugins/mcp-spec/skills/search-mcp-github/SKILL.md


### PR DESCRIPTION
## Summary

- Follow-up to #2589: after merge, `search-mcp-github` never appeared in [`/.well-known/agent-skills/index.json`](https://modelcontextprotocol.io/.well-known/agent-skills/index.json) — only the auto-generated `mcp` skill showed up.
- Reviewer [@jonathanhefner](https://github.com/jonathanhefner) flagged that #2589 created a **file-level** symlink (`SKILL.md -> SKILL.md`), while Mintlify's auto-scan appears to expect each skill as a **subdirectory**. The live auto-generated skill is served at `/agent-skills/mcp/skill.md`, matching that pattern.
- This PR replaces the file symlink with a per-skill directory symlink: `docs/.mintlify/skills/search-mcp-github` → `../../../plugins/mcp-spec/skills/search-mcp-github`. Both modes stay `120000` in git, so the tree survives Linux checkouts.

## Test plan

- [ ] CI green
- [ ] After deploy, `curl https://modelcontextprotocol.io/.well-known/agent-skills/index.json` includes an entry with `name: search-mcp-github` and `url: /.well-known/agent-skills/search-mcp-github/skill.md`
- [ ] `curl https://modelcontextprotocol.io/.well-known/agent-skills/search-mcp-github/skill.md` returns the skill body with frontmatter
- [ ] If the index is still only `mcp` after deploy, the file-vs-directory hypothesis was wrong — next step is to ask Mintlify support whether symlinks are supported at all

🦉 Generated with [Claude Code](https://claude.com/claude-code)