### PR TITLE
Disambiguate HTTP backward-compat fallbacks: inspect 400/404 body before falling back

### DIFF
--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -96,18 +96,28 @@ A server that wishes to support both legacy clients (which expect an
 **MAY** implement both behaviors. A client that needs to interoperate with
 both kinds of servers can detect which is present:
 
-- **HTTP.** Try a modern request directly. If the server returns
-  `400 Bad Request` (or any other version error indicating the server does not
-  implement the modern protocol), fall back to `initialize` and continue with
-  the legacy version for subsequent requests.
+- **HTTP.** Try a modern request directly. On `400 Bad Request`, inspect the
+  response body before deciding to fall back: a `400` is also used by modern
+  servers for `UnsupportedProtocolVersionError`,
+  `MissingRequiredClientCapabilityError`, and header-validation failures, so
+  the status alone does not indicate a legacy server.
+  - If the body contains a recognized modern JSON-RPC error such as
+    [`UnsupportedProtocolVersionError`](/specification/draft/schema#unsupportedprotocolversionerror),
+    the server speaks a modern version of MCP — retry using one of its
+    advertised `supported` versions, or correct the request. Do **not** fall
+    back to `initialize`.
+  - If the response body is empty or is not a recognized modern JSON-RPC
+    error, fall back to `initialize` and continue with the legacy version
+    for subsequent requests.
 - **STDIO.** Because there is no per-request status code to drive fallback,
   a client that supports both eras **SHOULD** probe with
   [`server/discover`](/specification/draft/server/discover) first,
   setting its preferred modern version in `_meta`. If the server returns
   `Method not found` (`-32601`), fall back to the legacy `initialize`
   handshake. If the server returns `UnsupportedProtocolVersionError`, the
-  server speaks a version of MCP without `initialize` — use one of its
-  advertised `supportedVersions` instead of falling back to `initialize`.
+  server speaks a version of MCP without `initialize` — use one of the
+  versions in its advertised `supported` list instead of falling back to
+  `initialize`.
 
 A client that only supports modern (per-request-metadata) versions does not
 need to probe — it simply sends its preferred version and handles

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -121,8 +121,8 @@ legacy version that requires an `initialize` handshake **SHOULD** probe with
 any other request. If the server returns `Method not found` (`-32601`), the
 client falls back to the legacy `initialize` handshake. If the server returns
 `UnsupportedProtocolVersionError`, it speaks a version of MCP without
-`initialize` — the client **SHOULD** retry using one of the advertised
-`supportedVersions` rather than falling back to `initialize`. See
+`initialize` — the client **SHOULD** retry using one of the versions in the
+advertised `supported` list rather than falling back to `initialize`. See
 [Lifecycle: Backward Compatibility][lifecycle-compat]
 for details.
 
@@ -279,11 +279,15 @@ for the negotiation flow.
 
 If the server does not implement the requested RPC method, it **MUST** respond
 with `404 Not Found` and a JSON-RPC error with code `-32601`
-(`Method not found`).
+(`Method not found`). The JSON-RPC error body distinguishes this case from a
+`404` returned by a legacy [HTTP+SSE][http-sse] server that does not host the
+modern MCP endpoint (see [Backward Compatibility](#backward-compatibility-1)).
 
-For backward compatibility, if the server does _not_ receive an
-`MCP-Protocol-Version` header and has no other way to identify the version,
-the server **SHOULD** assume protocol version `2025-03-26`.
+A server that supports clients implementing protocol versions earlier than
+`2025-06-18` (which did not define the `MCP-Protocol-Version` header) **MAY**
+treat a request that omits the header as protocol version `2025-03-26`. A
+server that does not support such clients **MUST** reject a request without
+the header per [Server Validation](#server-validation).
 
 [unsupported-version]: /specification/draft/schema#unsupportedprotocolversionerror
 [lifecycle-version]: /specification/draft/basic/lifecycle#protocol-version-negotiation
@@ -576,12 +580,20 @@ a JSON-RPC error response.
 
 A client that supports both modern (per-request-metadata) MCP versions and a
 legacy version that requires an `initialize` handshake **MAY** detect which
-era the server implements by attempting a modern request first. If the
-server returns `400 Bad Request` (or any other version error indicating the
-server does not implement the modern protocol), the client falls back to
-`initialize` and continues with the legacy version for subsequent requests.
-See [Lifecycle: Backward Compatibility][lifecycle-compat]
-for details.
+era the server implements by attempting a modern request first. On
+`400 Bad Request`, the client **SHOULD** inspect the response body before
+falling back: modern servers also use `400` for
+[`UnsupportedProtocolVersionError`][unsupported-version],
+`MissingRequiredClientCapabilityError`, and header-validation failures.
+
+- If the body contains a recognized modern JSON-RPC error, the server speaks
+  a modern version of MCP — retry using the advertised `supported` versions
+  or correct the request, rather than falling back.
+- If the body is empty or is not a recognized modern JSON-RPC error, fall
+  back to `initialize` and continue with the legacy version for subsequent
+  requests.
+
+See [Lifecycle: Backward Compatibility][lifecycle-compat] for details.
 
 Separately, clients and servers can maintain backward compatibility with the
 deprecated [HTTP+SSE transport][http-sse] (from
@@ -602,8 +614,10 @@ protocol version 2024-11-05) as follows:
    defined above:
    - If it succeeds, the client can assume this is a server supporting the
      new Streamable HTTP transport.
-   - If it fails with HTTP status codes "400 Bad Request", "404 Not Found",
-     or "405 Method Not Allowed":
+   - If it fails with HTTP status code `400 Bad Request`, `404 Not Found`,
+     or `405 Method Not Allowed` **and** the response body is not a
+     recognized modern JSON-RPC error (a modern server returns one for
+     unsupported version, unknown method, or header-validation failure):
      - Issue a GET request to the server URL, expecting that this will open
        an SSE stream and return an `endpoint` event as the first event.
      - When the `endpoint` event arrives, the client can assume this is a


### PR DESCRIPTION
## Motivation and Context

A review of the draft spec found that several HTTP backward-compatibility paths are over-determined: the same status codes signal multiple unrelated conditions, with no defined way for a client to distinguish them.

- **`400 Bad Request` is overloaded.** Modern servers return `400` for `UnsupportedProtocolVersionError`, `MissingRequiredClientCapabilityError`, and `Mcp-*` header-validation failures. The backward-compatibility section of `lifecycle.mdx` (and `transports.mdx` § Backward Compatibility) tells clients to fall back to the legacy `initialize` handshake on *any* `400`. A client that does so will incorrectly drop into legacy mode against a modern server that simply doesn't support the requested version, or whose request was malformed.
- **`404 Not Found` is overloaded.** `transports.mdx` § Protocol Version Header introduces `404` + JSON-RPC `-32601` for unknown methods, while the HTTP+SSE backward-compat heuristic uses `404` (alongside `400`/`405`) as a signal to try the deprecated `2024-11-05` GET-SSE transport.
- **A missing `MCP-Protocol-Version` header has two conflicting behaviors.** § Server Validation lists the missing header as a MUST-reject failure; § Protocol Version Header says the server SHOULD assume `2025-03-26`. There is no statement of which rule applies.

This PR makes the **response body the disambiguator**, since a modern server always returns a recognizable JSON-RPC error in the body and a legacy server does not. Specifically:

- **`lifecycle.mdx`**: the HTTP fallback bullet now tells clients to inspect the `400` body. A recognized modern error means "modern server — retry with a supported version or correct the request"; an empty or unrecognized body means "legacy server — fall back to `initialize`."
- **`transports.mdx`**: the same body-inspection guidance is applied to both backward-compat paths. The HTTP+SSE detection step now triggers only when the `400`/`404`/`405` body is *not* a recognized modern JSON-RPC error, so a `404` for unknown method does not falsely look like an old transport.
- **`transports.mdx`**: the missing-`MCP-Protocol-Version` SHOULD rule is scoped to servers that opt in to supporting clients implementing protocol versions earlier than `2025-06-18` (which did not define the header). Servers that do not support such clients reject per Server Validation.

Also fixes `supportedVersions` → `supported` in the two backward-compat sections; the field on `UnsupportedProtocolVersionError.error.data` is named `supported`. (`supportedVersions` is the field on `DiscoverResult`, a successful result, not an error.)

## How Has This Been Tested?

- `npm run check:docs` (no new errors).

## Breaking Changes

None. This is a documentation clarification; the wire format and status codes are unchanged. It does change what conformant *clients* should do on a `400`/`404`, which is the point — the previous text would have caused incorrect fallbacks.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Related: #2716 introduces a dedicated `-32004` error code for `UnsupportedProtocolVersionError`, which makes the body-inspection rule even more reliable.
