### PR TITLE
docs: clarify HTTP log stream routing

### DIFF
--- a/docs/specification/2025-11-25/server/utilities/logging.mdx
+++ b/docs/specification/2025-11-25/server/utilities/logging.mdx
@@ -83,6 +83,20 @@ Servers send log messages using `notifications/message` notifications:
 }
 ```
 
+When using
+[Streamable HTTP](/specification/2025-11-25/basic/transports#streamable-http),
+log message notifications follow the same stream routing rules as other
+server-to-client notifications:
+
+- Log messages produced while handling a specific client JSON-RPC request
+  **SHOULD** be sent on that request's POST-initiated SSE stream, when such a
+  stream is used.
+- Log messages that are not associated with a concurrently-running client
+  request **MAY** be sent on a standalone GET-initiated SSE stream, when the
+  client has opened one.
+- The server **MUST NOT** broadcast the same log notification across multiple
+  connected streams.
+
 ## Message Flow
 
 ```mermaid


### PR DESCRIPTION
## Summary
- clarify where notifications/message logs should be sent with Streamable HTTP
- distinguish request-scoped logs from unrelated/background logs
- restate that a log notification must not be broadcast across multiple connected streams

Fixes #2475

## Verification
- git diff --check
- npm run check:docs:format