### PR TITLE
Add cut-release / publish-release workflows

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,161 @@
+name: Cut spec release
+
+# Two paths:
+#   kind=rc    → tag <version>-RC + prerelease GitHub Release on current main.
+#                Spec content stays under docs/specification/draft/. No PR.
+#   kind=final → promote draft/ to docs/specification/<version>/ and schema/<version>/,
+#                open a PR for core-maintainers review. Tagging the GA release is
+#                handled by the companion `publish-release` job after that PR merges.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Spec version (YYYY-MM-DD)
+        required: true
+      kind:
+        description: rc | final
+        required: true
+        type: choice
+        options: [rc, final]
+      dry_run:
+        description: Skip the write step (log what would happen)
+        required: false
+        default: 'false'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Never interpolate inputs.* directly into run: — pass via env and reference as
+# shell vars so a malicious input can't inject shell.
+env:
+  VERSION: ${{ inputs.version }}
+
+jobs:
+  rc:
+    if: inputs.kind == 'rc'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate version
+        run: |
+          [[ "$VERSION" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || { echo "::error::version must be YYYY-MM-DD"; exit 1; }
+          # Never publish over an existing tag.
+          ! git ls-remote --exit-code --tags origin "refs/tags/${VERSION}-RC" \
+            || { echo "::error::tag ${VERSION}-RC already exists"; exit 1; }
+
+      - name: Create RC tag and prerelease
+        if: inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ github.sha }}
+        run: |
+          gh release create "${VERSION}-RC" \
+            --target "$TARGET_SHA" \
+            --prerelease \
+            --title "MCP ${VERSION} RC" \
+            --notes "Release candidate for the ${VERSION} revision of the Model Context Protocol specification.
+
+          The RC content is the current draft: https://modelcontextprotocol.io/specification/draft
+
+          Please file issues against SEPs in this milestone before the final cut."
+
+      - name: Summary
+        run: |
+          echo "tag=${VERSION}-RC" >> "$GITHUB_OUTPUT"
+          echo "RC ${VERSION} → tag \`${VERSION}-RC\` (prerelease)" >> "$GITHUB_STEP_SUMMARY"
+
+  final:
+    if: inputs.kind == 'final'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Validate version
+        run: |
+          [[ "$VERSION" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || { echo "::error::version must be YYYY-MM-DD"; exit 1; }
+          [[ ! -d "docs/specification/$VERSION" ]] || { echo "::error::docs/specification/$VERSION already exists"; exit 1; }
+
+      - name: Promote draft → versioned dir
+        run: |
+          set -euo pipefail
+          cp -r docs/specification/draft "docs/specification/$VERSION"
+          cp -r schema/draft "schema/$VERSION"
+          # Stamp the protocolVersion constant the generators read.
+          sed -i "s|^export const LATEST_PROTOCOL_VERSION = .*|export const LATEST_PROTOCOL_VERSION = \"$VERSION\";|" "schema/$VERSION/schema.ts"
+
+      - name: Regenerate schema artifacts
+        run: |
+          npm ci
+          npm run generate
+
+      - name: Patch Mintlify nav (docs/docs.json)
+        run: |
+          node <<'EOF'
+          const fs = require('fs');
+          const V = process.env.VERSION;
+          const p = 'docs/docs.json';
+          const j = JSON.parse(fs.readFileSync(p, 'utf8'));
+          // navigation.tabs[].versions[] where version === 'Draft' is the template.
+          // Insert a copy as the new "(latest)", strip "(latest)" from the previous one,
+          // and rewrite page paths draft/ → <V>/.
+          const rewrite = (o) =>
+            JSON.parse(JSON.stringify(o).replaceAll('specification/draft', `specification/${V}`));
+          for (const tab of j.navigation.tabs ?? []) {
+            const versions = tab.versions;
+            if (!Array.isArray(versions)) continue;
+            const draft = versions.find((v) => v.version === 'Draft');
+            if (!draft) continue;
+            for (const v of versions)
+              if (typeof v.version === 'string')
+                v.version = v.version.replace(' (latest)', '');
+            const promoted = rewrite(draft);
+            promoted.version = `Version ${V} (latest)`;
+            const i = versions.indexOf(draft);
+            versions.splice(i, 0, promoted);
+          }
+          fs.writeFileSync(p, JSON.stringify(j, null, 2) + '\n');
+          EOF
+
+      - name: Reset draft changelog for next cycle
+        run: |
+          cat > docs/specification/draft/changelog.mdx <<'EOF'
+          ---
+          title: Changelog
+          ---
+
+          Changes since the most recent release will accumulate here.
+          EOF
+
+      - name: Open release PR
+        if: inputs.dry_run != 'true'
+        id: pr
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        with:
+          branch: release/${{ inputs.version }}
+          title: "Add ${{ inputs.version }} MCP specification"
+          commit-message: "Add ${{ inputs.version }} MCP specification"
+          labels: release
+          body: |
+            Promotes `docs/specification/draft/` and `schema/draft/` to `${{ inputs.version }}`.
+
+            Generated by `cut-release.yml` (dispatched from mcp-spec-tpm).
+
+            - [ ] Spot-check rendered pages on the preview deploy
+            - [ ] Confirm `schema/${{ inputs.version }}/schema.json` regenerated cleanly
+            - [ ] Prior version's `(latest)` suffix removed in `docs/docs.json`
+
+            Tagging `${{ inputs.version }}` happens via `publish-release.yml` after merge.
+
+      - name: Summary
+        env:
+          PR_URL: ${{ steps.pr.outputs.pull-request-url }}
+        run: |
+          echo "pr=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "Final ${VERSION} → PR ${PR_URL}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,54 @@
+name: Publish spec release
+
+# Companion to cut-release.yml. Creates the GA tag + GitHub Release once the
+# `release/<version>` PR has merged to main. Runs only on the merge commit of a
+# release branch so a stray push can't publish.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Only fire for the merge of a release/<YYYY-MM-DD> branch.
+    if: |
+      startsWith(github.event.head_commit.message, 'Add ')
+      && contains(github.event.head_commit.message, ' MCP specification')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Derive version from merged release branch
+        id: v
+        env:
+          # Never interpolate event payloads directly into run: — pass via env.
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          # COMMIT_MSG is "Add YYYY-MM-DD MCP specification (#NNN)"
+          V=$(printf '%s' "$COMMIT_MSG" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1)
+          [[ -n "$V" ]] || { echo "::error::could not parse version from commit message"; exit 1; }
+          [[ -d "docs/specification/$V" ]] || { echo "::error::docs/specification/$V missing on main"; exit 1; }
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+
+      - name: Create GA release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.v.outputs.version }}
+          TARGET_SHA: ${{ github.sha }}
+        run: |
+          # Idempotent — skip if the tag already exists.
+          if git ls-remote --exit-code --tags origin "refs/tags/${VERSION}"; then
+            echo "tag ${VERSION} already exists — skipping"
+            exit 0
+          fi
+          gh release create "$VERSION" \
+            --target "$TARGET_SHA" \
+            --latest \
+            --title "MCP ${VERSION}" \
+            --notes "Model Context Protocol specification ${VERSION}.
+
+          https://modelcontextprotocol.io/specification/${VERSION}
+          Changelog: https://modelcontextprotocol.io/specification/${VERSION}/changelog"


### PR DESCRIPTION
Automates the two manual steps of cutting a spec revision so the release tracker can dispatch them and the result is reproducible.

### `cut-release.yml` — `workflow_dispatch(version, kind, dry_run)`

| `kind` | Effect | Review |
|---|---|---|
| `rc` | Tags current `main` as `<version>-RC` and publishes a **prerelease**. Spec content stays under `docs/specification/draft/` — no file changes, no PR. | — |
| `final` | Copies `draft/` → `docs/specification/<version>/` and `schema/<version>/`, runs `npm run generate`, inserts the new version into `docs/docs.json` nav, resets `draft/changelog.mdx`, opens PR `release/<version>`. | Existing CODEOWNERS ruleset → **`@modelcontextprotocol/core-maintainers` approval required** to merge. |

Both paths validate `YYYY-MM-DD` and refuse to overwrite an existing tag/dir. Inputs are passed through `env:` (not `${{ }}` in `run:`); third-party action is SHA-pinned.

### `publish-release.yml`

Fires on push to `main` when a `release/<version>` PR merges: creates the GA tag + GitHub Release. Idempotent (skips if the tag already exists).

### Why

Today each release is a hand-authored PR (#1887, #232, …) followed by a manually drafted GitHub Release. This makes the file promotion + nav patch deterministic, keeps the human check at the CODEOWNERS review on the Final PR, and gives the release tracker (modelcontextprotocol/mcp-spec-tpm) a dispatch target so the RC/Final cut shows up as a single button on the release plan.