### PR TITLE
fix: correct NumberSchema minimum/maximum/default types from integer to number

### DIFF
--- a/schema/2025-11-25/schema.json
+++ b/schema/2025-11-25/schema.json
@@ -2107,16 +2107,16 @@
         "NumberSchema": {
             "properties": {
                 "default": {
-                    "type": "integer"
+                    "type": "number"
                 },
                 "description": {
                     "type": "string"
                 },
                 "maximum": {
-                    "type": "integer"
+                    "type": "number"
                 },
                 "minimum": {
-                    "type": "integer"
+                    "type": "number"
                 },
                 "title": {
                     "type": "string"

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -2509,16 +2509,16 @@
         "NumberSchema": {
             "properties": {
                 "default": {
-                    "type": "integer"
+                    "type": "number"
                 },
                 "description": {
                     "type": "string"
                 },
                 "maximum": {
-                    "type": "integer"
+                    "type": "number"
                 },
                 "minimum": {
-                    "type": "integer"
+                    "type": "number"
                 },
                 "title": {
                     "type": "string"

--- a/scripts/generate-schemas.ts
+++ b/scripts/generate-schemas.ts
@@ -20,6 +20,31 @@ const ALL_SCHEMAS = [...LEGACY_SCHEMAS, ...MODERN_SCHEMAS];
 const CHECK_MODE = process.argv.includes('--check');
 
 /**
+ * Fix NumberSchema properties that should be `number` type instead of `integer`.
+ *
+ * The `--defaultNumberType integer` flag used during schema generation converts
+ * all TypeScript `number` types to JSON Schema `integer`. This is correct for
+ * most fields (request IDs, ports, etc.) but wrong for `NumberSchema.minimum`,
+ * `NumberSchema.maximum`, and `NumberSchema.default`, which must accept number
+ * values because they define constraints for schemas with `"type": "number"`.
+ */
+function fixNumberSchemaTypes(schemaPath: string): void {
+  let content = readFileSync(schemaPath, 'utf-8');
+  const schema = JSON.parse(content);
+
+  const numberSchema = schema.$defs?.NumberSchema ?? schema.definitions?.NumberSchema;
+  if (numberSchema?.properties) {
+    for (const prop of ['minimum', 'maximum', 'default']) {
+      if (numberSchema.properties[prop]?.type === 'integer') {
+        numberSchema.properties[prop].type = 'number';
+      }
+    }
+  }
+
+  writeFileSync(schemaPath, JSON.stringify(schema, null, 2) + '\n', 'utf-8');
+}
+
+/**
  * Apply JSON Schema 2020-12 transformations to a schema file
  */
 function applyJsonSchema202012Transformations(schemaPath: string): void {
@@ -76,6 +101,18 @@ async function generateSchema(version: string, check: boolean = false): Promise<
         expectedSchema = expectedSchema.replace(/#\/definitions\//g, '#/$defs/');
       }
 
+      // Fix NumberSchema properties that were incorrectly converted to integer
+      const parsedSchema = JSON.parse(expectedSchema);
+      const numberSchema = parsedSchema.$defs?.NumberSchema ?? parsedSchema.definitions?.NumberSchema;
+      if (numberSchema?.properties) {
+        for (const prop of ['minimum', 'maximum', 'default']) {
+          if (numberSchema.properties[prop]?.type === 'integer') {
+            numberSchema.properties[prop].type = 'number';
+          }
+        }
+      }
+      expectedSchema = JSON.stringify(parsedSchema, null, 2) + '\n';
+
       // Compare
       if (existingSchema.trim() !== expectedSchema.trim()) {
         console.error(`  ✗ Schema ${version} is out of date!`);
@@ -98,6 +135,9 @@ async function generateSchema(version: string, check: boolean = false): Promise<
       console.error(`Failed to generate schema for ${version}`);
       throw error;
     }
+
+    // Fix NumberSchema properties that were incorrectly converted to integer
+    fixNumberSchemaTypes(schemaJson);
 
     // Apply transformations for non-legacy schemas
     if (!LEGACY_SCHEMAS.includes(version)) {


### PR DESCRIPTION
## Summary

Fixes #2698

The `--defaultNumberType integer` flag in `scripts/generate-schemas.ts` converts all TypeScript `number` types to JSON Schema `integer` during schema generation. While this is correct for most fields (request IDs, ports, etc.), it incorrectly converts `NumberSchema`'s `minimum`, `maximum`, and `default` properties to `integer` type. These fields should be `number` type because they define constraints for schemas that can have `"type": "number"`.

## Changes

### scripts/generate-schemas.ts
- Added `fixNumberSchemaTypes()` post-processing function that corrects `NumberSchema.minimum`, `NumberSchema.maximum`, and `NumberSchema.default` from `integer` to `number` in generated JSON schemas
- Applied the fix in both the generation path and the check/validation path to ensure consistency

### schema/2025-11-25/schema.json and schema/draft/schema.json
- Changed `NumberSchema.default`, `NumberSchema.maximum`, and `NumberSchema.minimum` from `"type": "integer"` to `"type": "number"`

## Before

```json
"minimum": { "type": "integer" },
"maximum": { "type": "integer" },
"default": { "type": "integer" }
```

## After

```json
"minimum": { "type": "number" },
"maximum": { "type": "number" },
"default": { "type": "number" }
```
