### PR TITLE
docs(spec): fix broken anchors, stale links, and mermaid diagrams in draft spec

### DIFF
--- a/docs/specification/draft/basic/utilities/mrtr.mdx
+++ b/docs/specification/draft/basic/utilities/mrtr.mdx
@@ -114,7 +114,7 @@ Keys correspond to the keys in the `InputRequests` map; values are the client's 
 
 #### InputRequiredResult
 
-An [`InputRequiredResult`](/specification/draft/schema#InputRequiredResult) is a type of [`Result`](https://modelcontextprotocol.io/specification/2025-11-25/basic#responses),
+An [`InputRequiredResult`](/specification/draft/schema#inputrequiredresult) is a type of [`Result`](/specification/draft/basic#responses),
 indicating that additional input is needed before the request can be completed.
 
 - `inputRequests` _(optional)_: An [`InputRequests`](/specification/draft/schema#inputrequests) map of server-initiated requests that the client must fulfill.

--- a/docs/specification/draft/basic/utilities/mrtr.mdx
+++ b/docs/specification/draft/basic/utilities/mrtr.mdx
@@ -260,4 +260,4 @@ the server **SHOULD** respond with a new `InputRequiredResult` requesting the mi
 ### Security Considerations
 
 Because `requestState` passes through the client, malicious or compromised clients could attempt to modify it to alter server behavior,
-bypass authorization checks, or corrupt server logic. Servers **MUST** validate request state as described in the [server requirements](#server-requirements-ephemeral) above.
+bypass authorization checks, or corrupt server logic. Servers **MUST** validate request state as described in the [server requirements](#server-requirements-basic-workflow) above.

--- a/docs/specification/draft/client/elicitation.mdx
+++ b/docs/specification/draft/client/elicitation.mdx
@@ -80,7 +80,7 @@ Servers **MUST NOT** send elicitation requests with modes that are not supported
 
 ### Elicitation Requests
 
-Servers **MAY** request information from a user during the processing of a client request, by sending an [`InputRequiredResult`](/specification/draft/basic/utilities/mrtr#InputRequiredResult)
+Servers **MAY** request information from a user during the processing of a client request, by sending an [`InputRequiredResult`](/specification/draft/basic/utilities/mrtr#inputrequiredresult)
 containing an `elicitation/create` request.
 
 All elicitation requests **MUST** include the following parameters:

--- a/docs/specification/draft/client/roots.mdx
+++ b/docs/specification/draft/client/roots.mdx
@@ -81,10 +81,10 @@ sequenceDiagram
     participant Server
     participant Client
 
-    Note over Server,Client: Discovery
-    Client->>Server: tool/call(id: 1)
+    Note over Server,Client: Initial Request
+    Client->>Server: tools/call(id: 1)
     Server-->>Client: InputRequiredResult(roots/list)
-    Client->>Server: tool/call(id: 2, Available roots)
+    Client->>Server: tools/call(id: 2, inputResponses{key: roots} + requestState)
 ```
 
 ## Data Types

--- a/docs/specification/draft/client/sampling.mdx
+++ b/docs/specification/draft/client/sampling.mdx
@@ -488,7 +488,7 @@ sequenceDiagram
     participant User
     participant LLM
 
-    Client->>Server: tool/call(id:1)
+    Client->>Server: tools/call(id:1)
     note right of Server: Server needs more info
     Server->>Client: InputRequiredResult(<br/>sampling/createMessage<br/>(messages + tools))
 

--- a/docs/specification/draft/server/prompts.mdx
+++ b/docs/specification/draft/server/prompts.mdx
@@ -153,7 +153,7 @@ auto-completed through [the completion API](/specification/draft/server/utilitie
 }
 ```
 
-Servers **MAY** also respond to `prompts/get` with an [`InputRequiredResult`](/specification/draft/basic/utilities/mrtr#InputRequiredResult) to indicate that additional input is needed before the prompt can be resolved. This follows the [multi round-trip requests](/specification/draft/basic/utilities/mrtr#multi-round-trip-requests) mechanism. When retrying the request, clients include `inputResponses` and, if provided by the server, `requestState` in the request parameters.
+Servers **MAY** also respond to `prompts/get` with an [`InputRequiredResult`](/specification/draft/basic/utilities/mrtr#inputrequiredresult) to indicate that additional input is needed before the prompt can be resolved. This follows the [multi round-trip requests](/specification/draft/basic/utilities/mrtr#multi-round-trip-requests) mechanism. When retrying the request, clients include `inputResponses` and, if provided by the server, `requestState` in the request parameters.
 
 ### List Changed Notification
 

--- a/docs/specification/draft/server/prompts.mdx
+++ b/docs/specification/draft/server/prompts.mdx
@@ -215,8 +215,8 @@ Messages in a prompt can contain:
 
 <Note>
   All content types in prompt messages support optional
-  [annotations](/specification/2025-06-18/server/resources#annotations) for
-  metadata about audience, priority, and modification times.
+  [annotations](/specification/draft/server/resources#annotations) for metadata
+  about audience, priority, and modification times.
 </Note>
 
 #### Text Content

--- a/docs/specification/draft/server/resources.mdx
+++ b/docs/specification/draft/server/resources.mdx
@@ -158,7 +158,7 @@ Servers **MAY** return multiple resource contents in response to a single
 `resources/read` request. For example, a server could return the contents of
 several files when a directory resource is read.
 
-Servers **MAY** also respond to `resources/read` with an [`InputRequiredResult`](/specification/draft/basic/utilities/mrtr#InputRequiredResult) to indicate that additional input is needed before the resource can be read. This follows the [multi round-trip requests](/specification/draft/basic/utilities/mrtr#multi-round-trip-requests) mechanism. When retrying the request, clients include `inputResponses` and, if provided by the server, `requestState` in the request parameters.
+Servers **MAY** also respond to `resources/read` with an [`InputRequiredResult`](/specification/draft/basic/utilities/mrtr#inputrequiredresult) to indicate that additional input is needed before the resource can be read. This follows the [multi round-trip requests](/specification/draft/basic/utilities/mrtr#multi-round-trip-requests) mechanism. When retrying the request, clients include `inputResponses` and, if provided by the server, `requestState` in the request parameters.
 
 Alternatively, if the scheme of `uri` is `https://`, clients may fetch the resource directly from the web. See the [Common URI Schemes section](#https%3A%2F%2F) for more information.
 

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -164,7 +164,7 @@ To invoke a tool, clients send a `tools/call` request:
 
 ### Input Required Tool Results
 
-Servers **MAY** respond to `tools/call` with an [`InputRequiredResult`](/specification/draft/basic/utilities/mrtr#InputRequiredResult) to indicate that additional input is needed before the tool call can be completed. This follows the [multi round-trip requests](/specification/draft/basic/utilities/mrtr#multi-round-trip-requests) mechanism.
+Servers **MAY** respond to `tools/call` with an [`InputRequiredResult`](/specification/draft/basic/utilities/mrtr#inputrequiredresult) to indicate that additional input is needed before the tool call can be completed. This follows the [multi round-trip requests](/specification/draft/basic/utilities/mrtr#multi-round-trip-requests) mechanism.
 
 When retrying the request with input responses, clients include `inputResponses` and, if provided by the server, `requestState` in the request parameters:
 


### PR DESCRIPTION
Cleans up the `Group 9` findings from the [draft-spec audit](https://docs.google.com/document/d/1l_wBmSf07gpqEnjca7G3xNky_MKHTS06Jpu3sELJbiY/): a handful of cross-document anchors, cross-version links, and mermaid sequence diagrams in the draft spec that either don't resolve or describe methods/sections that no longer exist. All changes are doc-only under `docs/specification/draft/`.

Split into three logical commits so each fix is easy to review in isolation:

- **`InputRequiredResult` anchor casing.** Mintlify lowercases heading slugs, so links to `mrtr#InputRequiredResult` 404. Updated the 5 call sites (`elicitation`, `tools`, `resources`, `prompts`, `mrtr`) to use `#inputrequiredresult`, and while in `mrtr.mdx` also swapped the cross-version `https://modelcontextprotocol.io/specification/2025-11-25/basic#responses` `Result` link to the draft-relative `/specification/draft/basic#responses`.
- **Dead and stale cross-version links.** `mrtr.mdx`'s Security Considerations linked to `#server-requirements-ephemeral`, but the heading is now ""Server Requirements (Basic Workflow)"" (slug `#server-requirements-basic-workflow`). `prompts.mdx`'s PromptMessage annotations note still pointed at `/specification/2025-06-18/server/resources#annotations`; updated it to the draft URL.
- **Mermaid sequence diagrams.** `sampling.mdx` and `roots.mdx` used a non-existent `tool/call` method in the diagrams; corrected to `tools/call`. In the roots flow, the leading `Note over Server,Client: Discovery` was misleading now that `server/discover` is a distinct concept, so relabeled it to `Initial Request`, and spelled out the retry payload as `inputResponses{key: roots} + requestState` to match the MRTR vocabulary used elsewhere in the spec.

No schema or normative changes; purely docs/DX.
