### PR TITLE
Add Ontheia as MCP client

### DIFF
--- a/docs/clients.mdx
+++ b/docs/clients.mdx
@@ -1819,6 +1819,25 @@ OpenCode is an open source AI coding agent. It’s available as a terminal-based
 </McpClient>
 
 <McpClient
+  name="Ontheia"
+  homepage="https://ontheia.ai"
+  sourceCode="https://github.com/Ontheia/ontheia"
+  supports="Tools, Resources"
+  instructions="https://docs.ontheia.ai/de/getting-started/03_compatible-mcp-servers/"
+>
+
+Ontheia is a self-hosted, open-source AI agent platform with native MCP support. Multi-provider (Claude, GPT-4, Gemini, Ollama), multi-user with RBAC, GDPR by design. Runs entirely on your own infrastructure.
+
+**Key features:**
+
+- Full MCP tool and resource support
+- Connect any MCP server via Docker (rootless, isolated containers)
+- Multi-agent orchestration with agent-to-agent delegation
+- Long-term vector memory (pgvector), chain engine for automated workflows
+
+</McpClient>
+
+<McpClient
   name="OpenSumi"
   homepage="https://github.com/opensumi/core"
   supports="Tools"


### PR DESCRIPTION
## Ontheia — Self-hosted MCP client

[Ontheia](https://ontheia.ai) is a self-hosted, open-source AI agent platform with native MCP support.

**Key details:**
- **License:** AGPL-3.0
- **Type:** Web app (self-hosted)
- **MCP support:** Tools, Resources
- **Source:** https://github.com/Ontheia/ontheia
- **MCP docs:** https://docs.ontheia.ai/de/getting-started/03_compatible-mcp-servers/

**What makes it notable:**
- Connects agents to any MCP server via isolated Docker containers (rootless)
- Multi-provider: Claude, GPT-4, Gemini, Ollama — vendor-agnostic
- Multi-agent orchestration with agent-to-agent delegation
- GDPR by design — all data stays on your own infrastructure
- Long-term vector memory (pgvector) and chain engine for workflows

The entry is inserted alphabetically between OpenCode and OpenSumi.