### PR TITLE
Update draft spec overview: remove deprecated features, add extensions

### DIFF
--- a/docs/specification/draft/index.mdx
+++ b/docs/specification/draft/index.mdx
@@ -63,8 +63,6 @@ Servers offer any of the following features to clients:
 
 Clients may offer the following features to servers:
 
-- **Sampling**: Server-initiated agentic behaviors and recursive LLM interactions
-- **Roots**: Server-initiated inquiries into URI or filesystem locations to operate in
 - **Elicitation**: Server-initiated requests for additional information from users
 
 ### Additional Utilities
@@ -74,6 +72,20 @@ Clients may offer the following features to servers:
 - Cancellation
 - Error reporting
 - Logging
+
+### Extensions
+
+Beyond the core protocol, MCP defines optional [extensions](/extensions/overview)
+that add modular, specialized, or experimental functionality. Extensions
+are always opt-in and require explicit support from both client and server, negotiated
+during initialization. Notable extensions include:
+
+- **[Tasks](/extensions/tasks/overview)**: Asynchronous execution of long-running
+  operations, with polling, mid-flight input, and durable handles
+- **[Skills over MCP](/community/skills-over-mcp/charter)**: Rich, structured
+  instructions for agent workflows, discovered and consumed through MCP
+- **[MCP Apps](/extensions/apps/overview)**: Interactive UI elements (charts, forms,
+  video players) rendered inline within conversations
 
 ## Security and Trust & Safety
 


### PR DESCRIPTION
Remove Sampling and Roots from the client features list since both are
deprecated (SEP-2577). Add an Extensions section highlighting optional
extensions: Tasks, Skills over MCP, and MCP Apps.