### PR TITLE
docs: fix incorrect method names in learning guides

### DIFF
--- a/docs/docs/learn/architecture.mdx
+++ b/docs/docs/learn/architecture.mdx
@@ -129,8 +129,8 @@ For more details about server primitives see [server concepts](./server-concepts
 
 MCP also defines primitives that _clients_ can expose. These primitives allow MCP server authors to build richer interactions.
 
-- **Sampling**: Allows servers to request language model completions from the client's AI application. This is useful when server authors want access to a language model, but want to stay model-independent and not include a language model SDK in their MCP server. They can use the `sampling/complete` method to request a language model completion from the client's AI application.
-- **Elicitation**: Allows servers to request additional information from users. This is useful when server authors want to get more information from the user, or ask for confirmation of an action. They can use the `elicitation/request` method to request additional information from the user.
+- **Sampling**: Allows servers to request language model completions from the client's AI application. This is useful when server authors want access to a language model, but want to stay model-independent and not include a language model SDK in their MCP server. They can use the `sampling/createMessage` method to request a language model completion from the client's AI application.
+- **Elicitation**: Allows servers to request additional information from users. This is useful when server authors want to get more information from the user, or ask for confirmation of an action. They can use the `elicitation/create` method to request additional information from the user.
 - **Logging**: Enables servers to send log messages to clients for debugging and monitoring purposes.
 
 For more details about client primitives see [client concepts](./client-concepts).

--- a/docs/docs/learn/client-concepts.mdx
+++ b/docs/docs/learn/client-concepts.mdx
@@ -52,7 +52,7 @@ The flow enables dynamic information gathering. Servers can request specific dat
 
 ```typescript
 {
-  method: "elicitation/requestInput",
+  method: "elicitation/create",
   params: {
     message: "Please confirm your Barcelona vacation booking details:",
     schema: {


### PR DESCRIPTION
Resolves #2644.

This PR fixes three incorrect JSON-RPC method names found in the user-facing documentation (`client-concepts.mdx` and `architecture.mdx`) to align them with the official protocol specification.

- `client-concepts.mdx`: Updated `elicitation/requestInput` -> `elicitation/create`
- `architecture.mdx`: Updated `sampling/complete` -> `sampling/createMessage`
- `architecture.mdx`: Updated `elicitation/request` -> `elicitation/create`

These are trivial documentation corrections that ensure developers reading the learning guides see the correct JSON-RPC method signatures as defined in the spec.
