### PR TITLE
Clarify initialize version header precedence

### DIFF
--- a/docs/specification/2025-11-25/basic/lifecycle.mdx
+++ b/docs/specification/2025-11-25/basic/lifecycle.mdx
@@ -167,6 +167,11 @@ to indicate it is ready to begin normal operations:
 In the `initialize` request, the client **MUST** send a protocol version it supports.
 This **SHOULD** be the _latest_ version supported by the client.
 
+For HTTP transports, the `initialize` request body is the authoritative input to
+version negotiation. The `MCP-Protocol-Version` HTTP header is not required on
+the initial `initialize` request and, if present, **MUST NOT** override the
+`params.protocolVersion` value in the request body.
+
 If the server supports the requested protocol version, it **MUST** respond with the same
 version. Otherwise, the server **MUST** respond with another protocol version it
 supports. This **SHOULD** be the _latest_ version supported by the server.

--- a/docs/specification/2025-11-25/basic/transports.mdx
+++ b/docs/specification/2025-11-25/basic/transports.mdx
@@ -271,6 +271,11 @@ For example: `MCP-Protocol-Version: 2025-11-25`
 The protocol version sent by the client **SHOULD** be the one [negotiated during
 initialization](/specification/2025-11-25/basic/lifecycle#version-negotiation).
 
+The initial `initialize` request negotiates the protocol version through
+`params.protocolVersion` in the JSON-RPC body. If an HTTP client also sends an
+`MCP-Protocol-Version` header on that initial request, the header **MUST NOT**
+override the body value used for version negotiation.
+
 For backwards compatibility, if the server does _not_ receive an `MCP-Protocol-Version`
 header, and has no other way to identify the version - for example, by relying on the
 protocol version negotiated during initialization - the server **SHOULD** assume protocol


### PR DESCRIPTION
## Summary
- clarify that HTTP `initialize` negotiates protocol version from `params.protocolVersion`
- state that `MCP-Protocol-Version` is not required on the initial `initialize` request
- state that an initial request header must not override the body value used for negotiation

Fixes #2721.

## Validation
- `npm run check:docs:format`
- `npm run check:docs:js-comments`
- `npx -p node@24 -p mint@4.2.565 -c 'node --version && cd docs && mint broken-links'`

Note: `npm run check:docs` under the system Node failed because Mintlify does not support Node 25; the broken-link check passed under Node 24.15.0, matching the repo `.nvmrc` major version.
