### PR TITLE
docs(tool-annotations): add IG members from first two meetings

### DIFF
--- a/docs/community/tool-annotations/charter.mdx
+++ b/docs/community/tool-annotations/charter.mdx
@@ -42,12 +42,16 @@ The Tool Annotations Interest Group explores the role of tool annotations in ena
 
 ## Membership
 
-| Name           | Organization | GitHub                                               | Discord | Level       |
-| -------------- | ------------ | ---------------------------------------------------- | ------- | ----------- |
-| Sam Morrow     | GitHub       | [@SamMorrowDrums](https://github.com/SamMorrowDrums) |         | Facilitator |
-| Robert Reichel | OpenAI       | [@rreichel3](https://github.com/rreichel3)           |         | Facilitator |
-| Matt Carey     | Cloudflare   | [@mattzcarey](https://github.com/mattzcarey)         |         | Participant |
-| Kapil Sharma   | Microsoft    | [@kapil8811](https://github.com/kapil8811)           |         | Participant |
+| Name                    | Organization | GitHub                                               | Discord | Level       |
+| ----------------------- | ------------ | ---------------------------------------------------- | ------- | ----------- |
+| Sam Morrow              | GitHub       | [@SamMorrowDrums](https://github.com/SamMorrowDrums) |         | Facilitator |
+| Robert Reichel          | OpenAI       | [@rreichel3](https://github.com/rreichel3)           |         | Facilitator |
+| Matt Carey              | Cloudflare   | [@mattzcarey](https://github.com/mattzcarey)         |         | Participant |
+| Kapil Sharma            | Microsoft    | [@kapil8811](https://github.com/kapil8811)           |         | Participant |
+| Connor Peet             | Microsoft    | [@connor4312](https://github.com/connor4312)         |         | Participant |
+| Ola Hungerford          | Nordstrom    | [@olaservo](https://github.com/olaservo)             |         | Participant |
+| Gökhan Arkan            | GitHub       | [@gokhanarkan](https://github.com/gokhanarkan)       |         | Participant |
+| Joanna Krzek-Lubowiecka | GitHub       | [@joannakl](https://github.com/joannakl)             |         | Participant |
 
 ## Operations
 


### PR DESCRIPTION
Adds Connor Peet, Ola Hungerford, Gökhan Arkan, and Joanna Krzek-Lubowiecka to the Tool Annotations IG membership table following their participation in the first two meetings of the IG (April 23 and May 28, 2026).

| Name                    | Organization | GitHub                                         | Level       |
| ----------------------- | ------------ | ---------------------------------------------- | ----------- |
| Connor Peet             | Microsoft    | [@connor4312](https://github.com/connor4312)   | Participant |
| Ola Hungerford          | Nordstrom    | [@olaservo](https://github.com/olaservo)       | Participant |
| Gökhan Arkan            | GitHub       | [@gokhanarkan](https://github.com/gokhanarkan) | Participant |
| Joanna Krzek-Lubowiecka | GitHub       | [@joannakl](https://github.com/joannakl)       | Participant |

Meeting notes for the two meetings are being posted as discussions in parallel for context.