### PR TITLE
build(deps-dev): bump vm2 to 3.11.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4252,9 +4252,9 @@
       }
     },
     "node_modules/vm2": {
-      "version": "3.10.5",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.10.5.tgz",
-      "integrity": "sha512-3P/2QDccVFBcujfCOeP8vVNuGfuBJHEuvGR8eMmI10p/iwLL2UwF5PDaNaoOS2pRGQEDmJRyeEcc8kmm2Z59RA==",
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.11.3.tgz",
+      "integrity": "sha512-DO1TTKuOc+veL11VNOvJwRab80mghFKE40Av3bl6pdXs11bdiDMuR73owy+dS2EsTZEvRUeBkkBuDVRjV/RgEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Bumps the transitive `vm2` dependency from 3.10.5 to 3.11.3 to address [GHSA-vwrp-x96c-mhwq](https://github.com/advisories/GHSA-vwrp-x96c-mhwq), a critical sandbox escape. This is pulled in via `typescript-json-schema` (dev-only, used for schema generation) and the parent constraint already permits 3.11.x, so this is a lockfile-only change. Resolves Dependabot alert #58.