### PR TITLE
docs: add `filter` URL parameter to `/clients` page to pre-filter clients with specific capabilities

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -99,10 +99,10 @@ export const ClientFilter = () => {
   useEffect(() => {
     if (typeof window === "undefined") return;
     const url = new URL(window.location.href);
+    url.searchParams.delete("filter");
     if (selectedFeatures.length > 0) {
-      url.searchParams.set("filter", selectedFeatures.join(","));
-    } else {
-      url.searchParams.delete("filter");
+      const value = selectedFeatures.map(encodeURIComponent).join(",");
+      url.search = url.search ? `${url.search}&filter=${value}` : `?filter=${value}`;
     }
     window.history.replaceState({}, "", url);
   }, [selectedFeatures]);

--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -85,8 +85,27 @@ export const ClientFilter = () => {
   const { selectedFeatures, searchText, visibleCount, totalCount } = useFilterStore();
 
   useEffect(() => {
-    filterStore.setState({ selectedFeatures: [], searchText: "" });
+    let initialFeatures = [];
+    if (typeof window !== "undefined") {
+      const filterParam = new URLSearchParams(window.location.search).get("filter");
+      if (filterParam) {
+        const requested = new Set(filterParam.split(",").map(f => f.trim()));
+        initialFeatures = FEATURES.filter(f => requested.has(f));
+      }
+    }
+    filterStore.setState({ selectedFeatures: initialFeatures, searchText: "" });
   }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const url = new URL(window.location.href);
+    if (selectedFeatures.length > 0) {
+      url.searchParams.set("filter", selectedFeatures.join(","));
+    } else {
+      url.searchParams.delete("filter");
+    }
+    window.history.replaceState({}, "", url);
+  }, [selectedFeatures]);
 
   const toggleFeature = (feature) => {
     const newFeatures = selectedFeatures.includes(feature)


### PR DESCRIPTION
This PR improves the https://modelcontextprotocol.io/clients page by adding the `filter` URL parameter, which automatically selects only the matching filters.

For example: https://modelcontextprotocol.io/clients?filter=Tools,Resources

## Motivation and Context

This small change enables sharing/linking to a pre-filtered client list (e.g. from blog posts or docs) that highlights only the clients matching specific MCP features, and thus helps promote MCO clients that support the newer capabilities.

Here are the changes made:

- **Read on mount**: parse the `filter` query parameter, split by comma, and intersect with the known `FEATURES` whitelist before populating `selectedFeatures`. Unknown values are dropped, which is what makes this safe against HTML/script injection — combined with React's auto-escaping, no attacker-controlled string can reach the DOM.
- **Write on change**: a `useEffect` mirrors `selectedFeatures` back into the URL via `history.replaceState`, so toggling a filter updates the address bar in place (no new history entries, back button still works). Each feature name is `encodeURIComponent`-encoded individually; the `,` separator is left literal (it's a valid sub-delim per RFC 3986) so the URL reads as `?filter=Prompts,Tools,Discovery` instead of `?filter=Prompts%2CTools%2CDiscovery`.
- Both effects are SSR-safe (`typeof window !== "undefined"` guard).

## How Has This Been Tested?

I've tested it locally in these scenarios:

- [x] `npm run serve:docs`, open `/clients?filter=Discovery,Resources` — both filters auto-selected, list narrowed
- [x] Open `/clients?filter=Resources,BogusValue` — only `Resources` selected (whitelist drops the unknown)
- [x] Open `/clients?filter=<script>alert(1)</script>` — nothing selected, no script execution
- [x] Click filter chips and confirm the URL updates in place; clicking "Clear filters" removes the param entirely

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
