### PR TITLE
docs(SEP-2575): consolidate back-compat rule and broaden stdio fallback

### DIFF
--- a/docs/specification/draft/basic/lifecycle.mdx
+++ b/docs/specification/draft/basic/lifecycle.mdx
@@ -112,12 +112,18 @@ both kinds of servers can detect which is present:
 - **STDIO.** Because there is no per-request status code to drive fallback,
   a client that supports both eras **SHOULD** probe with
   [`server/discover`](/specification/draft/server/discover) first,
-  setting its preferred modern version in `_meta`. If the server returns
-  `Method not found` (`-32601`), fall back to the legacy `initialize`
-  handshake. If the server returns `UnsupportedProtocolVersionError`, the
-  server speaks a version of MCP without `initialize` — use one of the
-  versions in its advertised `supported` list instead of falling back to
-  `initialize`.
+  setting its preferred modern version in `_meta`. The client interprets the
+  response as follows:
+  - **`UnsupportedProtocolVersionError`**: the server speaks modern MCP
+    without the requested version. Retry using one of the versions in its
+    advertised `supported` list rather than falling back to `initialize`.
+  - **Any other error response, or no response within a reasonable timeout**:
+    restart the server process and perform the legacy `initialize` handshake
+    on the fresh process. Legacy servers are not required to use any
+    particular error code (or to respond at all) for an unknown method
+    received before `initialize`, so the fallback cannot rely on a single
+    code such as `-32601`, and the server may be left in an undefined state
+    after the unrecognized probe.
 
 A client that only supports modern (per-request-metadata) versions does not
 need to probe — it simply sends its preferred version and handles

--- a/docs/specification/draft/basic/transports.mdx
+++ b/docs/specification/draft/basic/transports.mdx
@@ -115,16 +115,11 @@ re-established after restart.
 
 ### Backward Compatibility
 
-A client that supports both modern (per-request-metadata) MCP versions and a
-legacy version that requires an `initialize` handshake **SHOULD** probe with
-[`server/discover`][server-discover] before sending
-any other request. If the server returns `Method not found` (`-32601`), the
-client falls back to the legacy `initialize` handshake. If the server returns
-`UnsupportedProtocolVersionError`, it speaks a version of MCP without
-`initialize` — the client **SHOULD** retry using one of the versions in the
-advertised `supported` list rather than falling back to `initialize`. See
-[Lifecycle: Backward Compatibility][lifecycle-compat]
-for details.
+A client that interoperates with both modern (per-request-metadata) MCP
+versions and a legacy version requiring an `initialize` handshake **SHOULD**
+probe with [`server/discover`][server-discover] before sending any other
+request. See [Lifecycle: Backward Compatibility][lifecycle-compat] for the
+rule that determines when to fall back to `initialize`.
 
 A client that only supports modern versions does not need to probe.
 
@@ -585,22 +580,11 @@ a JSON-RPC error response.
 
 ### Backward Compatibility
 
-A client that supports both modern (per-request-metadata) MCP versions and a
-legacy version that requires an `initialize` handshake **MAY** detect which
-era the server implements by attempting a modern request first. On
-`400 Bad Request`, the client **SHOULD** inspect the response body before
-falling back: modern servers also use `400` for
-[`UnsupportedProtocolVersionError`][unsupported-version],
-`MissingRequiredClientCapabilityError`, and header-validation failures.
-
-- If the body contains a recognized modern JSON-RPC error, the server speaks
-  a modern version of MCP — retry using the advertised `supported` versions
-  or correct the request, rather than falling back.
-- If the body is empty or is not a recognized modern JSON-RPC error, fall
-  back to `initialize` and continue with the legacy version for subsequent
-  requests.
-
-See [Lifecycle: Backward Compatibility][lifecycle-compat] for details.
+A client that interoperates with both modern (per-request-metadata) MCP
+versions and a legacy version requiring an `initialize` handshake **MAY**
+detect which era the server implements by attempting a modern request first.
+See [Lifecycle: Backward Compatibility][lifecycle-compat] for the rule that
+determines when to fall back to `initialize`.
 
 Separately, clients and servers can maintain backward compatibility with the
 deprecated [HTTP+SSE transport][http-sse] (from

--- a/docs/specification/draft/server/discover.mdx
+++ b/docs/specification/draft/server/discover.mdx
@@ -75,10 +75,11 @@ is useful in two scenarios:
 - **Up-front version selection.** The client learns the server's supported
   versions before sending any other request, avoiding a round-trip error.
 - **STDIO backward-compatibility probe.** On stdio, there is no per-request
-  HTTP status code to drive fallback. A client that supports both modern
+  HTTP status code to drive fallback, so a client that supports both modern
   (per-request `_meta`) and legacy (`initialize` handshake) servers **SHOULD**
-  send `server/discover` first. If the server returns `Method not found`
-  (`-32601`), the client falls back to the `initialize` handshake.
+  send `server/discover` first to detect which era the server speaks. See
+  [Lifecycle: Backward Compatibility](/specification/draft/basic/lifecycle#backward-compatibility-with-initialization-based-versions)
+  for the rule that determines when to fall back.
 
 See [Protocol Version Negotiation](/specification/draft/basic/lifecycle#protocol-version-negotiation)
 for the full version-selection flow. For HTTP-specific status codes returned for


### PR DESCRIPTION
Move the per-transport rule for "modern vs legacy server" detection into the Lifecycle: Backward Compatibility section as the single source of truth, and replace the duplicated paragraphs in Transports (stdio + HTTP) and Discover with brief cross-links.

For the stdio probe, broaden the fallback condition: legacy servers are not required to answer an unknown pre-initialize method with -32601 (or to respond at all), so the client falls back to initialize on any error other than UnsupportedProtocolVersionError, or on no response within a reasonable timeout. The client also restarts the server process before sending initialize, since the legacy server may be in an undefined state after the unrecognized probe.
