### PR TITLE
docs: symlink draft-sep skill for Mintlify + note Agent Skills symlink requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,10 @@ JSON examples live in `schema/[version]/examples/[TypeName]/`:
 - Files validate against their directory's type: `Tool/example-name.json` → Tool schema
 - Referenced in `schema.ts` via `@includeCode` JSDoc tags
 
+## Agent Skills
+
+When adding a new skill, also add a directory symlink at `docs/.mintlify/skills/<name>` pointing to `../../../plugins/<plugin-name>/skills/<name>` so Mintlify's `.well-known/agent-skills/` and MCP server auto-scan exposes it.
+
 ## Useful Commands
 
 ```bash

--- a/docs/.mintlify/skills/draft-sep
+++ b/docs/.mintlify/skills/draft-sep
@@ -1,0 +1,1 @@
+../../../plugins/mcp-spec/skills/draft-sep


### PR DESCRIPTION
## Summary
- Adds a directory symlink `docs/.mintlify/skills/draft-sep` → `../../../plugins/mcp-spec/skills/draft-sep` so the `draft-sep` skill (added in #2410) is picked up by Mintlify's `.well-known/agent-skills/` auto-scan. Mirrors the `search-mcp-github` fix from #2597.
- Documents the requirement in `AGENTS.md` so future skill additions don't miss this step.

## Test plan
- [ ] After merge, verify `draft-sep` appears in the live `.well-known/agent-skills/` index alongside `search-mcp-github` and `mcp`.
- [ ] Confirm `/agent-skills/draft-sep/skill.md` resolves to the SKILL.md content.