### PR TITLE
docs(SEP-2575): clarify stdio process lifetime in lifecycle spec

### DIFF
--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -28,9 +28,8 @@ Specifically:
 - State that needs to span multiple requests (e.g., long-running tasks,
   application-level handles) **MUST** be referenced by an explicit identifier
   the client passes on each request.
-- The stdio process **SHOULD** have approximately the same lifetime as the host
-  application instance that launched it. Clients **SHOULD** attempt to restart
-  the stdio process if the server terminates unexpectedly.
+- Clients **SHOULD** attempt to restart the stdio process if the server 
+  terminates unexpectedly.
 
 Long-lived requests like
 [`subscriptions/listen`](/specification/draft/basic/utilities/subscriptions)

--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -20,11 +20,17 @@ Specifically:
   establish context (e.g., capabilities, protocol version, client identity).
   Every request supplies this metadata in its
   [`_meta`](/specification/draft/basic/index#meta) field.
-- Servers **MUST NOT** require that a client reuse the same connection to
-  perform related operations.
+- Servers **SHOULD** be prepared to handle requests associated with multiple
+  tasks, threads, or conversations. Servers **SHOULD NOT** require that a client
+  reuse the same connection or process to perform related operations. Clients
+  **SHOULD NOT** use an individual task, thread, or conversation as the default
+  lifetime boundary for the stdio process.
 - State that needs to span multiple requests (e.g., long-running tasks,
   application-level handles) **MUST** be referenced by an explicit identifier
   the client passes on each request.
+- The stdio process **SHOULD** have approximately the same lifetime as the host
+  application instance that launched it. Clients **SHOULD** attempt to restart
+  the stdio process if the server terminates unexpectedly.
 
 Long-lived requests like
 [`subscriptions/listen`](/specification/draft/basic/utilities/subscriptions)

--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -28,7 +28,7 @@ Specifically:
 - State that needs to span multiple requests (e.g., long-running tasks,
   application-level handles) **MUST** be referenced by an explicit identifier
   the client passes on each request.
-- Clients **SHOULD** attempt to restart the stdio process if the server 
+- Clients **SHOULD** attempt to restart the stdio process if the server
   terminates unexpectedly.
 
 Long-lived requests like


### PR DESCRIPTION
Add prescriptive guidance that the stdio process should track the host application lifetime and serve multiple tasks, threads, or conversations, rather than being scoped to any single one.
