### PR TITLE
docs: refresh Skills Over MCP charter for SEP-2640

### DIFF
--- a/docs/community/skills-over-mcp/charter.mdx
+++ b/docs/community/skills-over-mcp/charter.mdx
@@ -117,12 +117,12 @@ Discord: [#skills-over-mcp-wg](https://discord.com/channels/1358869848138059966/
 
 Full live tracking is on the [Skills Over MCP WG project board](https://github.com/orgs/modelcontextprotocol/projects/38/views/1). Headline workstreams:
 
-| Item                                           | Status      | Target Date | Champion                                                                                     |
-| ---------------------------------------------- | ----------- | ----------- | -------------------------------------------------------------------------------------------- |
+| Item                                                                                                              | Status      | Target Date | Champion                                                                                     |
+| ----------------------------------------------------------------------------------------------------------------- | ----------- | ----------- | -------------------------------------------------------------------------------------------- |
 | [Skills Extension SEP](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) (Extensions Track) | In Review   |             | [@pja-ant](https://github.com/pja-ant)                                                       |
-| Skills Extension reference implementation      | In Review   |             | [@olaservo](https://github.com/olaservo)                                                     |
-| Agent Skills spec coordination                 | In Progress |             | [@jonathanhefner](https://github.com/jonathanhefner), [@pja-ant](https://github.com/pja-ant) |
-| Registry skills.json proposal                  | In Progress |             | [@JAORMX](https://github.com/JAORMX)                                                         |
+| Skills Extension reference implementation                                                                         | In Review   |             | [@olaservo](https://github.com/olaservo)                                                     |
+| Agent Skills spec coordination                                                                                    | In Progress |             | [@jonathanhefner](https://github.com/jonathanhefner), [@pja-ant](https://github.com/pja-ant) |
+| Registry skills.json proposal                                                                                     | In Progress |             | [@JAORMX](https://github.com/JAORMX)                                                         |
 
 ### Success Criteria
 

--- a/docs/community/skills-over-mcp/charter.mdx
+++ b/docs/community/skills-over-mcp/charter.mdx
@@ -16,7 +16,9 @@ emerged from discussion on [SEP-2076 — Agent Skills as a First-Class MCP Primi
 which raised open questions about whether existing MCP primitives suffice or what
 conventions to standardize. The WG produces specification extensions, reference
 implementations, and coordination artifacts because solutions touch the protocol spec,
-registry schema, SDK implementations, and client behavior.
+registry schema, SDK implementations, and client behavior. The WG's current direction
+is captured in [SEP-2640 — Skills Extension](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640)
+(Resources-based, Extensions Track).
 
 ## Scope
 
@@ -90,6 +92,7 @@ registry schema, SDK implementations, and client behavior.
 | Juan Antonio Osorio      | Stacklok                        | [@JAORMX](https://github.com/JAORMX)                   |         | Participant |
 | Kaxil Naik               | Astronomer / Apache Airflow PMC | [@kaxil](https://github.com/kaxil)                     |         | Participant |
 | Cliff Hall               | Futurescale                     | [@cliffhall](https://github.com/cliffhall)             |         | Participant |
+| Haoyu Wang               | Google                          | [@helloeve](https://github.com/helloeve)               |         | Participant |
 
 ## Operations
 
@@ -116,7 +119,7 @@ Full live tracking is on the [Skills Over MCP WG project board](https://github.c
 
 | Item                                           | Status      | Target Date | Champion                                                                                     |
 | ---------------------------------------------- | ----------- | ----------- | -------------------------------------------------------------------------------------------- |
-| Skills Extension SEP (draft, Extensions Track) | In Review   |             | [@pja-ant](https://github.com/pja-ant)                                                       |
+| [Skills Extension SEP](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) (Extensions Track) | In Review   |             | [@pja-ant](https://github.com/pja-ant)                                                       |
 | Skills Extension reference implementation      | In Review   |             | [@olaservo](https://github.com/olaservo)                                                     |
 | Agent Skills spec coordination                 | In Progress |             | [@jonathanhefner](https://github.com/jonathanhefner), [@pja-ant](https://github.com/pja-ant) |
 | Registry skills.json proposal                  | In Progress |             | [@JAORMX](https://github.com/JAORMX)                                                         |
@@ -131,6 +134,7 @@ Full live tracking is on the [Skills Over MCP WG project board](https://github.c
 
 | Date       | Change                                                                                                                                                                                                                                                                                                           |
 | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-25 | Linked SEP-2640 in Active Work Items; added @helloeve (Google) as Participant                                                                                                                                                                                                                                    |
 | 2026-04-16 | Converted from Interest Group to Working Group                                                                                                                                                                                                                                                                   |
 | 2026-04-14 | Initial charter (formalized from [experimental-ext-skills](https://github.com/modelcontextprotocol/experimental-ext-skills) repo README, which served as the de facto charter before the charter process was established via [SEP-2149](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2149)) |
 | 2026-02-01 | IG formed; experimental repo created                                                                                                                                                                                                                                                                             |


### PR DESCRIPTION
## Summary

Brings the [Skills Over MCP WG charter](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/docs/community/skills-over-mcp/charter.mdx) current with the WG's state as of 2026-04-25:

- Link [SEP-2640 (Skills Extension)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) in the mission statement and the Active Work Items table (the only SEP link previously was to the closed SEP-2076).
- Add Haoyu Wang (Google, @helloeve) as a Participant.
- Log the update in the changelog.

In-flight experimental work (alternative SEPs, prototypes, comparison artifacts) is intentionally **not** added — that lives on the [project board](https://github.com/orgs/modelcontextprotocol/projects/38/views/1) and in [experimental-ext-skills](https://github.com/modelcontextprotocol/experimental-ext-skills), per the README's "approaches being explored" posture.

## Test plan

- [ ] Docs site renders `/community/skills-over-mcp/charter` without table-formatting issues
- [ ] SEP-2640 link resolves
- [ ] @helloeve link resolves

🦉 Generated with [Claude Code](https://claude.com/claude-code)