### PR TITLE
Use canonical release-notes template in cut-release / publish-release

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -52,15 +52,23 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ github.sha }}
         run: |
+          cat > /tmp/notes.md <<EOF
+          This release marks the **release candidate (RC)** \`${VERSION}\` revision of the Model Context Protocol.
+
+          The specification is available in [draft form](https://modelcontextprotocol.io/specification/draft).
+
+          For a detailed overview of changes, see [${VERSION} draft changelog](https://modelcontextprotocol.io/specification/draft/changelog).
+
+          >[!NOTE]
+          >**To users and implementers:** this specification is not final. Changes may be introduced between the RC and the final release. SDKs will adopt this version at their own pace, and the prior version of the spec may remain in use for an undetermined amount of time.
+          >
+          >Refer to the [Version Negotiation documentation](https://modelcontextprotocol.io/specification/draft/basic/lifecycle#version-negotiation) to learn about the process for clients and servers to determine the version of the protocol being used.
+          EOF
           gh release create "${VERSION}-RC" \
             --target "$TARGET_SHA" \
             --prerelease \
             --title "MCP ${VERSION} RC" \
-            --notes "Release candidate for the ${VERSION} revision of the Model Context Protocol specification.
-
-          The RC content is the current draft: https://modelcontextprotocol.io/specification/draft
-
-          Please file issues against SEPs in this milestone before the final cut."
+            --notes-file /tmp/notes.md
 
       - name: Summary
         run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -44,11 +44,15 @@ jobs:
             echo "tag ${VERSION} already exists — skipping"
             exit 0
           fi
+          cat > /tmp/notes.md <<EOF
+          This release marks the \`${VERSION}\` revision of the Model Context Protocol.
+
+          The specification is available at [modelcontextprotocol.io/specification/${VERSION}](https://modelcontextprotocol.io/specification/${VERSION}).
+
+          For a detailed overview of changes, see the [${VERSION} changelog](https://modelcontextprotocol.io/specification/${VERSION}/changelog).
+          EOF
           gh release create "$VERSION" \
             --target "$TARGET_SHA" \
             --latest \
             --title "MCP ${VERSION}" \
-            --notes "Model Context Protocol specification ${VERSION}.
-
-          https://modelcontextprotocol.io/specification/${VERSION}
-          Changelog: https://modelcontextprotocol.io/specification/${VERSION}/changelog"
+            --notes-file /tmp/notes.md


### PR DESCRIPTION
Swap the placeholder `--notes` strings for the description format used on prior releases (e.g. `2025-11-25-RC`).

**RC** (`cut-release.yml`):
- "release candidate (RC) \`<version>\`" lede
- Links to `/specification/draft` and `/specification/draft/changelog`
- `>[!NOTE]` block: not final, SDK adoption pace, version-negotiation link

**GA** (`publish-release.yml`):
- Same structure, links rewritten to `/specification/<version>`, NOTE block removed

Body is written via heredoc → `--notes-file` so the markdown survives. `$VERSION` is the env-passed, regex-validated input from the existing validate step.