### PR TITLE
docs: move Che Liu and Basil Hosmer to Core Maintainer Emeritus

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,7 +2,7 @@
 
 This document lists current maintainers in the Model Context Protocol project.
 
-**Last updated:** April 8, 2026
+**Last updated:** May 1, 2026
 
 ## Lead Maintainers
 
@@ -12,7 +12,6 @@ This document lists current maintainers in the Model Context Protocol project.
 ## Core Maintainers
 
 - [Caitie McCaffrey](https://github.com/CaitieM20)
-- [Che Liu](https://github.com/pwwpche)
 - [Clare Liguori](https://github.com/clareliguori)
 - [Kurtis Van Gent](https://github.com/kurtisvg)
 - [Nick Aldridge](https://github.com/000-000-000-000-000)
@@ -23,6 +22,8 @@ This document lists current maintainers in the Model Context Protocol project.
 ## Emeritus
 
 - [Justin Spahr-Summers](https://github.com/jspahrsummers) (Co-Inventor, Lead Maintainer Emeritus)
+- [Basil Hosmer](https://github.com/bhosmer-ant) (Core Maintainer Emeritus)
+- [Che Liu](https://github.com/pwwpche) (Core Maintainer Emeritus)
 
 ## SDK Maintainers
 

--- a/docs/community/governance.mdx
+++ b/docs/community/governance.mdx
@@ -116,11 +116,12 @@ The nomination process, sponsorship requirements, review timeline, and inactivit
 - Paul Carleton
 - Nick Cooper
 - Nick Aldridge
-- Che Liu
 
 ## Emeritus
 
 - Justin Spahr-Summers (Co-Inventor, Lead Maintainer Emeritus)
+- Basil Hosmer (Core Maintainer Emeritus)
+- Che Liu (Core Maintainer Emeritus)
 
 ## Current Maintainers and Working Groups
 


### PR DESCRIPTION
Moves Che Liu from Core Maintainers to the Emeritus section, and adds Basil Hosmer (removed from core in Feb 2026 but never listed as emeritus) alongside him.

- `MAINTAINERS.md`: remove Che from Core Maintainers, add both as Core Maintainer Emeritus, bump last-updated date
- `docs/community/governance.mdx`: same change to Current Core Maintainers / Emeritus

Companion access change: modelcontextprotocol/access#111