### PR TITLE
docs(extensions): Use SEP-2575 capability exchanges consistently

### DIFF
--- a/docs/extensions/auth/enterprise-managed-authorization.mdx
+++ b/docs/extensions/auth/enterprise-managed-authorization.mdx
@@ -89,15 +89,24 @@ Key aspects of the flow:
 
 To support Enterprise-Managed Authorization, your client must:
 
-1. **Declare support** in the `initialize` request:
+1. **Declare support** in its per-request capabilities:
 
-```json
+```jsonc
 {
-  "capabilities": {
-    "extensions": {
-      "io.modelcontextprotocol/enterprise-managed-authorization": {}
-    }
-  }
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "...",
+  "params": {
+    // Other fields...
+    "_meta": {
+      // Other fields...
+      "io.modelcontextprotocol/clientCapabilities": {
+        "extensions": {
+          "io.modelcontextprotocol/enterprise-managed-authorization": {},
+        },
+      },
+    },
+  },
 }
 ```
 

--- a/docs/extensions/auth/oauth-client-credentials.mdx
+++ b/docs/extensions/auth/oauth-client-credentials.mdx
@@ -92,15 +92,24 @@ To use the OAuth Client Credentials extension, your client must:
 <Steps>
 <Step title="Declare support">
 
-Include the extension in the `initialize` request capabilities:
+Include the extension in its per-request capabilities:
 
-```json
+```jsonc
 {
-  "capabilities": {
-    "extensions": {
-      "io.modelcontextprotocol/oauth-client-credentials": {}
-    }
-  }
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "...",
+  "params": {
+    // Other fields...
+    "_meta": {
+      // Other fields...
+      "io.modelcontextprotocol/clientCapabilities": {
+        "extensions": {
+          "io.modelcontextprotocol/oauth-client-credentials": {},
+        },
+      },
+    },
+  },
 }
 ```
 
@@ -143,15 +152,20 @@ Ensure the token includes the required scopes for the requested operation.
 </Step>
 <Step title="Advertise support">
 
-Optionally (but recommended for discoverability), include the extension in the `initialize` response:
+Optionally (but recommended for discoverability), include the extension in the `server/discover` response:
 
-```json
+```jsonc
 {
-  "capabilities": {
-    "extensions": {
-      "io.modelcontextprotocol/oauth-client-credentials": {}
-    }
-  }
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    // Other fields...
+    "capabilities": {
+      "extensions": {
+        "io.modelcontextprotocol/oauth-client-credentials": {},
+      },
+    },
+  },
 }
 ```
 

--- a/docs/extensions/overview.mdx
+++ b/docs/extensions/overview.mdx
@@ -113,32 +113,35 @@ A **breaking change** is any modification that would cause existing implementati
 
 ## Negotiation
 
-Clients and servers advertise their support for extensions in the `extensions` field within their respective capabilities during the [initialization handshake](/specification/latest/basic/lifecycle).
+Clients and servers advertise their support for extensions in the `extensions` field within their respective capability declarations.
 
 ### Client Capabilities
 
-Clients advertise extension support in the `initialize` request:
+Clients advertise extension support in `_meta["io.modelcontextprotocol/clientCapabilities"]` within each request:
 
 ```json
 {
   "jsonrpc": "2.0",
   "id": 1,
-  "method": "initialize",
+  "method": "tools/call",
   "params": {
-    "protocolVersion": "2025-06-18",
-    "capabilities": {
-      "roots": {
-        "listChanged": true
-      },
-      "extensions": {
-        "io.modelcontextprotocol/ui": {
-          "mimeTypes": ["text/html;profile=mcp-app"]
-        }
-      }
+    "name": "get_weather",
+    "arguments": {
+      "location": "New York"
     },
-    "clientInfo": {
-      "name": "ExampleClient",
-      "version": "1.0.0"
+    "_meta": {
+      "io.modelcontextprotocol/protocolVersion": "2025-06-18",
+      "io.modelcontextprotocol/clientCapabilities": {
+        "extensions": {
+          "io.modelcontextprotocol/ui": {
+            "mimeTypes": ["text/html;profile=mcp-app"]
+          }
+        }
+      },
+      "io.modelcontextprotocol/clientInfo": {
+        "name": "ExampleClient",
+        "version": "1.0.0"
+      }
     }
   }
 }
@@ -146,14 +149,14 @@ Clients advertise extension support in the `initialize` request:
 
 ### Server Capabilities
 
-Servers advertise extension support in the `initialize` response:
+Servers advertise extension support in the `server/discover` response:
 
 ```json
 {
   "jsonrpc": "2.0",
   "id": 1,
   "result": {
-    "protocolVersion": "2025-06-18",
+    "supportedVersions": ["2025-06-18"],
     "capabilities": {
       "tools": {},
       "extensions": {

--- a/docs/extensions/tasks/overview.mdx
+++ b/docs/extensions/tasks/overview.mdx
@@ -152,19 +152,24 @@ To consume task-augmented responses, your client must:
 <Steps>
 <Step title="Declare support">
 
-Include the extension in per-request capabilities:
+Include the extension in its per-request capabilities:
 
-```json
+```jsonc
 {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "...",
   "params": {
+    // Other fields...
     "_meta": {
+      // Other fields...
       "io.modelcontextprotocol/clientCapabilities": {
         "extensions": {
-          "io.modelcontextprotocol/tasks": {}
-        }
-      }
-    }
-  }
+          "io.modelcontextprotocol/tasks": {},
+        },
+      },
+    },
+  },
 }
 ```
 
@@ -204,13 +209,18 @@ To return tasks from your server:
 
 Include the extension in your `server/discover` capabilities:
 
-```json
+```jsonc
 {
-  "capabilities": {
-    "extensions": {
-      "io.modelcontextprotocol/tasks": {}
-    }
-  }
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    // Other fields...
+    "capabilities": {
+      "extensions": {
+        "io.modelcontextprotocol/tasks": {},
+      },
+    },
+  },
 }
 ```
 


### PR DESCRIPTION
Updates extension documentation to use per-request client capabilities and `server/discover` consistently for capability exchanges.

Ref: https://docs.google.com/document/d/1l_wBmSf07gpqEnjca7G3xNky_MKHTS06Jpu3sELJbiY/edit?tab=t.0