### PR TITLE
[Doc] Update Ruby client example to use explicit connect

### DIFF
--- a/docs/docs/develop/build-client.mdx
+++ b/docs/docs/develop/build-client.mdx
@@ -1791,6 +1791,7 @@ def connect_to_server(server_script_path)
 
   @transport = MCP::Client::Stdio.new(command: command, args: [server_script_path])
   @mcp_client = MCP::Client.new(transport: @transport)
+  @mcp_client.connect
 
   tool_names = @mcp_client.tools.map(&:name)
   puts "\nConnected to server with tools: #{tool_names}"


### PR DESCRIPTION
## Motivation and Context

Follow-up to https://github.com/modelcontextprotocol/ruby-sdk/pull/336 and https://github.com/modelcontextprotocol/quickstart-resources/pull/133.

The Ruby example in `docs/docs/develop/build-client.mdx` constructed `MCP::Client` with a stdio transport and immediately called `client.tools`, relying on the implicit `initialize_session` that the stdio transport performed on the first request.

ruby-sdk PR #336 added `MCP::Client#connect` for the stdio transport so that the explicit `initialize` plus `notifications/initialized` handshake is exposed at the public API level, matching the Python SDK (`ClientSession.initialize()`) and the TypeScript SDK (`Client.connect(transport)`). The implicit-init path is preserved as a backwards-compatible shim, but new code is expected to call `connect` explicitly.

This change updates the Ruby example so readers learn the explicit `@mcp_client.connect` pattern from the start, consistent with how the Python and TypeScript examples present the handshake.

## How Has This Been Tested?

- Re-read the surrounding `connect_to_server` example in `docs/docs/develop/build-client.mdx` to confirm `@mcp_client.connect` fits naturally between the client construction and the subsequent `@mcp_client.tools` call.
- Ran `npm run prep` to confirm there are no documentation warnings or errors introduced by the change.

## Breaking Changes

None. This is a documentation-only change that adds a single explicit `connect` call to the Ruby client example. No schema, navigation, or runtime behavior is affected.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
