### PR TITLE
Mark generated files with -merge and document regeneration on conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,10 @@
 package-lock.json linguist-generated=true
-schema/*/schema.json linguist-generated=true
-docs/specification/*/schema.md linguist-generated=true
-docs/specification/*/schema.mdx linguist-generated=true
-docs/seps/index.mdx linguist-generated=true
-docs/seps/[0-9]*.mdx linguist-generated=true
+
+# Generated files: linguist-generated collapses them in PR diffs; -merge tells
+# git not to attempt a textual merge (keeps the current branch's copy and marks
+# the file conflicted). Resolve by re-running `npm run generate` and committing.
+schema/*/schema.json linguist-generated=true -merge
+docs/specification/*/schema.md linguist-generated=true -merge
+docs/specification/*/schema.mdx linguist-generated=true -merge
+docs/seps/index.mdx linguist-generated=true -merge
+docs/seps/[0-9]*.mdx linguist-generated=true -merge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,19 @@ npm run check:schema:ts
 npm run generate:schema
 ```
 
+### Resolving merge conflicts in generated files
+
+If your branch conflicts with `main` in generated files (`schema/*/schema.json`, `docs/specification/*/schema.mdx`, `docs/seps/*.mdx`), do not resolve them by hand. Merge `main`, resolve any conflicts in the source files (e.g. `schema/draft/schema.ts`), then regenerate and commit:
+
+```bash
+git merge main
+npm run generate
+git add .
+git commit
+```
+
+These files are marked with `-merge` in `.gitattributes`, so git keeps your branch's copy and flags them as conflicted instead of inserting conflict markers.
+
 ## Documentation changes
 
 Documentation is written in MDX format and in the [`docs`](./docs) directory.


### PR DESCRIPTION
## Motivation and Context

PRs that touch `schema/*/schema.ts` regularly end up conflicting with `main` in the generated files (`schema.json`, `docs/specification/*/schema.mdx`) — see #2775 for a current example. Git attempts a textual merge of those files and fills them with conflict markers, which invites hand-resolution of content that should only ever be regenerated.

## How Has This Been Tested?

Test-merged #2775 into `main` with the new attributes in place:

- `schema/draft/schema.ts` auto-merged cleanly.
- `schema/draft/schema.json` and `docs/specification/draft/schema.mdx` were marked conflicted but kept the branch copy with **no conflict markers**.
- Running `npm run generate` followed by `git add` resolved the conflict with the correctly regenerated output.

## Breaking Changes

None. Note that GitHub still reports such PRs as conflicting until the regenerated files are pushed — that is expected, since the files genuinely need regeneration; this change just makes the local resolution a regenerate-and-commit instead of hand-editing conflict markers. The `-merge` attribute only takes effect for checkouts that already contain the updated `.gitattributes`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
