### PR TITLE
docs: SEP-2243 clarifications for x-mcp-header

### DIFF
--- a/docs/seps/2243-http-standardization.mdx
+++ b/docs/seps/2243-http-standardization.mdx
@@ -176,7 +176,8 @@ The `x-mcp-header` property specifies the name portion used to construct the hea
 **Constraints on `x-mcp-header` values**:
 
 - MUST NOT be empty
-- MUST contain only ASCII characters (excluding space and `:`)
+- MUST match HTTP field-name token syntax (`1*tchar`, [RFC 9110 Section 5.1](https://datatracker.ietf.org/doc/html/rfc9110#section-5.1))
+- MUST NOT contain control characters, including carriage return (CR, `\r`) or line feed (LF, `\n`)
 - MUST be case-insensitively unique among all `x-mcp-header` values in the `inputSchema`
 - MUST only be applied to parameters with primitive types (number, string, boolean)
 

--- a/docs/seps/2243-http-standardization.mdx
+++ b/docs/seps/2243-http-standardization.mdx
@@ -431,7 +431,7 @@ When a value cannot be safely represented as a plain ASCII header value, clients
 Mcp-Param-{Name}: =?base64?{Base64EncodedValue}?=
 ```
 
-The prefix `=?base64?` and suffix `?=` indicate that the value is Base64-encoded. Servers and intermediaries that need to inspect these values MUST decode them accordingly.
+The prefix `=?base64?` and suffix `?=` indicate that the value is Base64-encoded. These markers are case-sensitive and MUST appear exactly as shown (lowercase). Servers and intermediaries that need to inspect these values MUST decode them accordingly.
 
 To avoid ambiguity, clients MUST also Base64-encode any plain-ASCII value that matches the sentinel pattern (i.e., starts with `=?base64?` and ends with `?=`).
 

--- a/docs/seps/2243-http-standardization.mdx
+++ b/docs/seps/2243-http-standardization.mdx
@@ -58,7 +58,7 @@ These headers are **required** for compliance with the MCP version in which they
 
 > **Rationale**: This requirement prevents potential security vulnerabilities and error conditions that could arise when different components in the network rely on different sources of truth. For example, a load balancer or gateway might use the header values to make routing decisions, while the MCP server uses the body values for execution. This requirement applies to any network intermediary that processes the message body, as well as the MCP server itself.
 
-> **Implementation Note**: When validating numeric parameter values, servers SHOULD compare the header value and the body value as numbers rather than as strings, treating them as equal if they differ by no more than a relative precision of 1E-9. This avoids false mismatches caused by differences in number-to-string conversion across implementations (e.g., `42` vs `42.0`, or `1e2` vs `100`).
+> **Implementation Note**: When validating integer parameter values, servers SHOULD compare the header value and the body value numerically rather than as strings (e.g., `42.0` and `42` are considered equal).
 
 **Case Sensitivity**: Header names (called "field names" in [RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#name-field-names)) are case-insensitive. Clients and servers MUST use case-insensitive comparisons for header names.
 
@@ -181,7 +181,7 @@ The `x-mcp-header` property specifies the name portion used to construct the hea
 - MUST match HTTP field-name token syntax (`1*tchar`, [RFC 9110 Section 5.1](https://datatracker.ietf.org/doc/html/rfc9110#section-5.1))
 - MUST NOT contain control characters, including carriage return (CR, `\r`) or line feed (LF, `\n`)
 - MUST be case-insensitively unique among all `x-mcp-header` values in the `inputSchema`
-- MUST only be applied to parameters with primitive types (number, string, boolean)
+- MUST only be applied to parameters with primitive types (integer, string, boolean). Parameters with type `number` are not permitted. Integer values MUST be within the safe range for JavaScript (−2^53+1 to 2^53−1)
 - MAY be applied to properties at any nesting depth within the `inputSchema`, not only top-level properties
 
 Clients using the Streamable HTTP transport MUST reject tool definitions where any `x-mcp-header` value violates these constraints. Rejection means the client MUST exclude the invalid tool from the result of `tools/list`. Clients SHOULD log a warning when rejecting a tool definition, including the tool name and the reason for rejection. This behavior ensures that a single malformed tool definition does not prevent other valid tools from being used. Clients using other transports (e.g., stdio) MAY ignore `x-mcp-header` annotations entirely.
@@ -410,7 +410,7 @@ Clients MUST apply the following encoding rules in order:
 
 1. **Type conversion**: Convert the parameter value to its string representation:
    - `string`: Use the value as-is
-   - `number`: Convert to decimal string representation (e.g., `42`, `3.14`)
+   - `integer`: Convert to decimal string representation (e.g., `42`, `-7`)
    - `boolean`: Convert to lowercase `"true"` or `"false"`
 
 2. **Whitespace check**: If the string starts or ends with whitespace (space or tab):

--- a/docs/seps/2243-http-standardization.mdx
+++ b/docs/seps/2243-http-standardization.mdx
@@ -455,6 +455,8 @@ When constructing a `tools/call` request via HTTP transport, the client MUST:
 1. Encode the values according to the rules in [Value Encoding](#value-encoding)
 1. Append a `Mcp-Param-{Name}: {Value}` header to the request:
 
+> **Implementation Note**: If the client does not have the tool's `inputSchema` (e.g., `tools/list` has not yet been called) or the cached schema is stale (e.g., its TTL has expired), the client SHOULD send the request without custom `Mcp-Param-*` headers. If the server rejects the request because required custom headers are missing, the client SHOULD call `tools/list` to obtain the current `inputSchema`, then retry the original request with the appropriate headers. Clients MAY pre-load tool definitions via other means (e.g., from a previous session or configuration) to enable header emission without a prior `tools/list` call.
+
 #### Server Behavior
 
 When receiving a request, the server MUST reject requests with `Mcp-Param-{Name}` headers that contain invalid characters (see "Character Restrictions" in the [Value Encoding](#value-encoding) section).

--- a/docs/seps/2243-http-standardization.mdx
+++ b/docs/seps/2243-http-standardization.mdx
@@ -180,6 +180,7 @@ The `x-mcp-header` property specifies the name portion used to construct the hea
 - MUST NOT contain control characters, including carriage return (CR, `\r`) or line feed (LF, `\n`)
 - MUST be case-insensitively unique among all `x-mcp-header` values in the `inputSchema`
 - MUST only be applied to parameters with primitive types (number, string, boolean)
+- MAY be applied to properties at any nesting depth within the `inputSchema`, not only top-level properties
 
 Clients MUST reject tool definitions where any `x-mcp-header` value violates these constraints. Rejection means the client MUST exclude the invalid tool from the result of `tools/list`. Clients SHOULD log a warning when rejecting a tool definition, including the tool name and the reason for rejection. This behavior ensures that a single malformed tool definition does not prevent other valid tools from being used.
 

--- a/docs/seps/2243-http-standardization.mdx
+++ b/docs/seps/2243-http-standardization.mdx
@@ -495,6 +495,8 @@ This error code is in the JSON-RPC implementation-defined server error range (`-
 
 > **Note**: Intermediaries MUST return an appropriate HTTP error status (e.g., `400 Bad Request`) for validation failures but are not required to return a JSON-RPC error response.
 
+> **Note**: Intermediaries that enforce policy based on mirrored headers (e.g., routing or rate-limiting by tenant) SHOULD verify that the `MCP-Protocol-Version` header indicates a version that requires header–body validation. If the version is older or the header is absent, the intermediary SHOULD reject the request rather than trusting unvalidated header values.
+
 **Custom Header Handling**:
 
 Custom headers (those defined via `x-mcp-header`) follow the same validation rules as standard headers:

--- a/docs/seps/2243-http-standardization.mdx
+++ b/docs/seps/2243-http-standardization.mdx
@@ -182,7 +182,7 @@ The `x-mcp-header` property specifies the name portion used to construct the hea
 - MUST only be applied to parameters with primitive types (number, string, boolean)
 - MAY be applied to properties at any nesting depth within the `inputSchema`, not only top-level properties
 
-Clients MUST reject tool definitions where any `x-mcp-header` value violates these constraints. Rejection means the client MUST exclude the invalid tool from the result of `tools/list`. Clients SHOULD log a warning when rejecting a tool definition, including the tool name and the reason for rejection. This behavior ensures that a single malformed tool definition does not prevent other valid tools from being used.
+Clients using the Streamable HTTP transport MUST reject tool definitions where any `x-mcp-header` value violates these constraints. Rejection means the client MUST exclude the invalid tool from the result of `tools/list`. Clients SHOULD log a warning when rejecting a tool definition, including the tool name and the reason for rejection. This behavior ensures that a single malformed tool definition does not prevent other valid tools from being used. Clients using other transports (e.g., stdio) MAY ignore `x-mcp-header` annotations entirely.
 
 **Example Tool Definition**:
 

--- a/docs/seps/2243-http-standardization.mdx
+++ b/docs/seps/2243-http-standardization.mdx
@@ -430,14 +430,17 @@ Mcp-Param-{Name}: =?base64?{Base64EncodedValue}?=
 
 The prefix `=?base64?` and suffix `?=` indicate that the value is Base64-encoded. Servers and intermediaries that need to inspect these values MUST decode them accordingly.
 
+To avoid ambiguity, clients MUST also Base64-encode any plain-ASCII value that matches the sentinel pattern (i.e., starts with `=?base64?` and ends with `?=`).
+
 **Examples**:
 
-| Original Value   | Reason                  | Encoded Header Value                                  |
-| ---------------- | ----------------------- | ----------------------------------------------------- |
-| `"us-west1"`     | Plain ASCII             | `Mcp-Param-Region: us-west1`                          |
-| `"Hello, 世界"`  | Contains non-ASCII      | `Mcp-Param-Greeting: =?base64?SGVsbG8sIOS4lueVjA==?=` |
-| `" padded "`     | Leading/trailing spaces | `Mcp-Param-Text: =?base64?IHBhZGRlZCA=?=`             |
-| `"line1\nline2"` | Contains newline        | `Mcp-Param-Text: =?base64?bGluZTEKbGluZTI=?=`         |
+| Original Value         | Reason                   | Encoded Header Value                                  |
+| ---------------------- | ------------------------ | ----------------------------------------------------- |
+| `"us-west1"`           | Plain ASCII              | `Mcp-Param-Region: us-west1`                          |
+| `"Hello, 世界"`        | Contains non-ASCII       | `Mcp-Param-Greeting: =?base64?SGVsbG8sIOS4lueVjA==?=` |
+| `" padded "`           | Leading/trailing spaces  | `Mcp-Param-Text: =?base64?IHBhZGRlZCA=?=`             |
+| `"line1\nline2"`       | Contains newline         | `Mcp-Param-Text: =?base64?bGluZTEKbGluZTI=?=`         |
+| `"=?base64?literal?="` | Matches sentinel pattern | `Mcp-Param-Val: =?base64?PT9iYXNlNjQ/bGl0ZXJhbD89?=`  |
 
 #### Client Behavior
 

--- a/docs/seps/2243-http-standardization.mdx
+++ b/docs/seps/2243-http-standardization.mdx
@@ -58,6 +58,8 @@ These headers are **required** for compliance with the MCP version in which they
 
 > **Rationale**: This requirement prevents potential security vulnerabilities and error conditions that could arise when different components in the network rely on different sources of truth. For example, a load balancer or gateway might use the header values to make routing decisions, while the MCP server uses the body values for execution. This requirement applies to any network intermediary that processes the message body, as well as the MCP server itself.
 
+> **Implementation Note**: When validating numeric parameter values, servers SHOULD compare the header value and the body value as numbers rather than as strings, treating them as equal if they differ by no more than a relative precision of 1E-9. This avoids false mismatches caused by differences in number-to-string conversion across implementations (e.g., `42` vs `42.0`, or `1e2` vs `100`).
+
 **Case Sensitivity**: Header names (called "field names" in [RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#name-field-names)) are case-insensitive. Clients and servers MUST use case-insensitive comparisons for header names.
 
 #### Example: tools/call Request

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -469,14 +469,19 @@ The prefix `=?base64?` and suffix `?=` indicate that the value is
 Base64-encoded. Servers and intermediaries that need to inspect these
 values **MUST** decode them accordingly.
 
+To avoid ambiguity, clients **MUST** also Base64-encode any plain-ASCII
+value that matches the sentinel pattern (i.e., starts with `=?base64?`
+and ends with `?=`).
+
 **Encoding examples:**
 
-| Original Value   | Reason                  | Encoded Header Value                                  |
-| ---------------- | ----------------------- | ----------------------------------------------------- |
-| `"us-west1"`     | Plain ASCII             | `Mcp-Param-Region: us-west1`                          |
-| `"Hello, 世界"`  | Contains non-ASCII      | `Mcp-Param-Greeting: =?base64?SGVsbG8sIOS4lueVjA==?=` |
-| `" padded "`     | Leading/trailing spaces | `Mcp-Param-Text: =?base64?IHBhZGRlZCA=?=`             |
-| `"line1\nline2"` | Contains newline        | `Mcp-Param-Text: =?base64?bGluZTEKbGluZTI=?=`         |
+| Original Value         | Reason                   | Encoded Header Value                                  |
+| ---------------------- | ------------------------ | ----------------------------------------------------- |
+| `"us-west1"`           | Plain ASCII              | `Mcp-Param-Region: us-west1`                          |
+| `"Hello, 世界"`        | Contains non-ASCII       | `Mcp-Param-Greeting: =?base64?SGVsbG8sIOS4lueVjA==?=` |
+| `" padded "`           | Leading/trailing spaces  | `Mcp-Param-Text: =?base64?IHBhZGRlZCA=?=`             |
+| `"line1\nline2"`       | Contains newline         | `Mcp-Param-Text: =?base64?bGluZTEKbGluZTI=?=`         |
+| `"=?base64?literal?="` | Matches sentinel pattern | `Mcp-Param-Val: =?base64?PT9iYXNlNjQ/bGl0ZXJhbD89?=`  |
 
 [rfc9110-values]: https://datatracker.ietf.org/doc/html/rfc9110#name-field-values
 

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -468,7 +468,8 @@ Mcp-Param-{Name}: =?base64?{Base64EncodedValue}?=
 ```
 
 The prefix `=?base64?` and suffix `?=` indicate that the value is
-Base64-encoded. Servers and intermediaries that need to inspect these
+Base64-encoded. These markers are case-sensitive and **MUST** appear exactly
+as shown (lowercase). Servers and intermediaries that need to inspect these
 values **MUST** decode them accordingly.
 
 To avoid ambiguity, clients **MUST** also Base64-encode any plain-ASCII

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -502,6 +502,20 @@ When constructing a `tools/call` request via HTTP transport, the client
    rules.
 5. Append a `Mcp-Param-{Name}: {Value}` header to the request.
 
+<Note>
+
+If the client does not have the tool's `inputSchema` (e.g., `tools/list`
+has not yet been called) or the cached schema is stale (e.g., its TTL has
+expired), the client **SHOULD** send the request without custom
+`Mcp-Param-*` headers. If the server rejects the request because required
+custom headers are missing, the client **SHOULD** call `tools/list` to
+obtain the current `inputSchema`, then retry the original request with the
+appropriate headers. Clients **MAY** pre-load tool definitions via other
+means (e.g., from a previous session or configuration) to enable header
+emission without a prior `tools/list` call.
+
+</Note>
+
 ##### Server Behavior for Custom Headers
 
 Intermediate servers that do not recognize an `Mcp-Param-{Name}` header

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -380,7 +380,9 @@ the header name `Mcp-Param-{name}`.
 **Constraints on `x-mcp-header` values**:
 
 - **MUST NOT** be empty
-- **MUST** contain only ASCII characters (excluding space and `:`)
+- **MUST** match HTTP field-name token syntax (`1*tchar`, [RFC 9110 Section 5.1](https://datatracker.ietf.org/doc/html/rfc9110#section-5.1))
+- **MUST NOT** contain control characters, including carriage return (CR, `\r`)
+  or line feed (LF, `\n`)
 - **MUST** be case-insensitively unique among all `x-mcp-header` values in
   the `inputSchema`
 - **MUST** only be applied to parameters with primitive types (number,

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -390,11 +390,14 @@ the header name `Mcp-Param-{name}`.
 - **MAY** be applied to properties at any nesting depth within the
   `inputSchema`, not only top-level properties
 
-Clients **MUST** reject tool definitions where any `x-mcp-header` value
-violates these constraints. Rejection means the client **MUST** exclude the
-invalid tool from the result of `tools/list`. Clients **SHOULD** log a
-warning when rejecting a tool definition, including the tool name and the
-reason for rejection.
+Clients using the Streamable HTTP transport **MUST** reject tool definitions
+where any `x-mcp-header` value violates these constraints. Rejection means
+the client **MUST** exclude the invalid tool from the result of `tools/list`.
+Clients **SHOULD** log a warning when rejecting a tool definition, including
+the tool name and the reason for rejection. This ensures that a single
+malformed tool definition does not prevent other valid tools from being used.
+Clients using other transports (e.g., stdio) **MAY** ignore `x-mcp-header`
+annotations entirely.
 
 **Example tool definition:**
 

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -385,8 +385,10 @@ the header name `Mcp-Param-{name}`.
   or line feed (LF, `\n`)
 - **MUST** be case-insensitively unique among all `x-mcp-header` values in
   the `inputSchema`
-- **MUST** only be applied to parameters with primitive types (number,
-  string, boolean)
+- **MUST** only be applied to parameters with primitive types (integer,
+  string, boolean). Parameters with type `number` are not permitted.
+  Integer values **MUST** be within the safe range for JavaScript
+  (−2<sup>53</sup>+1 to 2<sup>53</sup>−1)
 - **MAY** be applied to properties at any nesting depth within the
   `inputSchema`, not only top-level properties
 
@@ -455,7 +457,7 @@ headers to ensure safe transmission and prevent injection attacks.
 **Type conversion**: Convert the parameter value to its string representation:
 
 - `string`: Use the value as-is
-- `number`: Convert to decimal string representation (e.g., `42`, `3.14`)
+- `integer`: Convert to decimal string representation (e.g., `42`, `-7`)
 - `boolean`: Convert to lowercase `"true"` or `"false"`
 
 Per [RFC 9110][rfc9110-values],
@@ -565,12 +567,9 @@ executes based on the body value).
 
 <Note>
 
-When validating numeric parameter values, servers **SHOULD** compare the
-header value and the body value as numbers rather than as strings, treating
-them as equal if they differ by no more than a relative precision of 1E-9.
-This avoids false mismatches caused by differences in number-to-string
-conversion across implementations (e.g., `42` vs `42.0`, or `1e2` vs
-`100`).
+When validating integer parameter values, servers **SHOULD** compare the
+header value and the body value numerically rather than as strings (e.g.,
+`42.0` and `42` are considered equal).
 
 </Note>
 

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -545,6 +545,17 @@ different components in the network rely on different sources of truth
 (e.g., a load balancer routing on the header value while the MCP server
 executes based on the body value).
 
+<Note>
+
+When validating numeric parameter values, servers **SHOULD** compare the
+header value and the body value as numbers rather than as strings, treating
+them as equal if they differ by no more than a relative precision of 1E-9.
+This avoids false mismatches caused by differences in number-to-string
+conversion across implementations (e.g., `42` vs `42.0`, or `1e2` vs
+`100`).
+
+</Note>
+
 When rejecting a request due to header validation failure, servers **MUST**
 return HTTP status `400 Bad Request` and **SHOULD** include a JSON-RPC error
 response using the following error code:

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -610,6 +610,16 @@ a JSON-RPC error response.
 
 </Note>
 
+<Note>
+
+Intermediaries that enforce policy based on mirrored headers (e.g., routing
+or rate-limiting by tenant) **SHOULD** verify that the `MCP-Protocol-Version`
+header indicates a version that requires header–body validation. If the
+version is older or the header is absent, the intermediary **SHOULD** reject
+the request rather than trusting unvalidated header values.
+
+</Note>
+
 ### Backward Compatibility
 
 A client that supports both modern (per-request-metadata) MCP versions and a

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -387,6 +387,8 @@ the header name `Mcp-Param-{name}`.
   the `inputSchema`
 - **MUST** only be applied to parameters with primitive types (number,
   string, boolean)
+- **MAY** be applied to properties at any nesting depth within the
+  `inputSchema`, not only top-level properties
 
 Clients **MUST** reject tool definitions where any `x-mcp-header` value
 violates these constraints. Rejection means the client **MUST** exclude the

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -340,6 +340,8 @@ HTTP header.
 - **MUST** be case-insensitively unique among all `x-mcp-header` values in the
   `inputSchema`
 - **MUST** only be applied to parameters with primitive types (number, string, boolean)
+- **MAY** be applied to properties at any nesting depth within the `inputSchema`, not
+  only top-level properties
 
 Clients **MUST** reject tool definitions where any `x-mcp-header` value violates these
 constraints. Rejection means the client **MUST** exclude the invalid tool from the result

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -343,11 +343,13 @@ HTTP header.
 - **MAY** be applied to properties at any nesting depth within the `inputSchema`, not
   only top-level properties
 
-Clients **MUST** reject tool definitions where any `x-mcp-header` value violates these
-constraints. Rejection means the client **MUST** exclude the invalid tool from the result
-of `tools/list`. Clients **SHOULD** log a warning when rejecting a tool definition,
-including the tool name and the reason for rejection. This ensures that a single
-malformed tool definition does not prevent other valid tools from being used.
+Clients using the Streamable HTTP transport **MUST** reject tool definitions where any
+`x-mcp-header` value violates these constraints. Rejection means the client **MUST**
+exclude the invalid tool from the result of `tools/list`. Clients **SHOULD** log a
+warning when rejecting a tool definition, including the tool name and the reason for
+rejection. This ensures that a single malformed tool definition does not prevent other
+valid tools from being used. Clients using other transports (e.g., stdio) **MAY** ignore
+`x-mcp-header` annotations entirely.
 
 **Example tool definition with `x-mcp-header`:**
 

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -339,7 +339,9 @@ HTTP header.
   line feed (LF, `\n`)
 - **MUST** be case-insensitively unique among all `x-mcp-header` values in the
   `inputSchema`
-- **MUST** only be applied to parameters with primitive types (number, string, boolean)
+- **MUST** only be applied to parameters with primitive types (integer, string, boolean).
+  Parameters with type `number` are not permitted. Integer values **MUST** be within the
+  safe range for JavaScript (−2<sup>53</sup>+1 to 2<sup>53</sup>−1)
 - **MAY** be applied to properties at any nesting depth within the `inputSchema`, not
   only top-level properties
 

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -334,7 +334,9 @@ HTTP header.
 **Constraints on `x-mcp-header` values:**
 
 - **MUST NOT** be empty
-- **MUST** contain only ASCII characters, excluding space and `:`
+- **MUST** match HTTP field-name token syntax (`1*tchar`, [RFC 9110 Section 5.1](https://datatracker.ietf.org/doc/html/rfc9110#section-5.1))
+- **MUST NOT** contain control characters, including carriage return (CR, `\r`) or
+  line feed (LF, `\n`)
 - **MUST** be case-insensitively unique among all `x-mcp-header` values in the
   `inputSchema`
 - **MUST** only be applied to parameters with primitive types (number, string, boolean)

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -341,7 +341,7 @@ HTTP header.
   `inputSchema`
 - **MUST** only be applied to parameters with primitive types (integer, string, boolean).
   Parameters with type `number` are not permitted. Integer values **MUST** be within the
-  safe range for JavaScript (−2<sup>53</sup>+1 to 2<sup>53</sup>−1)
+  safe range for integers represented using IEEE754 double-precision floating point numbers (−2<sup>53</sup>+1 to 2<sup>53</sup>−1)
 - **MAY** be applied to properties at any nesting depth within the `inputSchema`, not
   only top-level properties
 

--- a/seps/2243-http-standardization.md
+++ b/seps/2243-http-standardization.md
@@ -415,7 +415,7 @@ When a value cannot be safely represented as a plain ASCII header value, clients
 Mcp-Param-{Name}: =?base64?{Base64EncodedValue}?=
 ```
 
-The prefix `=?base64?` and suffix `?=` indicate that the value is Base64-encoded. Servers and intermediaries that need to inspect these values MUST decode them accordingly.
+The prefix `=?base64?` and suffix `?=` indicate that the value is Base64-encoded. These markers are case-sensitive and MUST appear exactly as shown (lowercase). Servers and intermediaries that need to inspect these values MUST decode them accordingly.
 
 To avoid ambiguity, clients MUST also Base64-encode any plain-ASCII value that matches the sentinel pattern (i.e., starts with `=?base64?` and ends with `?=`).
 

--- a/seps/2243-http-standardization.md
+++ b/seps/2243-http-standardization.md
@@ -439,6 +439,8 @@ When constructing a `tools/call` request via HTTP transport, the client MUST:
 1. Encode the values according to the rules in [Value Encoding](#value-encoding)
 1. Append a `Mcp-Param-{Name}: {Value}` header to the request:
 
+> **Implementation Note**: If the client does not have the tool's `inputSchema` (e.g., `tools/list` has not yet been called) or the cached schema is stale (e.g., its TTL has expired), the client SHOULD send the request without custom `Mcp-Param-*` headers. If the server rejects the request because required custom headers are missing, the client SHOULD call `tools/list` to obtain the current `inputSchema`, then retry the original request with the appropriate headers. Clients MAY pre-load tool definitions via other means (e.g., from a previous session or configuration) to enable header emission without a prior `tools/list` call.
+
 #### Server Behavior
 
 When receiving a request, the server MUST reject requests with `Mcp-Param-{Name}` headers that contain invalid characters (see "Character Restrictions" in the [Value Encoding](#value-encoding) section).

--- a/seps/2243-http-standardization.md
+++ b/seps/2243-http-standardization.md
@@ -164,6 +164,7 @@ The `x-mcp-header` property specifies the name portion used to construct the hea
 - MUST NOT contain control characters, including carriage return (CR, `\r`) or line feed (LF, `\n`)
 - MUST be case-insensitively unique among all `x-mcp-header` values in the `inputSchema`
 - MUST only be applied to parameters with primitive types (number, string, boolean)
+- MAY be applied to properties at any nesting depth within the `inputSchema`, not only top-level properties
 
 Clients MUST reject tool definitions where any `x-mcp-header` value violates these constraints. Rejection means the client MUST exclude the invalid tool from the result of `tools/list`. Clients SHOULD log a warning when rejecting a tool definition, including the tool name and the reason for rejection. This behavior ensures that a single malformed tool definition does not prevent other valid tools from being used.
 

--- a/seps/2243-http-standardization.md
+++ b/seps/2243-http-standardization.md
@@ -42,7 +42,7 @@ These headers are **required** for compliance with the MCP version in which they
 
 > **Rationale**: This requirement prevents potential security vulnerabilities and error conditions that could arise when different components in the network rely on different sources of truth. For example, a load balancer or gateway might use the header values to make routing decisions, while the MCP server uses the body values for execution. This requirement applies to any network intermediary that processes the message body, as well as the MCP server itself.
 
-> **Implementation Note**: When validating numeric parameter values, servers SHOULD compare the header value and the body value as numbers rather than as strings, treating them as equal if they differ by no more than a relative precision of 1E-9. This avoids false mismatches caused by differences in number-to-string conversion across implementations (e.g., `42` vs `42.0`, or `1e2` vs `100`).
+> **Implementation Note**: When validating integer parameter values, servers SHOULD compare the header value and the body value numerically rather than as strings (e.g., `42.0` and `42` are considered equal).
 
 **Case Sensitivity**: Header names (called "field names" in [RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#name-field-names)) are case-insensitive. Clients and servers MUST use case-insensitive comparisons for header names.
 
@@ -165,7 +165,7 @@ The `x-mcp-header` property specifies the name portion used to construct the hea
 - MUST match HTTP field-name token syntax (`1*tchar`, [RFC 9110 Section 5.1](https://datatracker.ietf.org/doc/html/rfc9110#section-5.1))
 - MUST NOT contain control characters, including carriage return (CR, `\r`) or line feed (LF, `\n`)
 - MUST be case-insensitively unique among all `x-mcp-header` values in the `inputSchema`
-- MUST only be applied to parameters with primitive types (number, string, boolean)
+- MUST only be applied to parameters with primitive types (integer, string, boolean). Parameters with type `number` are not permitted. Integer values MUST be within the safe range for JavaScript (−2^53+1 to 2^53−1)
 - MAY be applied to properties at any nesting depth within the `inputSchema`, not only top-level properties
 
 Clients using the Streamable HTTP transport MUST reject tool definitions where any `x-mcp-header` value violates these constraints. Rejection means the client MUST exclude the invalid tool from the result of `tools/list`. Clients SHOULD log a warning when rejecting a tool definition, including the tool name and the reason for rejection. This behavior ensures that a single malformed tool definition does not prevent other valid tools from being used. Clients using other transports (e.g., stdio) MAY ignore `x-mcp-header` annotations entirely.
@@ -394,7 +394,7 @@ Clients MUST apply the following encoding rules in order:
 
 1. **Type conversion**: Convert the parameter value to its string representation:
    - `string`: Use the value as-is
-   - `number`: Convert to decimal string representation (e.g., `42`, `3.14`)
+   - `integer`: Convert to decimal string representation (e.g., `42`, `-7`)
    - `boolean`: Convert to lowercase `"true"` or `"false"`
 
 2. **Whitespace check**: If the string starts or ends with whitespace (space or tab):

--- a/seps/2243-http-standardization.md
+++ b/seps/2243-http-standardization.md
@@ -160,7 +160,8 @@ The `x-mcp-header` property specifies the name portion used to construct the hea
 **Constraints on `x-mcp-header` values**:
 
 - MUST NOT be empty
-- MUST contain only ASCII characters (excluding space and `:`)
+- MUST match HTTP field-name token syntax (`1*tchar`, [RFC 9110 Section 5.1](https://datatracker.ietf.org/doc/html/rfc9110#section-5.1))
+- MUST NOT contain control characters, including carriage return (CR, `\r`) or line feed (LF, `\n`)
 - MUST be case-insensitively unique among all `x-mcp-header` values in the `inputSchema`
 - MUST only be applied to parameters with primitive types (number, string, boolean)
 

--- a/seps/2243-http-standardization.md
+++ b/seps/2243-http-standardization.md
@@ -42,6 +42,8 @@ These headers are **required** for compliance with the MCP version in which they
 
 > **Rationale**: This requirement prevents potential security vulnerabilities and error conditions that could arise when different components in the network rely on different sources of truth. For example, a load balancer or gateway might use the header values to make routing decisions, while the MCP server uses the body values for execution. This requirement applies to any network intermediary that processes the message body, as well as the MCP server itself.
 
+> **Implementation Note**: When validating numeric parameter values, servers SHOULD compare the header value and the body value as numbers rather than as strings, treating them as equal if they differ by no more than a relative precision of 1E-9. This avoids false mismatches caused by differences in number-to-string conversion across implementations (e.g., `42` vs `42.0`, or `1e2` vs `100`).
+
 **Case Sensitivity**: Header names (called "field names" in [RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#name-field-names)) are case-insensitive. Clients and servers MUST use case-insensitive comparisons for header names.
 
 #### Example: tools/call Request

--- a/seps/2243-http-standardization.md
+++ b/seps/2243-http-standardization.md
@@ -414,14 +414,17 @@ Mcp-Param-{Name}: =?base64?{Base64EncodedValue}?=
 
 The prefix `=?base64?` and suffix `?=` indicate that the value is Base64-encoded. Servers and intermediaries that need to inspect these values MUST decode them accordingly.
 
+To avoid ambiguity, clients MUST also Base64-encode any plain-ASCII value that matches the sentinel pattern (i.e., starts with `=?base64?` and ends with `?=`).
+
 **Examples**:
 
-| Original Value   | Reason                  | Encoded Header Value                                  |
-| ---------------- | ----------------------- | ----------------------------------------------------- |
-| `"us-west1"`     | Plain ASCII             | `Mcp-Param-Region: us-west1`                          |
-| `"Hello, 世界"`  | Contains non-ASCII      | `Mcp-Param-Greeting: =?base64?SGVsbG8sIOS4lueVjA==?=` |
-| `" padded "`     | Leading/trailing spaces | `Mcp-Param-Text: =?base64?IHBhZGRlZCA=?=`             |
-| `"line1\nline2"` | Contains newline        | `Mcp-Param-Text: =?base64?bGluZTEKbGluZTI=?=`         |
+| Original Value         | Reason                   | Encoded Header Value                                  |
+| ---------------------- | ------------------------ | ----------------------------------------------------- |
+| `"us-west1"`           | Plain ASCII              | `Mcp-Param-Region: us-west1`                          |
+| `"Hello, 世界"`        | Contains non-ASCII       | `Mcp-Param-Greeting: =?base64?SGVsbG8sIOS4lueVjA==?=` |
+| `" padded "`           | Leading/trailing spaces  | `Mcp-Param-Text: =?base64?IHBhZGRlZCA=?=`             |
+| `"line1\nline2"`       | Contains newline         | `Mcp-Param-Text: =?base64?bGluZTEKbGluZTI=?=`         |
+| `"=?base64?literal?="` | Matches sentinel pattern | `Mcp-Param-Val: =?base64?PT9iYXNlNjQ/bGl0ZXJhbD89?=`  |
 
 #### Client Behavior
 

--- a/seps/2243-http-standardization.md
+++ b/seps/2243-http-standardization.md
@@ -479,6 +479,8 @@ This error code is in the JSON-RPC implementation-defined server error range (`-
 
 > **Note**: Intermediaries MUST return an appropriate HTTP error status (e.g., `400 Bad Request`) for validation failures but are not required to return a JSON-RPC error response.
 
+> **Note**: Intermediaries that enforce policy based on mirrored headers (e.g., routing or rate-limiting by tenant) SHOULD verify that the `MCP-Protocol-Version` header indicates a version that requires header–body validation. If the version is older or the header is absent, the intermediary SHOULD reject the request rather than trusting unvalidated header values.
+
 **Custom Header Handling**:
 
 Custom headers (those defined via `x-mcp-header`) follow the same validation rules as standard headers:

--- a/seps/2243-http-standardization.md
+++ b/seps/2243-http-standardization.md
@@ -166,7 +166,7 @@ The `x-mcp-header` property specifies the name portion used to construct the hea
 - MUST only be applied to parameters with primitive types (number, string, boolean)
 - MAY be applied to properties at any nesting depth within the `inputSchema`, not only top-level properties
 
-Clients MUST reject tool definitions where any `x-mcp-header` value violates these constraints. Rejection means the client MUST exclude the invalid tool from the result of `tools/list`. Clients SHOULD log a warning when rejecting a tool definition, including the tool name and the reason for rejection. This behavior ensures that a single malformed tool definition does not prevent other valid tools from being used.
+Clients using the Streamable HTTP transport MUST reject tool definitions where any `x-mcp-header` value violates these constraints. Rejection means the client MUST exclude the invalid tool from the result of `tools/list`. Clients SHOULD log a warning when rejecting a tool definition, including the tool name and the reason for rejection. This behavior ensures that a single malformed tool definition does not prevent other valid tools from being used. Clients using other transports (e.g., stdio) MAY ignore `x-mcp-header` annotations entirely.
 
 **Example Tool Definition**:
 


### PR DESCRIPTION
## Summary

Addresses clarification issues raised during implementation of SEP-2243 (HTTP Standardization), primarily from Go SDK implementers in https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2243.

Fixes #2762

## Changes

1. **RFC 9110 token rule for header names** — Replace loose "ASCII excluding space and colon" constraint with RFC 9110 `tchar` syntax and explicit CR/LF prohibition. Adds link to RFC 9110 Section 5.1.

2. **Base64 sentinel collision** — Require clients to Base64-encode any plain-ASCII value that matches the `=?base64?...?=` sentinel pattern, preventing ambiguity.

3. **Nested property support** — Clarify that `x-mcp-header` MAY be applied to properties at any nesting depth, not only top-level properties.

4. **Transport scoping** — Scope `x-mcp-header` rejection to Streamable HTTP transport only; clients using other transports (e.g., stdio) MAY ignore annotations entirely.

5. **Numeric comparison precision** — Add implementation note: numeric fields should be compared numerically (within 1E-9 relative precision) rather than as strings.

6. **Stale/missing schema retry** — Add note on client behavior when tool schema is unavailable: send without custom headers, retry after `tools/list` if rejected. Also allows pre-loading tool definitions from other sources.

7. **Case-sensitive sentinel markers** — Clarify that `=?base64?` and `?=` markers are case-sensitive and must appear exactly as shown.

8. **Version-gating for intermediaries** — Add note that intermediaries enforcing policy on mirrored headers should verify `MCP-Protocol-Version` indicates a version requiring header–body validation, and reject otherwise.