### PR TITLE
SEP-2243: mark as Final

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -418,7 +418,8 @@
               "seps/2085-governance-succession-and-amendment",
               "seps/2133-extensions",
               "seps/2148-contributor-ladder",
-              "seps/2149-working-group-charter-template"
+              "seps/2149-working-group-charter-template",
+              "seps/2243-http-standardization"
             ]
           },
           {
@@ -426,12 +427,6 @@
             "pages": [
               "seps/2207-oidc-refresh-token-guidance",
               "seps/2260-Require-Server-requests-to-be-associated-with-Client-requests"
-            ]
-          },
-          {
-            "group": "Draft",
-            "pages": [
-              "seps/2243-http-standardization"
             ]
           }
         ]

--- a/docs/seps/2243-http-standardization.mdx
+++ b/docs/seps/2243-http-standardization.mdx
@@ -5,8 +5,8 @@ description: "HTTP Header Standardization for Streamable HTTP Transport"
 ---
 
 <div className="flex items-center gap-2 mb-4">
-  <Badge color="gray" shape="pill">
-    Draft
+  <Badge color="green" shape="pill">
+    Final
   </Badge>
   <Badge color="gray" shape="pill">
     Standards Track
@@ -17,7 +17,7 @@ description: "HTTP Header Standardization for Streamable HTTP Transport"
 | ------------- | ------------------------------------------------------------------------------- |
 | **SEP**       | 2243                                                                            |
 | **Title**     | HTTP Header Standardization for Streamable HTTP Transport                       |
-| **Status**    | Draft                                                                           |
+| **Status**    | Final                                                                           |
 | **Type**      | Standards Track                                                                 |
 | **Created**   | 2026-02-04                                                                      |
 | **Author(s)** | MCP Transports Working Group                                                    |

--- a/docs/seps/index.mdx
+++ b/docs/seps/index.mdx
@@ -13,15 +13,14 @@ Specification Enhancement Proposals (SEPs) are the primary mechanism for proposi
 ## Summary
 
 - **Accepted**: 2
-- **Draft**: 1
-- **Final**: 27
+- **Final**: 28
 
 ## All SEPs
 
 | SEP                                                                                  | Title                                                                         | Status                                            | Type             | Created    |
 | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- | ------------------------------------------------- | ---------------- | ---------- |
 | [SEP-2260](/seps/2260-Require-Server-requests-to-be-associated-with-Client-requests) | Require Server requests to be associated with a Client request.               | <Badge color="blue" shape="pill">Accepted</Badge> | Standards Track  | 2026-02-16 |
-| [SEP-2243](/seps/2243-http-standardization)                                          | HTTP Header Standardization for Streamable HTTP Transport                     | <Badge color="gray" shape="pill">Draft</Badge>    | Standards Track  | 2026-02-04 |
+| [SEP-2243](/seps/2243-http-standardization)                                          | HTTP Header Standardization for Streamable HTTP Transport                     | <Badge color="green" shape="pill">Final</Badge>   | Standards Track  | 2026-02-04 |
 | [SEP-2207](/seps/2207-oidc-refresh-token-guidance)                                   | OIDC-Flavored Refresh Token Guidance                                          | <Badge color="blue" shape="pill">Accepted</Badge> | Standards Track  | 2026-02-04 |
 | [SEP-2149](/seps/2149-working-group-charter-template)                                | MCP Group Governance and Charter Template                                     | <Badge color="green" shape="pill">Final</Badge>   | Process          | 2025-01-15 |
 | [SEP-2148](/seps/2148-contributor-ladder)                                            | MCP Contributor Ladder                                                        | <Badge color="green" shape="pill">Final</Badge>   | Process          | 2026-01-15 |

--- a/seps/2243-http-standardization.md
+++ b/seps/2243-http-standardization.md
@@ -3,7 +3,7 @@
 <!-- cspell:ignore streamable -->
 <!-- markdownlint-disable MD036 MD060 -->
 
-- **Status**: Draft
+- **Status**: Final
 - **Type**: Standards Track
 - **Created**: 2026-02-04
 - **Author(s)**: MCP Transports Working Group


### PR DESCRIPTION
## Summary
- SEP-2243 (HTTP Header Standardization) was merged in #2243 with `Status: Draft`
- Flip status to `Final` and regenerate SEP docs (`npm run generate:seps`)
- Moves the SEP from the Draft group to the Final group in `docs.json` and updates index counts

## Test plan
- [x] `npm run prep` passes