### PR TITLE
docs(maintainers): rename Server Identity WG to Server Card WG; add Sam Morrow to IGs/WGs

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -193,10 +193,11 @@ This document lists current maintainers in the Model Context Protocol project.
 - [Shaun Smith](https://github.com/evalstate)
 - [Harvey Tuch](https://github.com/htuch)
 
-### Server Identity Working Group
+### Server Card Working Group
 
+- [Tadas Antanavicius](https://github.com/tadasant)
 - [David Soria Parra](https://github.com/dsp-ant)
-- [Nick Cooper](https://github.com/nickcoai)
+- [Sam Morrow](https://github.com/SamMorrowDrums)
 
 ### Agents Working Group
 
@@ -212,6 +213,15 @@ This document lists current maintainers in the Model Context Protocol project.
 ### Primitive Grouping Interest Group
 
 - [Tapan Chugh](https://github.com/chughtapan)
+- [Sam Morrow](https://github.com/SamMorrowDrums)
+
+### Tool Annotations Interest Group
+
+- [Sam Morrow](https://github.com/SamMorrowDrums)
+
+### Tool Scopes Working Group
+
+- [Sam Morrow](https://github.com/SamMorrowDrums)
 
 ## About This Document
 


### PR DESCRIPTION
## Summary

Updates to `MAINTAINERS.md`:

- **Rename** *Server Identity Working Group* → *Server Card Working Group*. Membership updated to Tadas Antanavicius, David Soria Parra, and Sam Morrow. Remove Nick Cooper.
- **Add** Sam Morrow to the *Primitive Grouping Interest Group*.
- **Add** new *Tool Annotations Interest Group* section (Sam Morrow).
- **Add** new *Tool Scopes Working Group* section (Sam Morrow).
