### PR TITLE
docs: move Adam & Toby to registry emeritus; add Pree as collaborator

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -121,11 +121,14 @@ This document lists current maintainers in the Model Context Protocol project.
 
 ### Registry
 
-- [Toby Padilla](https://github.com/toby)
-- [Tadas Antanavicius](https://github.com/tadasant)
-- [Adam Jones](https://github.com/domdomegg)
-- [Radoslav (Rado) Dimitrov](https://github.com/rdimitrov)
+- [Tadas Antanavicius](https://github.com/tadasant) (Lead)
+- [Radoslav (Rado) Dimitrov](https://github.com/rdimitrov) (Lead)
 - [Bob Dickinson](https://github.com/BobDickinson)
+
+#### Registry Emeritus
+
+- [Adam Jones](https://github.com/domdomegg) (Registry Maintainer Emeritus)
+- [Toby Padilla](https://github.com/toby) (Registry Maintainer Emeritus)
 
 ### MCPB (Model Context Protocol Bundle)
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -121,14 +121,14 @@ This document lists current maintainers in the Model Context Protocol project.
 
 ### Registry
 
-- [Tadas Antanavicius](https://github.com/tadasant) (Lead)
-- [Radoslav (Rado) Dimitrov](https://github.com/rdimitrov) (Lead)
+- [Tadas Antanavicius](https://github.com/tadasant)
+- [Radoslav (Rado) Dimitrov](https://github.com/rdimitrov)
 - [Bob Dickinson](https://github.com/BobDickinson)
 
 #### Registry Emeritus
 
-- [Adam Jones](https://github.com/domdomegg) (Registry Maintainer Emeritus)
-- [Toby Padilla](https://github.com/toby) (Registry Maintainer Emeritus)
+- [Adam Jones](https://github.com/domdomegg)
+- [Toby Padilla](https://github.com/toby)
 
 ### MCPB (Model Context Protocol Bundle)
 


### PR DESCRIPTION
## Summary

Aligns the Registry roster in `MAINTAINERS.md` with the [Registry Working Group charter](https://modelcontextprotocol.io/community/registry/charter).

- Adds a new **Registry Emeritus** subsection (under `### Registry`) and moves **Adam Jones** (@domdomegg) and **Toby Padilla** (@toby) into it. These are the first **non-core** emeritus entries, so they are scoped under Registry rather than the org-wide `## Emeritus` section (which is Core/Lead only).
- Lists current registry maintainers: **Tadas**, **Rado**, **Bob**.
- Bumps the "Last updated" date.

## Companion PRs
- `modelcontextprotocol/registry` README matrix: https://github.com/modelcontextprotocol/registry/pull/1311
- `modelcontextprotocol/access` IaC (teams/Discord/Google): https://github.com/modelcontextprotocol/access/pull/119

🤖 Generated with [Claude Code](https://claude.com/claude-code)