### PR TITLE
docs: clarify server description and instructions

### DIFF
--- a/docs/specification/2025-11-25/basic/lifecycle.mdx
+++ b/docs/specification/2025-11-25/basic/lifecycle.mdx
@@ -144,6 +144,18 @@ The server **MUST** respond with its own capabilities and information:
 }
 ```
 
+The `serverInfo.description` field describes the server itself: what kind of
+capabilities it provides and when a client or host might choose to connect to
+it. The `instructions` field describes how to use the server effectively after
+it has been initialized, such as workflow guidance, constraints, or important
+relationships between tools, resources, and prompts.
+
+Servers that provide `instructions` should keep them focused on server-level
+usage guidance and avoid duplicating individual tool, resource, or prompt
+descriptions. Clients and hosts may use `serverInfo.description` for discovery,
+server selection, or progressive disclosure, and may use `instructions` as
+model-facing context once the server is loaded.
+
 After successful initialization, the client **MUST** send an `initialized` notification
 to indicate it is ready to begin normal operations:
 

--- a/docs/specification/draft/server/discover.mdx
+++ b/docs/specification/draft/server/discover.mdx
@@ -64,6 +64,18 @@ identity:
 | `serverInfo`        | `Implementation`     | yes      | Name and version of the server software.                                                     |
 | `instructions`      | `string`             | no       | Natural-language guidance for LLMs on how to use this server effectively.                    |
 
+The `serverInfo.description` field describes the server itself: what kind of
+capabilities it provides and when a client or host might choose to connect to
+it. The `instructions` field describes how to use the server effectively after
+it is discovered, such as workflow guidance, constraints, or important
+relationships between tools, resources, and prompts.
+
+Servers that provide `instructions` should keep them focused on server-level
+usage guidance and avoid duplicating individual tool, resource, or prompt
+descriptions. Clients and hosts may use `serverInfo.description` for discovery,
+server selection, or progressive disclosure, and may use `instructions` as
+model-facing context once the server is loaded.
+
 ## When to Call
 
 Calling `server/discover` is optional for clients — a client may invoke any


### PR DESCRIPTION
Clarifies how servers and clients should treat `serverInfo.description` and initialize-result `instructions`.

The new text distinguishes server discovery/selection metadata from model-facing usage guidance, and notes that instructions should provide server-level guidance without duplicating individual tool, resource, or prompt descriptions.

Addresses #2146.

Note: I saw #2602, which adds a broader server instructions guide. This PR is intentionally narrower: it updates the lifecycle/specification text in both the current dated spec and draft spec, so it can complement that guide rather than replace it.

Verification:
- `npx prettier --check docs/specification/2025-11-25/basic/lifecycle.mdx docs/specification/draft/basic/lifecycle.mdx`
- `npm run check:docs:js-comments`
- `git diff --check`

Note: `npm run check:docs:links` was attempted but timed out after 5 minutes during the full-site link check.
