### PR TITLE
update basic/index.mdx to reference message patterns page

### DIFF
--- a/docs/specification/draft/basic/index.mdx
+++ b/docs/specification/draft/basic/index.mdx
@@ -8,13 +8,14 @@ The Model Context Protocol consists of several key components that work together
 
 - **Base Protocol**: Core JSON-RPC message types
 - **Lifecycle Management**: Protocol version negotiation and per-request capability declaration
+- **Message Patterns**: Messaging patterns supported by the core protocol including request-response, subscription-based notifications, and multi round trip requests(MRTR)..
 - **Authorization**: Authentication and authorization framework for HTTP-based transports
 - **Server Features**: Resources, prompts, and tools exposed by servers
-- **Client Features**: Sampling and root directory lists provided by clients
+- **Client Features**: Elicitation, sampling and root directory lists provided by clients
 - **Utilities**: Cross-cutting concerns like logging and argument completion
 
-All implementations **MUST** support the base protocol and lifecycle management
-components. Other components **MAY** be implemented based on the specific needs of the
+All implementations **MUST** support the base protocol, lifecycle management
+components and messaging patterns. Other components **MAY** be implemented based on the specific needs of the
 application.
 
 These protocol layers establish clear separation of concerns while enabling rich
@@ -29,7 +30,7 @@ these types of messages:
 
 ### Requests
 
-[Requests](/specification/draft/schema#jsonrpcrequest) are sent from the client to the server or vice versa, to initiate an operation.
+[Requests](/specification/draft/schema#jsonrpcrequest) are sent from the client to the server, to initiate an operation.
 
 ```typescript
 {

--- a/docs/specification/draft/basic/index.mdx
+++ b/docs/specification/draft/basic/index.mdx
@@ -8,7 +8,7 @@ The Model Context Protocol consists of several key components that work together
 
 - **Base Protocol**: Core JSON-RPC message types
 - **Lifecycle Management**: Protocol version negotiation and per-request capability declaration
-- **Message Patterns**: Messaging patterns supported by the core protocol including request-response, subscription-based notifications, and multi round trip requests(MRTR)..
+- **Message Patterns**: Messaging patterns supported by the core protocol including request-response, subscription-based notifications, and multi round trip requests(MRTR).
 - **Authorization**: Authentication and authorization framework for HTTP-based transports
 - **Server Features**: Resources, prompts, and tools exposed by servers
 - **Client Features**: Elicitation, sampling and root directory lists provided by clients
@@ -79,7 +79,7 @@ allowing servers to return different structures based on the outcome of the requ
 can use to determine how to parse and handle the `result` object.
 
 - A `resultType` of `"complete"` indicates the request completed successfully and the result contains the final content.
-- A `resultType` of `"input_required"` indicates the request is incomplete and more information is needed to process the request. The result contains an `InputRequiredResult` object with additional information needed.
+- A `resultType` of `"input_required"` indicates the request is incomplete and more information is needed to process the request. The result contains an [`InputRequiredResult`](/specification/draft/basic/utilities/mrtr#inputrequiredresult) object with additional information needed.
 - Extensions **MAY** add additional `ResultType` values. The set of supported `ResultType` values **MUST** be created from the set defined in the core protocol and include any additional values of supported extensions that are advertised via capabilities.
 - A `resultType` of any value unrecognized by the client **MUST** be considered invalid.
 - For backward compatibility with servers implementing earlier protocol versions, which do not include `resultType`, clients **MUST** treat an absent `resultType` as `"complete"`.
@@ -120,6 +120,14 @@ The receiver **MUST NOT** send a response.
 ```
 
 - Notifications **MUST NOT** include an ID.
+
+## Message Patterns
+
+The Model Context Protocol (MCP) supports several [Message Patterns](/specification/draft/basic/patterns) that define how clients and servers interact:
+
+1. **Request-Response**: A client sends a request to the server, and the server responds with a result or error.
+2. **Subscription-Based Notifications**: A client subscribes to a stream of notifications from the server, which are sent as they occur.
+3. **Multi-Round-Trip Requests (MRTR)**: when a server requires additional client input (sampling, elicitation, or roots) to complete a request.
 
 ## Auth
 


### PR DESCRIPTION
Updated basic/index.mdx to refer to the new message pattern page. 

