### PR TITLE
Change error response status from 400 to 404 for invalid sessions

### DIFF
--- a/docs/docs/tutorials/security/authorization.mdx
+++ b/docs/docs/tutorials/security/authorization.mdx
@@ -567,7 +567,7 @@ const mcpPostHandler = async (req: express.Request, res: express.Response) => {
     const server = createMcpServer();
     await server.connect(transport);
   } else {
-    res.status(400).json({
+    res.status(404).json({
       jsonrpc: "2.0",
       error: {
         code: -32000,


### PR DESCRIPTION
Changes the error status code from 400 to 404 in the documentation's TypeScript example.

## Motivation and Context

The error status code returned by the server should be 404, not 400, so that the client starts a new session.

> When a client receives HTTP 404 in response to a request containing an MCP-Session-Id, it MUST start a new session by sending a new InitializeRequest without a session ID attached.

https://modelcontextprotocol.io/specification/draft/basic/transports#session-management

## How Has This Been Tested?

Tested with Claude. Claude returns an error when receiving a 400 status code error after sending an invalid `MCP-Session-Id`, but with the 404 status code, it initializes a new session, as it should.

## Breaking Changes

No breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
