### PR TITLE
docs(clients): add Burnish (explorer-first MCP client)

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -623,6 +623,30 @@ Bob Shell brings IBM Bob's AI capabilities to your command line.
 </McpClient>
 
 <McpClient
+  name="Burnish"
+  homepage="https://burnish-demo.fly.dev"
+  sourceCode="https://github.com/danfking/burnish"
+  supports="Tools, Discovery, Instructions"
+>
+
+Burnish is an explorer-first MCP client — "Swagger UI for MCP." It auto-generates interactive UI from any server's tool outputs and input schemas, so you can inspect and invoke tools directly without an LLM or chat loop.
+
+**Key features:**
+
+- No LLM required: tools are executed from auto-generated forms, outputs render as cards, tables, charts, pipelines, and dashboards based on JSON shape.
+- 10 Lit 3 web components drive the output layer; embeddable via npm or CDN in your own app (`@burnishdev/components`).
+- Deep-linkable per server and per tool, so individual tools can be shared like Swagger UI endpoints.
+- Works with any stdio or SSE MCP server via `npx burnish -- <your-server>` — zero config.
+- Open source (AGPL-3.0), cross-platform (macOS, Windows, Linux), and includes a hosted demo.
+
+**Learn more:**
+
+- [Hosted demo](https://burnish-demo.fly.dev)
+- [Example server (34 tools across every rendering path)](https://www.npmjs.com/package/@burnishdev/example-server)
+
+</McpClient>
+
+<McpClient
   name="Call Chirp"
   homepage="https://www.call-chirp.com"
   supports="Prompts, Tools"


### PR DESCRIPTION
Adds [Burnish](https://github.com/danfking/burnish) to the Example Clients list.

Burnish is an explorer-first MCP client — "Swagger UI for MCP" — that auto-generates interactive UI from any MCP server's tool schemas and outputs. It's a different shape from the chat-based clients already on this list: no LLM, no tool-calling loop, no chat window. Point it at any stdio or SSE MCP server and browse/invoke tools directly with JSON shape → component mapping (cards for objects, tables for arrays, charts for `{labels, datasets}`, etc.).

- **Supports:** `Tools, Discovery, Instructions` — audited against the codebase; Burnish does not currently implement Resources, Prompts, Sampling, Roots, Elicitation, or auth flows, so those are honestly omitted.
- **Live demo:** https://burnish-demo.fly.dev
- **npm:** `npx burnish -- <your-mcp-server>`
- **License:** AGPL-3.0
- **Platforms:** macOS, Windows, Linux (Node.js 20+)

Alphabetically placed between "Bob Shell" and "Call Chirp".

Happy to adjust the description length, wording, or supports list if that helps. Thanks for maintaining this list!