### PR TITLE
SEP-2848: Asynchronous Approval for Tool Calls

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -455,7 +455,8 @@
               "seps/2106-json-schema-2020-12",
               "seps/2164-resource-not-found-error",
               "seps/2484-conformance-tests-required-for-final-seps",
-              "seps/2596-spec-feature-lifecycle-and-deprecation"
+              "seps/2596-spec-feature-lifecycle-and-deprecation",
+              "seps/2848-asynchronous-approval-for-tool-calls"
             ]
           }
         ]

--- a/docs/seps/2848-asynchronous-approval-for-tool-calls.mdx
+++ b/docs/seps/2848-asynchronous-approval-for-tool-calls.mdx
@@ -1,0 +1,707 @@
+---
+title: "SEP-2848: Asynchronous Approval for Tool Calls"
+sidebarTitle: "SEP-2848: Asynchronous Approval for Tool Calls"
+description: "Asynchronous Approval for Tool Calls"
+---
+
+<div className="flex items-center gap-2 mb-4">
+  <Badge color="gray" shape="pill">
+    draft
+  </Badge>
+  <Badge color="gray" shape="pill">
+    Extensions Track
+  </Badge>
+</div>
+
+| Field         | Value                                                                           |
+| ------------- | ------------------------------------------------------------------------------- |
+| **SEP**       | 2848                                                                            |
+| **Title**     | Asynchronous Approval for Tool Calls                                            |
+| **Status**    | draft                                                                           |
+| **Type**      | Extensions Track                                                                |
+| **Created**   | 2026-06-02                                                                      |
+| **Author(s)** | Karl McGuinness                                                                 |
+| **Sponsor**   | None (seeking sponsor)                                                          |
+| **PR**        | [#2848](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2848) |
+
+---
+
+## Abstract
+
+This SEP defines an extension that lets an MCP server gate a tool call on
+out-of-session approval without holding the session open. When a server's
+authorization decision is a denial that is _requestable_ (something can still
+approve it), the server returns a task handle ([SEP-2663](./2663-tasks-extension.md),
+the `io.modelcontextprotocol/tasks` extension) in place of the tool result,
+instead of failing the call. What approves is up to the deployment: a human
+reviewer, a supervising agent, an automated policy or risk engine, an external
+ITSM or IGA system, or a combination. The task stays `working` while that workflow
+runs over seconds, minutes, hours, or days; on approval the server re-checks
+policy and executes the tool, and the result becomes available through `tasks/get`.
+The approval protocol runs entirely on the server's backend (referencing the
+OpenID AuthZEN Access Request and Approval Profile) and never appears on the MCP
+wire. The client sees only a server-generated task ID it can poll and cancel, and
+never handles an authorization artifact. The bridge is binding AuthZEN's portable
+task handle to a durable MCP task ID, so a poll resumes after the server or the
+calling agent restarts; resumption by a _different_ principal is constrained by
+MCP's task-access model and is treated under Limitations. The feature is an
+experimental extension per [SEP-2133](./2133-extensions.md), layered on the tasks
+extension.
+
+## Motivation
+
+A requestable denial is resolved by whatever the deployment's approval workflow
+designates. That resolver is often _not_ a human: it may be a supervising agent
+applying a budget, an automated policy or risk engine that re-checks once
+conditions change, an external ticketing or identity-governance system, or a human
+reviewer, or several of these in sequence. The constant is not who decides; it is
+that the decision happens **out of band and asynchronously**, and may outlive the
+request, the connection, and even the process that made the call.
+
+MCP can represent asynchronous execution (the tasks extension, SEP-2663) and
+connection-level authorization (OAuth 2.1), and per-tool-call policy can be
+externalized (for example, the OpenID AuthZEN profile). What is missing is the
+binding that says a tool call is _denied now but approvable later, by something
+else_, and that ties the pending decision to a durable task the client can come
+back to.
+
+Tasks gives the durable, pollable primitive, but says nothing about _why_ a task
+is pending or how a policy decision resolves it. The in-session input paths
+(multi round-trip input requests, and historically elicitation and sampling) all
+target the principal driving the current session and do not survive a disconnect;
+they cannot model a decision made by a different party, on a different timeline,
+through a different channel. Without this extension, a server facing a requestable
+denial either fails the call and loses the workflow, or blocks until something
+times out.
+
+The OpenID AuthZEN Access Request and Approval Profile already defines the approval
+lifecycle (a requestable denial, an access request, a portable task handle, and
+re-evaluation that keeps the policy decision point authoritative at enforcement
+time), and its task handle is designed to survive restart (cross-principal handoff
+is treated under Limitations).
+This SEP binds that handle to an MCP task so the approval workflow becomes a
+first-class, pollable MCP object, regardless of what resolves it, and defines the
+narrow, MCP-observable server behavior that connects the two.
+
+### Use cases
+
+The resolver differs by deployment; the MCP-facing shape is identical in all of
+them:
+
+- **Human reviewer.** An agent calls `wire_transfer` above a threshold; a treasury
+  manager approves out of band, possibly the next day. The agent hands off and a
+  later poll returns the executed result.
+- **Supervising agent or orchestrator.** A worker agent requests a scope; a
+  supervisor agent (or a planner holding the budget) approves programmatically in
+  seconds, with no human involved.
+- **Automated policy or risk engine.** The first call is denied because a risk
+  signal is elevated or a grant has not provisioned yet; an automated re-check
+  approves once the condition clears, no human action.
+- **External ITSM or IGA system.** The access request becomes a ServiceNow change
+  or an identity-governance request; its existing approval rules (which may be
+  fully automated) decide, and MCP reflects the outcome.
+- **Four-eyes or break-glass.** A second, different principal (human or a
+  designated approver service) must authorize a sensitive operation, audited end to
+  end by the approval service.
+
+For the no-human resolvers (supervising agent, policy or risk engine, external
+system), there is no present session: submission input is filled by the agent itself
+against the request schema, and the approval decision is made fully out of band (see
+Collecting submission input).
+
+## Specification
+
+### Relationship to existing specifications
+
+This SEP composes existing pieces and adds the binding between them:
+
+- **SEP-2663 (Tasks extension, `io.modelcontextprotocol/tasks`)** supplies the
+  durable, pollable primitive: server-directed `CreateTaskResult`
+  (`resultType: "task"`), the methods `tasks/get`, `tasks/update`, and
+  `tasks/cancel`, `notifications/tasks`, and the statuses `working`,
+  `input_required`, `completed`, `failed`, `cancelled`.
+- **SEP-2322 (Multi Round-Trip Requests)** supplies the in-task input channel
+  (`inputRequests` / `inputResponses`) used for submission-time input.
+- **SEP-2133 (Extensions)** supplies the extension and capability framing.
+- **OpenID AuthZEN Access Request and Approval Profile** supplies the approval
+  lifecycle (requestable denial context, access request submission, the portable
+  task handle, and re-evaluation via `context.approval`). A companion AuthZEN MCP
+  profile (COAZ) maps a `tools/call` to an AuthZEN Access Evaluation; COAZ is itself a
+  draft, so the `tools/call`-to-evaluation mapping is not yet stable.
+
+The MCP server is the Policy Enforcement Point (PEP) and is the _only_ party that
+speaks the approval protocol. The client speaks ordinary MCP. AuthZEN is the
+reference approval backend; the MCP-observable behavior in this SEP does not depend
+on AuthZEN internals and could be satisfied by another backend that provides an
+equivalent durable handle and re-evaluation guarantee.
+
+The composition order is:
+
+1. the server evaluates every `tools/call` as an AuthZEN Access Evaluation (the COAZ
+   mapping);
+2. a requestable denial enters the Access Request lifecycle: submit the access
+   request, bind the approval handle to the MCP `taskId`, and return a `working` task;
+3. on resolution the server re-evaluates with `context.approval`;
+4. that decision is final: an approval is an input to a new decision, not a standing
+   grant.
+
+### Server-side flow (informative)
+
+The exchange below is non-normative and shows how the approval protocol sits behind
+a single MCP task. Nothing in it is part of the MCP wire contract: the only MCP
+messages are between the Client and the Server.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as MCP Server (PEP)
+    participant P as Policy Decision Point
+    participant A as Approval Service
+
+    C->>S: tools/call
+    S->>P: Access Evaluation
+    P-->>S: deny + context.access_request (requestable)
+    S->>A: submit Access Request (binding_token)
+    A-->>S: task handle (bound to MCP taskId)
+    S-->>C: CreateTaskResult (resultType: "task", status: working)
+    Note over P,A: Out-of-band resolution<br/>(human, agent, policy, or external system)
+    A-->>S: approved (callback or poll)
+    S->>P: re-evaluate (context.approval)
+    P-->>S: allow
+    S->>S: execute tool; task = completed (result available)
+    C->>S: tasks/get
+    S-->>C: CompletedTask with result (CallToolResult)
+```
+
+Everything to the right of the MCP Server (the Policy Decision Point and Approval
+Service exchanges) is internal to the PEP and never crosses the MCP boundary. The
+AuthZEN constructs shown (`context.access_request`, `binding_token`, the task
+handle, and `context.approval`) are specified by the OpenID AuthZEN Access Request
+and Approval Profile and are referenced, not redefined, by this SEP.
+
+### Extension identifier and capability
+
+The feature is an experimental extension with identifier
+`net.openid.authzen/tool-approval` (reversed-domain prefix per SEP-2133;
+illustrative, to be confirmed with the owning group).
+
+This extension builds on the tasks extension, so a server MUST also support
+`io.modelcontextprotocol/tasks`. Both are declared in the server's `extensions`
+capability:
+
+```json
+{
+  "capabilities": {
+    "extensions": {
+      "io.modelcontextprotocol/tasks": {},
+      "net.openid.authzen/tool-approval": { "version": "0.1" }
+    }
+  }
+}
+```
+
+Per SEP-2663, task creation is **server-directed**: a client does not flag a
+request for task execution. A client signals that it can receive task handles by
+declaring the `io.modelcontextprotocol/tasks` extension in its per-request
+capabilities (SEP-2663 / SEP-2575); the server then decides per request whether to
+return a `CreateTaskResult`. A client that has not declared the tasks extension and
+issues a call the server can only satisfy through approval MUST receive either:
+
+- a `-32003` (Missing Required Client Capability) error naming
+  `io.modelcontextprotocol/tasks`, which a tasks-capable client reads as "re-issue the
+  call with the capability declared"; or
+- a normal `CallToolResult` with `isError: true` carrying requestable guidance in its
+  content (a degraded path with no asynchronous resume), for clients that will not
+  speak the tasks extension.
+
+`-32003` is a capability-negotiation error, not an "access is requestable" signal: an
+agent reads it as "I did not declare something," not "go obtain access." A server that
+wants today's non-tasks agents to act on a requestable denial SHOULD prefer the
+degraded `CallToolResult` and include machine-readable next-step guidance (see the
+client-maturity note).
+
+Declaring `net.openid.authzen/tool-approval` is an optional client signal that it
+understands approval semantics (for example, to render approval-specific progress
+UI). Correct behavior does not require it: an approval-gated task is an ordinary
+tasks-extension task, and a client that supports only `io.modelcontextprotocol/tasks`
+already interoperates.
+
+> **Client maturity (non-normative).** The canonical flow requires a client that
+> declares and drives `io.modelcontextprotocol/tasks` (receives `CreateTaskResult`,
+> polls `tasks/get`). That capability is experimental (SEP-2663) and, at the time of
+> writing, is not present in shipping MCP clients, whose task support is server-side.
+> End-to-end value is therefore gated on client tasks adoption, and interop testing
+> needs a purpose-built tasks client (the Reference Implementation clause requires
+> one). During the gap, servers may also expose approval as ordinary tools (for
+> example `request_access` / `get_request_status`) so today's agents can self-drive
+> request-poll-retry without tasks support. This SEP does not standardize that interim
+> shape, but a server that adopts it SHOULD carry the same machine-readable next-step
+> fields the Access Request profile already defines (a next-step hint, the request
+> schema, and a poll-interval hint) so interim shapes interoperate.
+
+### Denied-but-requestable returns a task
+
+When the server evaluates a `tools/call` against its policy decision point and the
+decision is "deny":
+
+1. If the denial is **not** requestable (no approval can change it), the server
+   returns the normal denied tool result: a `CallToolResult` with `isError: true`
+   describing the denial, so the model can react. (Per SEP-2663, an `isError`
+   result delivered through a task is a `completed` task, not a `failed` one.)
+2. If the denial **is** requestable, and the client declared the tasks extension,
+   the server MUST NOT execute the tool. Instead it:
+   - submits an access request to the approval service on the caller's behalf and
+     obtains a durable approval task handle;
+   - creates a durable MCP task bound to that handle and returns a
+     `CreateTaskResult` (`resultType: "task"`) with `status: "working"` and a
+     human-readable `statusMessage` (for example, "Awaiting treasury approval");
+   - MAY include an `io.modelcontextprotocol/model-immediate-response` value in the
+     result `_meta` so the model receives an immediate string (for example,
+     "This action is pending approval; you can continue other work and check back").
+
+The server MUST NOT surface approval-binding material (the AuthZEN `binding_token`,
+`evaluation_id`, `approval` object, or access-request endpoints) to the client.
+These are internal to the PEP.
+
+**At-most-once execution and deduplication.** Because the server controls both task
+creation and tool execution, it MUST execute the approved tool at most once per task.
+To keep a client retry (after a poll timeout or an agent restart) from creating a
+second approval task, and thus a second execution, the server SHOULD return the
+existing task's `CreateTaskResult` when it recognizes a repeated requestable denial
+within one dedup scope: the same **originating authorization context** (the
+authenticated caller or subject the task is bound to), the same tool, and the same
+arguments. This correlation is inherently best-effort: if the arguments carry a
+client-local value (a nonce or timestamp) two genuine retries will not match, and if
+they do not, two distinct intents with identical arguments will collide. MCP today
+has no general request-level idempotency key that would make it exact (see
+Limitations), so deployments needing exactness must wait for one.
+
+Deduplication applies only while the prior task is non-terminal. After a task reaches
+a terminal disposition (including `denied-not-executed`), an identical `tools/call`
+MUST start a **new** access request and a new task; the terminal denial was final and
+MUST NOT be folded into the old task.
+
+**Retention.** The server MUST keep the task resolvable through `tasks/get` for the
+full approval window: it MUST NOT delete or expire a `working` approval task before
+the approval's expiry, and `ttlMs` MUST cover the approval window plus the server's
+result-retention period. The approval service often sets or extends the window after
+submission, so the creation-time `ttlMs` is provisional: when the server learns a
+later expiry, it MUST extend `ttlMs` (reported on `tasks/get` and
+`notifications/tasks`) so a `working` task is never expired before the current known
+approval expiry. A server SHOULD bound the maximum approval window it accepts so
+pending tasks do not accumulate without limit.
+
+**Model-facing text is untrusted and non-committal.** `statusMessage` and any
+`io.modelcontextprotocol/model-immediate-response` value are fed to the model and
+MUST NOT carry unsanitized text from untrusted sources (agent-supplied rationale,
+approver free-text); they are a prompt-injection surface. A `working` or
+`input_required` approval task MUST NOT be represented to the model as a completed
+action; if `model-immediate-response` is used, it MUST make clear the action has not
+yet occurred and may still be denied.
+
+### The task handle is not authority
+
+The `taskId` is a reference to a pending decision, never a grant. Authority is the
+PDP decision, re-derived at execution against the original call envelope (see
+Completion). Possessing a `taskId` does not authorize execution.
+
+When it creates the task, the server MUST retain a binding record and MUST check it
+before executing. The record MUST include at least:
+
+- the task id;
+- the tool name;
+- a canonical digest of the arguments;
+- the requester principal (and session, where applicable);
+- the subject or resource being acted on;
+- the approval request id;
+- the disposition;
+- the expiry / freshness window.
+
+The server MAY also record the policy id and version for audit and drift detection;
+this is recorded, not pinned (see Completion).
+
+**Envelope match or new approval.** At execution time the server MUST compare the
+current call against the bound envelope. If the tool, arguments, requester principal,
+or subject/resource differ, the task MUST resolve `denied-not-executed` with no side
+effect, and the changed call requires a new access request. An approval is bound to
+the exact envelope that produced the requestable denial; it never carries over to a
+different or mutated call.
+
+### Collecting submission input
+
+The access request may require inputs from the requester before or during the
+approval: a justification, a ticket reference, or fields the approval service
+defines (the AuthZEN profile's `request_schema_url`, `form_url`, and
+`request_catalogs_url`). The server collects these over the tasks input channel
+(SEP-2322 multi round-trip requests), not a standalone `elicitation/create`, since
+SEP-2260 disallows unsolicited server-to-client requests and SEP-2663 routes task
+input through `inputRequests` / `tasks/update`:
+
+- **Before submission (synchronous).** The server returns `resultType:
+"input_required"` on the original `tools/call`, collects the inputs, then returns a
+  `CreateTaskResult` and submits the access request. Use this when the approval
+  service will not accept the request without them.
+- **During the workflow (in-task).** The server sets the task to `input_required`
+  with the outstanding `inputRequests` (for example, an approver asks for more
+  detail, or a catalog-backed field is resolved after submission); the client answers
+  with `inputResponses` via `tasks/update`, and the task returns to `working`.
+
+Who answers is a property of the client, not this extension. An interactive client
+renders the request for a human (the profile's `form_url` case); an autonomous agent
+client MAY answer it from context against the request schema (the
+`request_schema_url` case), resolving catalog-backed fields per
+`request_catalogs_url`. The server derives the `inputRequests` schema from those
+profile fields. Either way this is submission-time input that shapes the access
+request; it is distinct from the approval decision, which is made out of band by a
+party (human or automated) not assumed to be reachable through the session.
+
+An in-task `input_required` round-trip requires a connected client: an agent that
+submitted and then disconnected or restarted cannot answer a later `inputRequests`.
+Deployments that expect long gaps between submission and approval SHOULD collect all
+inputs synchronously before submission. The mapping from the profile's
+`request_schema_url` (a JSON Schema) onto the SEP-2322 `inputRequests` schema is not
+pinned by this SEP and is currently implementation-specific; two servers MAY produce
+different `inputRequests` for the same access request until a canonical mapping is
+defined.
+
+### Approval lifecycle maps onto task status
+
+| Approval-profile state                                           | MCP task status                                                 |
+| ---------------------------------------------------------------- | --------------------------------------------------------------- |
+| Access request submitted, awaiting a decision                    | `working`                                                       |
+| Submission needs input from the requester (human or agent)       | `input_required`                                                |
+| Approved, re-evaluated to "allow", tool executed (once)          | `completed`, disposition `approved-executed`                    |
+| Terminal denial (rejected, revoked, expired, or not executed)    | `completed`, `isError: true`, disposition `denied-not-executed` |
+| Approved and executed, but the tool itself errored               | `completed`, `isError: true`, disposition `execution-error`     |
+| Server could not produce a tool result at all (protocol failure) | `failed`                                                        |
+| Client cancelled                                                 | `cancelled`                                                     |
+
+A terminal authorization denial is an outcome of the call, not a failure of the
+task machinery, so it is a `completed` task whose `result` is a `CallToolResult`
+with `isError: true` and disposition `denied-not-executed`. That disposition lets a
+consumer distinguish a denial (no side effect occurred) from an `execution-error`
+(the tool ran and a side effect may have occurred). `failed` is reserved for cases
+where the server could not produce a tool result at all.
+
+While `working`, the server tracks the approval by polling the approval service's
+status endpoint or by receiving its callback. The MCP `taskId` and the approval
+task handle are bound for the task's lifetime, so a server that restarts can
+rehydrate the task from the persisted handle and keep serving `tasks/get`. Both the
+tasks extension and the AuthZEN task handle are durable by design, which is what
+makes resolution that outlives the session possible.
+
+### Completion: re-evaluate, then execute
+
+On approval, the server MUST perform a fresh authorization evaluation that takes the
+approval as an input (for AuthZEN, placing the `approval` object at
+`context.approval`), so the policy decision point remains authoritative at
+enforcement time. An approval is an input to a new decision, not a standing grant.
+This re-evaluation is server-internal and is not observable on the MCP wire.
+
+The re-evaluation runs against the bound call envelope (see The task handle is not
+authority) and current policy. The recorded policy version is for audit and drift
+detection, not pinning: a policy change yields a fresh allow-or-deny rather than an
+automatic denial, so an approval still valid under current policy proceeds. Envelope
+fields (tool, arguments, requester principal, subject/resource) are an exact-match
+binding; a mismatch resolves `denied-not-executed` and requires a new approval.
+
+Because execution can occur long after the original request, the server SHOULD
+verify at execution time that the captured arguments and any downstream credential
+it must use are still valid. If a required credential has expired, or the action is
+materially stale, the server SHOULD NOT execute: it completes the task as a denial
+(disposition `denied-not-executed`) or returns a fresh requestable denial so the
+caller can resubmit.
+
+The terminal outcome MUST be distinguishable so a consumer can tell whether a side
+effect occurred. Because a client that supports only `io.modelcontextprotocol/tasks`
+does not understand this extension's `_meta`, the distinction MUST be carried in the
+`CallToolResult` itself, not only in `_meta`: the result `content` (and
+`structuredContent` where used) MUST state plainly whether the tool executed, so the
+model behind any tasks client reads "denied, the tool did not run" and does not
+blindly retry. A `net.openid.authzen/disposition` value in the result `_meta` is the
+machine-readable companion for extension-aware consumers. The body and the `_meta`
+disposition MUST agree:
+
+- **allow**: the server executes the tool exactly once and moves the task to
+  `completed`; the `tasks/get` response carries the tool's `CallToolResult` in the
+  task's `result` field. `_meta` disposition `approved-executed`.
+- **deny** at re-evaluation (policy changed, approval unverifiable, expired with no
+  re-request path), or a freshness or credential failure that prevented execution:
+  the task is `completed` with an `isError: true` `CallToolResult` whose content says
+  the tool did not run; `_meta` disposition `denied-not-executed`.
+- **execution error**: the tool was authorized and ran but failed; `isError: true`
+  with content describing the failure and `_meta` disposition `execution-error`, since
+  a side effect may have occurred.
+
+The server MUST bound any downstream credential, cached result, or follow-on
+authorization by the approval's expiry.
+
+### Cancellation
+
+A `tasks/cancel` request MUST cause the server to cancel the underlying access
+request and move the task to `cancelled`. Per SEP-2663, `notifications/cancelled`
+MUST NOT be used to cancel a task.
+
+A cancel can arrive after approval but before the tool has executed. To avoid
+ambiguity about whether a side effect occurred, the server resolves the race by the
+execution boundary: if it has not begun executing the tool, it MUST honor the cancel,
+skip execution, and move the task to `cancelled` (no side effect); once execution has
+begun, the cancel is ineffective and the task completes with its normal disposition.
+The server MUST NOT both execute the tool and report `cancelled`.
+
+### What the client carries
+
+The client carries a server-generated `taskId` only. It MUST NOT be required to
+read, store, or forward any authorization artifact. A client that supports the tasks
+extension already interoperates with an approval-gated server: it must already be
+prepared to receive a `CreateTaskResult` for any supported request, and it observes
+a task that stays `working` and then becomes `completed` (or `failed`/`cancelled`).
+This extension adds meaning, not new client wire format. Because the
+denied-versus-executed distinction is carried in the `CallToolResult` body (see
+Completion) and not only in `_meta`, a tasks-only client's model can act on it safely;
+without that rule a tasks-only client could not tell a denial from an execution error
+and could double-execute a side-effecting tool on retry.
+
+### End-to-end example
+
+Client calls a tool (the client has declared the `io.modelcontextprotocol/tasks`
+extension in its per-request capabilities):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "wire_transfer",
+    "arguments": { "to": "acct-991", "amount": 50000 }
+  }
+}
+```
+
+The server evaluates, gets a requestable denial, submits the access request, and
+returns a task handle in place of the tool result:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "resultType": "task",
+    "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840",
+    "status": "working",
+    "statusMessage": "Transfers over $25,000 require treasury approval.",
+    "createdAt": "2026-06-02T10:30:00Z",
+    "ttlMs": 604800000,
+    "pollIntervalMs": 15000,
+    "_meta": {
+      "io.modelcontextprotocol/model-immediate-response": "This transfer is pending treasury approval. You can continue other work and check back."
+    }
+  }
+}
+```
+
+After the approval workflow resolves out of band (whether a human acts the next day
+or an automated re-check clears in seconds), the server re-evaluates and executes.
+A later poll returns the completed task with the tool result:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "method": "tasks/get",
+  "params": { "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840" }
+}
+```
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "result": {
+    "resultType": "complete",
+    "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840",
+    "status": "completed",
+    "createdAt": "2026-06-02T10:30:00Z",
+    "lastUpdatedAt": "2026-06-03T09:05:00Z",
+    "ttlMs": 604800000,
+    "result": {
+      "content": [
+        { "type": "text", "text": "Transfer of $50,000 to acct-991 completed." }
+      ],
+      "isError": false
+    }
+  }
+}
+```
+
+## Rationale
+
+**Server-directed creation makes the client trivial.** Under SEP-2663 a client that
+supports tasks must already handle a `CreateTaskResult` for any call, and the server
+alone decides when to return one. An approval-gated server therefore needs no new
+client wire format and no per-tool opt-in: it returns a task exactly when it hits a
+requestable denial. This is the strongest property of the design and aligns with
+"Interoperability over optimization" (graceful degradation through capability
+negotiation).
+
+**Build on the tasks extension rather than invent a primitive.** Tasks already
+provides a durable state machine with polling, cancellation, input, and retention.
+An approval workflow is a long-running task, and the approval profile's portable
+handle provides the durability guarantee the binding needs. Aligns with
+"Composability over specificity."
+
+**Resolver-agnostic by construction.** Because approval is brokered server-side and
+surfaced only as task status, the MCP-facing contract is identical whether a human,
+a supervising agent, a policy engine, or an external system decides. The SEP does
+not encode "human in the loop"; it encodes "decided out of band, asynchronously,"
+which serves fully automated and fully manual deployments alike.
+
+**Why an extension.** Per SEP-2133, optional capabilities that build on the core and
+need time to incubate belong as extensions; "extensions are where convergence gets
+tested." This feature layers on another extension and is not universally needed, so
+it starts experimental on the Extensions Track. It is an extension rather than
+Informational guidance because it defines normative, wire-observable behavior that
+plain tasks does not: a requestable denial MUST return a task, the
+denied-versus-executed distinction MUST be carried in the `CallToolResult` body (with
+a `net.openid.authzen/disposition` `_meta` companion), and authorization artifacts
+MUST NOT cross the wire. Those rules, not mere discovery, are what earns a capability.
+If the body-convey rule were dropped and the signal left optional in `_meta`, the
+value would collapse to a discovery hint and Informational guidance would be the
+better home.
+
+**Why submission input uses the task input channel.** SEP-2260 disallows unsolicited
+server-to-client requests, and SEP-2663 routes in-task input through MRTR
+(`inputRequests` / `tasks/update`) rather than standalone elicitation. Submission
+input therefore flows through the task, not a separate elicitation call.
+
+## Limitations and Open Questions
+
+- **Resumption by a different principal is not portable at the MCP layer.** The
+  AuthZEN task handle can be polled by any caller authorized for the bound subject,
+  but MCP task access is bound to a server-defined originating authorization context,
+  `tasks/list` was removed, and sessions were removed (SEP-2567), so there is no
+  standard way for a _different_ principal, or the same agent on a new connection with
+  a new credential, to reclaim a task. Same-principal resumption across restart works
+  to the extent the server's context binding recognizes the returning caller.
+  Defining a portable task-claim or re-authorization mechanism is open; until then,
+  deployments that need cross-principal handoff arrange it out of band.
+- **Someone has to come back and consume the result.** This SEP provides the
+  primitive, not the orchestration that resumes a paused agent and acts on the
+  completed task. For a side-effecting tool this matters: the tool may execute after
+  approval with no consumer observing the outcome. Deployments MUST ensure either a
+  durable consumer that polls or that the effect is independently auditable; a
+  fire-and-forget agent that never returns is a misuse, not a supported pattern.
+- **A lost `taskId` has no protocol recourse.** With `tasks/list` and sessions both
+  removed (SEP-2663 / SEP-2567), an agent that restarts without having persisted its
+  `taskId` cannot rediscover a possibly-executed side-effecting task. Clients MUST
+  persist task IDs to durable storage; there is no protocol-level recovery.
+- **No general request idempotency in MCP.** MCP has no request-level idempotency
+  key (only the `idempotentHint` tool annotation, which describes a tool rather than
+  deduplicating a call), so the server's duplicate suppression is best-effort
+  (matching the originating context, tool, and arguments). A general idempotency
+  mechanism belongs in the core protocol or the tasks extension, not in an approval
+  extension; if one is added, this extension should adopt it. Defining one here is
+  out of scope.
+- **Extension versus Informational (resolved, flagged for the sponsor).** Much of the
+  behavior can be built on the tasks extension alone. This SEP takes it as an
+  extension because the body-convey denied-versus-executed rule, the mandatory task on
+  a requestable denial, and the `disposition` signal are normative wire-observable
+  behavior, not just discovery (see Rationale). A sponsor who judges that surface too
+  thin may prefer an Informational SEP; that is the one positioning question left
+  open.
+
+## Backward Compatibility
+
+Additive for new tools and new servers. A client that supports the tasks extension but
+not this one still observes a valid task lifecycle and a final
+`completed`/`failed`/`cancelled` task; there is no new client wire format, and no
+per-tool opt-in to change.
+
+For an existing tool that previously returned a synchronous denial, however, enabling
+approval gating changes the `tools/call` response set seen by existing integrations: a
+tasks client now receives a `CreateTaskResult`, and a non-tasks client receives
+`-32003` or the degraded requestable `CallToolResult` where a plain denial used to
+appear. That is a behavior change for upgraders, not a purely additive one.
+
+## Reference Implementation
+
+Required before Final (this introduces observable protocol behavior). Planned:
+
+- an MCP server that fronts an OpenID AuthZEN policy decision point and access
+  request service, returning `CreateTaskResult` for approval-gated calls and
+  re-evaluating before execution, with at least one human-resolved and one
+  automatically-resolved approval path;
+- a client built only on the `io.modelcontextprotocol/tasks` extension, to
+  demonstrate that it interoperates with no approval-specific code.
+
+A conformance scenario tagged with the assigned SEP number, plus a `sep-NNNN.yaml`
+traceability file, is required for Final. The traceability file MUST cover these
+MCP-observable statements:
+
+- a requestable denial returns a task without executing the tool;
+- approval resumes execution at most once;
+- a terminal denial is a `completed` task whose `CallToolResult` body (not only
+  `_meta`) marks it `denied-not-executed`, distinct from an execution error;
+- a changed envelope (tool, arguments, principal, or subject/resource) requires a new
+  approval;
+- a cancelled or expired task cannot later execute;
+- result retrieval does not expose backend approval artifacts;
+- submission input flows through the task input channel.
+
+Server-internal behavior such as re-evaluation is referenced from the AuthZEN profile
+and is not MCP-observable. Not yet built.
+
+## Security Implications
+
+- **Denial remains denial.** The server MUST NOT execute on the requestable denial
+  alone, and MUST re-evaluate after approval. The policy decision point is
+  authoritative at enforcement time.
+- **Authorization artifacts stay server-side.** Binding material (`binding_token`,
+  `approval`, `evaluation_id`) is never exposed to the client, preventing replay or
+  substitution through the client surface.
+- **The task handle is not a bearer approval token.** The `taskId` references a
+  pending decision; the server MUST re-derive authority from the bound call envelope
+  and current policy at execution (see The task handle is not authority), so holding a
+  `taskId` never authorizes execution of a different or mutated call.
+- **Task access control.** A `taskId` lets a caller poll and retrieve results.
+  SEP-2663 omits `tasks/list` precisely because tasks cannot always be bound to a
+  caller; task IDs are unguessable, single-task handles. The server MUST authorize
+  `tasks/get`, `tasks/update`, and `tasks/cancel` against the task's originating
+  authorization context, and MUST NOT leak approval contents or approver identity
+  through `statusMessage`.
+- **Confused deputy.** The server binds each task to the originally evaluated
+  subject, resource, action, and context, and applies an approval only within its
+  recorded scope. It MUST NOT let a client steer execution to a different operation
+  than the one that was approved.
+- **Out-of-band resolution.** Whoever or whatever decides (human, agent, policy
+  engine, external system), authentication, eligibility, and separation of duties are
+  properties of the approval service, outside MCP, as the approval profile specifies.
+- **Expiry.** The server MUST stop honoring an approval after its expiry and MUST
+  bound any downstream credential lifetime by it.
+- **Untrusted model-facing text.** `statusMessage` and `model-immediate-response` are
+  fed to the model and MUST be sanitized; a pending task MUST NOT be presented as a
+  completed action.
+- **At-most-once execution.** The server MUST execute an approved side-effecting tool
+  at most once per task and SHOULD deduplicate a retried requestable denial (by
+  originating context, tool, and arguments) so a poll timeout and replay cannot
+  double-execute.
+- **Approval-request amplification.** A compromised or buggy agent loop is the
+  expected failure mode here, not an edge case, and approval fatigue is a known
+  bypass. Deployments MUST rate-limit access-request submission per caller and SHOULD
+  bound the number of outstanding pending tasks per caller. When a limit is hit, the
+  server MUST return a non-requestable denial (a `CallToolResult` with `isError: true`,
+  not a task and not a requestable signal) so the agent does not retry-loop.
+- **The client cannot verify the gate.** "Denial remains denial" is enforced by the
+  server; the client receives no proof that the server re-evaluated rather than
+  executed. The binding material protects the server-to-PDP-to-approval-service path,
+  not the client's trust in the server. Clients needing stronger assurance must
+  obtain it out of band.
+
+## References
+
+- [SEP-2663: Tasks Extension](./2663-tasks-extension.md)
+- [SEP-2322: Multi Round-Trip Requests](./2322-MRTR.md)
+- [SEP-2133: Extensions](./2133-extensions.md)
+- [OpenID AuthZEN Access Request and Approval Profile](https://openid.github.io/authzen/authzen-access-request-approval-profile-1_0.html)
+- [OpenID AuthZEN Authorization API 1.0](https://openid.github.io/authzen/)

--- a/docs/seps/2848-asynchronous-approval-for-tool-calls.mdx
+++ b/docs/seps/2848-asynchronous-approval-for-tool-calls.mdx
@@ -28,86 +28,49 @@ description: "Asynchronous Approval for Tool Calls"
 
 ## Abstract
 
-This SEP defines an extension that lets an MCP server gate a tool call on
-out-of-session approval without holding the session open. When a server's
-authorization decision is a denial that is _requestable_ (something can still
-approve it), the server returns a task handle ([SEP-2663](./2663-tasks-extension.md),
-the `io.modelcontextprotocol/tasks` extension) in place of the tool result,
-instead of failing the call. What approves is up to the deployment: a human
-reviewer, a supervising agent, an automated policy or risk engine, an external
-ITSM or IGA system, or a combination. The task stays `working` while that workflow
-runs over seconds, minutes, hours, or days; on approval the server re-checks
-policy and executes the tool, and the result becomes available through `tasks/get`.
-The approval protocol runs entirely on the server's backend (referencing the
-OpenID AuthZEN Access Request and Approval Profile) and never appears on the MCP
-wire. The client sees only a server-generated task ID it can poll and cancel, and
-never handles an authorization artifact. The bridge is binding AuthZEN's portable
-task handle to a durable MCP task ID, so a poll resumes after the server or the
-calling agent restarts; resumption by a _different_ principal is constrained by
-MCP's task-access model and is treated under Limitations. The feature is an
-experimental extension per [SEP-2133](./2133-extensions.md), layered on the tasks
-extension.
+This SEP defines an extension that lets an MCP server gate a tool call on an out-of-band
+approval without keeping the original request open. When the server's authorization decision is a
+denial that is _requestable_ (something can still approve it), the server returns a task
+handle ([SEP-2663](./2663-tasks-extension.md)) in place of the tool result instead of
+failing the call. The task stays `working` while the deployment's resolver decides out of band; on approval
+the server re-checks policy, executes the tool, and makes the result available through
+`tasks/get`.
+
+The approval protocol runs on the server's approval backend and never crosses the MCP
+wire: the client sees only a task ID it can poll and cancel, and handles no authorization
+artifact. Binding the backend's durable, resumable handle to a durable MCP task ID lets a
+poll resume after a restart. The backend is pluggable, with the OpenID AuthZEN Access
+Request and Approval Profile (ARAP) as a worked example (see Example binding). The feature
+is an experimental extension per [SEP-2133](./2133-extensions.md), layered on tasks.
 
 ## Motivation
 
-A requestable denial is resolved by whatever the deployment's approval workflow
-designates. That resolver is often _not_ a human: it may be a supervising agent
-applying a budget, an automated policy or risk engine that re-checks once
-conditions change, an external ticketing or identity-governance system, or a human
-reviewer, or several of these in sequence. The constant is not who decides; it is
-that the decision happens **out of band and asynchronously**, and may outlive the
-request, the connection, and even the process that made the call.
-
-MCP can represent asynchronous execution (the tasks extension, SEP-2663) and
-connection-level authorization (OAuth 2.1), and per-tool-call policy can be
-externalized (for example, the OpenID AuthZEN profile). What is missing is the
-binding that says a tool call is _denied now but approvable later, by something
-else_, and that ties the pending decision to a durable task the client can come
-back to.
-
-Tasks gives the durable, pollable primitive, but says nothing about _why_ a task
-is pending or how a policy decision resolves it. The in-session input paths
-(multi round-trip input requests, and historically elicitation and sampling) all
-target the principal driving the current session and do not survive a disconnect;
-they cannot model a decision made by a different party, on a different timeline,
-through a different channel. Without this extension, a server facing a requestable
-denial either fails the call and loses the workflow, or blocks until something
-times out.
-
-The OpenID AuthZEN Access Request and Approval Profile already defines the approval
-lifecycle (a requestable denial, an access request, a portable task handle, and
-re-evaluation that keeps the policy decision point authoritative at enforcement
-time), and its task handle is designed to survive restart (cross-principal handoff
-is treated under Limitations).
-This SEP binds that handle to an MCP task so the approval workflow becomes a
-first-class, pollable MCP object, regardless of what resolves it, and defines the
-narrow, MCP-observable server behavior that connects the two.
+A requestable denial is resolved by whatever the deployment designates, often not a human,
+and sometimes several resolvers in sequence (see Use cases). What is constant is that the
+decision
+happens **out of band and asynchronously**, and may outlive the request, the connection,
+and the process that made the call. MCP already has asynchronous execution (tasks,
+SEP-2663), connection-level authorization (OAuth 2.1), and externalized per-call policy;
+what is missing is the binding that says a call is denied now but approvable later by
+something else, and ties that pending decision to a durable task. The input paths tied to
+the original request do not survive a disconnect, so without this binding a server facing a
+requestable
+denial either fails the call and loses the workflow, or blocks until something times out.
+This SEP defines the binding and the narrow, MCP-observable behavior around it.
 
 ### Use cases
 
-The resolver differs by deployment; the MCP-facing shape is identical in all of
-them:
+The MCP-facing shape is identical across resolvers:
 
-- **Human reviewer.** An agent calls `wire_transfer` above a threshold; a treasury
-  manager approves out of band, possibly the next day. The agent hands off and a
-  later poll returns the executed result.
-- **Supervising agent or orchestrator.** A worker agent requests a scope; a
-  supervisor agent (or a planner holding the budget) approves programmatically in
-  seconds, with no human involved.
-- **Automated policy or risk engine.** The first call is denied because a risk
-  signal is elevated or a grant has not provisioned yet; an automated re-check
-  approves once the condition clears, no human action.
-- **External ITSM or IGA system.** The access request becomes a ServiceNow change
-  or an identity-governance request; its existing approval rules (which may be
-  fully automated) decide, and MCP reflects the outcome.
-- **Four-eyes or break-glass.** A second, different principal (human or a
-  designated approver service) must authorize a sensitive operation, audited end to
-  end by the approval service.
+- **Human reviewer** approves out of band, possibly the next day (for example
+  `wire_transfer` above a threshold).
+- **Supervising agent or orchestrator** approves programmatically in seconds.
+- **Automated policy or risk engine** clears once a condition or grant provisions.
+- **External ITSM or IGA system** decides by its own, possibly automated, rules.
+- **Four-eyes or break-glass**: a second principal authorizes a sensitive operation.
 
-For the no-human resolvers (supervising agent, policy or risk engine, external
-system), there is no present session: submission input is filled by the agent itself
-against the request schema, and the approval decision is made fully out of band (see
-Collecting submission input).
+For the no-human resolvers there is no session, so submission input is filled by the agent
+against the backend's schema (see Collecting submission input).
 
 ## Specification
 
@@ -115,357 +78,441 @@ Collecting submission input).
 
 This SEP composes existing pieces and adds the binding between them:
 
-- **SEP-2663 (Tasks extension, `io.modelcontextprotocol/tasks`)** supplies the
-  durable, pollable primitive: server-directed `CreateTaskResult`
-  (`resultType: "task"`), the methods `tasks/get`, `tasks/update`, and
-  `tasks/cancel`, `notifications/tasks`, and the statuses `working`,
-  `input_required`, `completed`, `failed`, `cancelled`.
-- **SEP-2322 (Multi Round-Trip Requests)** supplies the in-task input channel
-  (`inputRequests` / `inputResponses`) used for submission-time input.
+- **SEP-2663 (Tasks extension, `io.modelcontextprotocol/tasks`)** supplies the durable,
+  pollable primitive: server-directed `CreateTaskResult` (`resultType: "task"`), the
+  methods `tasks/get`, `tasks/update`, `tasks/cancel`, `notifications/tasks`, and the
+  statuses `working`, `input_required`, `completed`, `failed`, `cancelled`.
+- **SEP-2322 (Multi Round-Trip Requests)** supplies the request round-trip channel
+  (`inputRequests` / `inputResponses` carried in `requestState`) for pre-task submission
+  input; in-task input uses SEP-2663's `tasks/update`.
 - **SEP-2133 (Extensions)** supplies the extension and capability framing.
-- **OpenID AuthZEN Access Request and Approval Profile** supplies the approval
-  lifecycle (requestable denial context, access request submission, the portable
-  task handle, and re-evaluation via `context.approval`). A companion AuthZEN MCP
-  profile (COAZ) maps a `tools/call` to an AuthZEN Access Evaluation; COAZ is itself a
-  draft, so the `tools/call`-to-evaluation mapping is not yet stable.
+- **SEP-2643 (Structured Authorization Denials)** supplies the portable denial
+  envelope, `io.modelcontextprotocol/authorization`, which classifies the failure and
+  states the remediation posture. A server that also implements SEP-2643 emits it as
+  the denial classification while a call is denied; this extension's
+  `io.modelcontextprotocol/tool-approval-disposition` carries the execution outcome.
+  Envelope behavior below applies only to servers that implement SEP-2643.
+- **An approval backend** supplies the approval lifecycle: it accepts an approval request
+  idempotently under a caller-supplied submission key, returns a durable resumable handle,
+  resolves the request out of band into a terminal state (granted, denied, expired,
+  cancelled, or failed), and on a grant returns approval material the server uses as an input
+  to re-evaluation. The server, not the backend, performs that re-evaluation through its
+  authorization decision so the decision stays authoritative. The backend bounds the approval
+  by an expiry and MAY support cancellation. This SEP references that abstract contract, not any single backend.
+  The OpenID AuthZEN ARAP is a worked example (see Example binding: AuthZEN ARAP).
 
-The MCP server is the Policy Enforcement Point (PEP) and is the _only_ party that
-speaks the approval protocol. The client speaks ordinary MCP. AuthZEN is the
-reference approval backend; the MCP-observable behavior in this SEP does not depend
-on AuthZEN internals and could be satisfied by another backend that provides an
-equivalent durable handle and re-evaluation guarantee.
+The MCP server is the Policy Enforcement Point (PEP) and the only party that speaks the
+approval protocol; the client speaks ordinary MCP. The backend is pluggable, and a
+deployment binds it to whatever provides the contract above. Whether the generic
+execution and disposition semantics should live here or move into SEP-2643 or the tasks
+extension is open (see Limitations).
 
 The composition order is:
 
-1. the server evaluates every `tools/call` as an AuthZEN Access Evaluation (the COAZ
-   mapping);
-2. a requestable denial enters the Access Request lifecycle: submit the access
-   request, bind the approval handle to the MCP `taskId`, and return a `working` task;
-3. on resolution the server re-evaluates with `context.approval`;
-4. that decision is final: an approval is an input to a new decision, not a standing
-   grant.
+1. the server evaluates every `tools/call` against its authorization policy;
+2. a requestable denial enters the approval lifecycle: submit the request, bind the
+   backend's handle to the MCP `taskId`, and return a `working` task;
+3. on resolution the server re-evaluates with the approval as an input;
+4. that decision is authoritative: an approval is an input to a new decision, not a
+   standing grant.
 
 ### Server-side flow (informative)
 
-The exchange below is non-normative and shows how the approval protocol sits behind
-a single MCP task. Nothing in it is part of the MCP wire contract: the only MCP
-messages are between the Client and the Server.
+Non-normative. The only MCP messages are between Client and Server; everything to the
+right of the server is internal to the PEP and never crosses the MCP boundary.
 
 ```mermaid
 sequenceDiagram
     participant C as Client
     participant S as MCP Server (PEP)
-    participant P as Policy Decision Point
-    participant A as Approval Service
+    participant P as Authorization decision
+    participant A as Approval backend
 
     C->>S: tools/call
-    S->>P: Access Evaluation
-    P-->>S: deny + context.access_request (requestable)
-    S->>A: submit Access Request (binding_token)
-    A-->>S: task handle (bound to MCP taskId)
+    S->>P: authorization check
+    P-->>S: deny, requestable
+    S->>A: submit approval request (binding material)
+    A-->>S: durable handle (bound to MCP taskId)
     S-->>C: CreateTaskResult (resultType: "task", status: working)
     Note over P,A: Out-of-band resolution<br/>(human, agent, policy, or external system)
-    A-->>S: approved (callback or poll)
-    S->>P: re-evaluate (context.approval)
+    A-->>S: resolved (callback or poll)
+    S->>P: re-evaluate with approval
     P-->>S: allow
     S->>S: execute tool; task = completed (result available)
     C->>S: tasks/get
     S-->>C: CompletedTask with result (CallToolResult)
 ```
 
-Everything to the right of the MCP Server (the Policy Decision Point and Approval
-Service exchanges) is internal to the PEP and never crosses the MCP boundary. The
-AuthZEN constructs shown (`context.access_request`, `binding_token`, the task
-handle, and `context.approval`) are specified by the OpenID AuthZEN Access Request
-and Approval Profile and are referenced, not redefined, by this SEP.
+The backend's constructs (the requestable-denial signal, binding material, the durable
+handle, and the approval input to re-evaluation) are defined by the backend and
+referenced, not redefined, by this SEP. For the AuthZEN ARAP mapping, see Example
+binding: AuthZEN ARAP.
 
 ### Extension identifier and capability
 
-The feature is an experimental extension with identifier
-`net.openid.authzen/tool-approval` (reversed-domain prefix per SEP-2133;
-illustrative, to be confirmed with the owning group).
-
-This extension builds on the tasks extension, so a server MUST also support
-`io.modelcontextprotocol/tasks`. Both are declared in the server's `extensions`
-capability:
+The extension identifier is `io.modelcontextprotocol/tool-approval` (reversed-domain
+prefix per SEP-2133; illustrative, to be confirmed with the owning group). It builds on
+the tasks extension, so a server MUST also support `io.modelcontextprotocol/tasks`.
+Both are declared in the server's `extensions` capability:
 
 ```json
 {
   "capabilities": {
     "extensions": {
       "io.modelcontextprotocol/tasks": {},
-      "net.openid.authzen/tool-approval": { "version": "0.1" }
+      "io.modelcontextprotocol/tool-approval": {}
     }
   }
 }
 ```
 
-Per SEP-2663, task creation is **server-directed**: a client does not flag a
-request for task execution. A client signals that it can receive task handles by
-declaring the `io.modelcontextprotocol/tasks` extension in its per-request
-capabilities (SEP-2663 / SEP-2575); the server then decides per request whether to
-return a `CreateTaskResult`. A client that has not declared the tasks extension and
-issues a call the server can only satisfy through approval MUST receive either:
+Task creation is server-directed (SEP-2663): the client only declares the tasks extension,
+and the server decides per request whether to return a `CreateTaskResult`. A client that
+has not declared tasks but issues a call the server can satisfy only through approval MUST
+receive either a `-32003` (Missing Required Client Capability) error naming
+`io.modelcontextprotocol/tasks`, or a normal `CallToolResult` with `isError: true`
+carrying requestable guidance (a degraded path with no async resume). Since `-32003` reads
+as a capability gap rather than "go obtain access," a server that wants non-tasks agents to
+act on a requestable denial SHOULD prefer the degraded `CallToolResult` with next-step
+guidance.
 
-- a `-32003` (Missing Required Client Capability) error naming
-  `io.modelcontextprotocol/tasks`, which a tasks-capable client reads as "re-issue the
-  call with the capability declared"; or
-- a normal `CallToolResult` with `isError: true` carrying requestable guidance in its
-  content (a degraded path with no asynchronous resume), for clients that will not
-  speak the tasks extension.
+Declaring `io.modelcontextprotocol/tool-approval` is an optional client signal that it
+understands approval semantics (for example, to render approval-specific UI). Correct
+behavior does not require it, since an approval-gated task is an ordinary
+tasks-extension task.
 
-`-32003` is a capability-negotiation error, not an "access is requestable" signal: an
-agent reads it as "I did not declare something," not "go obtain access." A server that
-wants today's non-tasks agents to act on a requestable denial SHOULD prefer the
-degraded `CallToolResult` and include machine-readable next-step guidance (see the
-client-maturity note).
-
-Declaring `net.openid.authzen/tool-approval` is an optional client signal that it
-understands approval semantics (for example, to render approval-specific progress
-UI). Correct behavior does not require it: an approval-gated task is an ordinary
-tasks-extension task, and a client that supports only `io.modelcontextprotocol/tasks`
-already interoperates.
-
-> **Client maturity (non-normative).** The canonical flow requires a client that
-> declares and drives `io.modelcontextprotocol/tasks` (receives `CreateTaskResult`,
-> polls `tasks/get`). That capability is experimental (SEP-2663) and, at the time of
-> writing, is not present in shipping MCP clients, whose task support is server-side.
-> End-to-end value is therefore gated on client tasks adoption, and interop testing
-> needs a purpose-built tasks client (the Reference Implementation clause requires
-> one). During the gap, servers may also expose approval as ordinary tools (for
-> example `request_access` / `get_request_status`) so today's agents can self-drive
-> request-poll-retry without tasks support. This SEP does not standardize that interim
-> shape, but a server that adopts it SHOULD carry the same machine-readable next-step
-> fields the Access Request profile already defines (a next-step hint, the request
-> schema, and a poll-interval hint) so interim shapes interoperate.
+> **Client maturity (non-normative).** The canonical flow needs a client that drives
+> `io.modelcontextprotocol/tasks`, which is experimental and not yet in shipping clients,
+> so end-to-end value and interop testing depend on tasks-client adoption. In the interim a
+> server MAY also expose approval as ordinary tools (for example `request_access` /
+> `get_request_status`) carrying the same next-step fields (a hint, the request schema, a
+> poll interval); this SEP does not standardize that shape.
 
 ### Denied-but-requestable returns a task
 
-When the server evaluates a `tools/call` against its policy decision point and the
-decision is "deny":
+When the server evaluates a `tools/call` and the decision is "deny":
 
-1. If the denial is **not** requestable (no approval can change it), the server
-   returns the normal denied tool result: a `CallToolResult` with `isError: true`
-   describing the denial, so the model can react. (Per SEP-2663, an `isError`
-   result delivered through a task is a `completed` task, not a `failed` one.)
-2. If the denial **is** requestable, and the client declared the tasks extension,
-   the server MUST NOT execute the tool. Instead it:
-   - submits an access request to the approval service on the caller's behalf and
-     obtains a durable approval task handle;
-   - creates a durable MCP task bound to that handle and returns a
-     `CreateTaskResult` (`resultType: "task"`) with `status: "working"` and a
-     human-readable `statusMessage` (for example, "Awaiting treasury approval");
-   - MAY include an `io.modelcontextprotocol/model-immediate-response` value in the
-     result `_meta` so the model receives an immediate string (for example,
-     "This action is pending approval; you can continue other work and check back").
+1. If the denial is **not** requestable, the server returns the normal denied tool
+   result: a `CallToolResult` with `isError: true` describing the denial. (Per SEP-2663,
+   an `isError` result delivered through a task is a `completed` task, not a `failed`
+   one.)
+2. If the denial **is** requestable and the client declared the tasks extension, the
+   server MUST NOT execute the tool. Instead it:
+   - records a durable submission-intent with a fresh, opaque idempotency key before
+     contacting the backend, submits the approval request under that key, and persists the
+     returned handle (see Crash-consistent creation);
+   - creates the durable MCP task bound to that handle and returns a `CreateTaskResult`
+     (`resultType: "task"`) with `status: "working"` and a human-readable
+     `statusMessage`;
+   - if it implements SEP-2643, includes the denial envelope in the result `_meta` under
+     `io.modelcontextprotocol/authorization` (`reason: "insufficient_authorization"`,
+     `remediation: "available"`, a `remediationHints` entry of `type: "task"`), and MUST
+     repeat that envelope on every `tasks/get` result while the task is non-terminal, so
+     a client resuming after a restart with only the `taskId` still reads the pending
+     classification;
+   - MAY include an `io.modelcontextprotocol/model-immediate-response` value in `_meta`
+     so the model receives an immediate string.
 
-The server MUST NOT surface approval-binding material (the AuthZEN `binding_token`,
-`evaluation_id`, `approval` object, or access-request endpoints) to the client.
-These are internal to the PEP.
+The server MUST NOT surface the backend's binding material or endpoints to the client
+(for example, in the ARAP binding, `binding_token`, `evaluation_id`, the `approval`
+object, and access-request endpoints). These are internal to the PEP.
 
-**At-most-once execution and deduplication.** Because the server controls both task
-creation and tool execution, it MUST execute the approved tool at most once per task.
-To keep a client retry (after a poll timeout or an agent restart) from creating a
-second approval task, and thus a second execution, the server SHOULD return the
-existing task's `CreateTaskResult` when it recognizes a repeated requestable denial
-within one dedup scope: the same **originating authorization context** (the
-authenticated caller or subject the task is bound to), the same tool, and the same
-arguments. This correlation is inherently best-effort: if the arguments carry a
-client-local value (a nonce or timestamp) two genuine retries will not match, and if
-they do not, two distinct intents with identical arguments will collide. MCP today
-has no general request-level idempotency key that would make it exact (see
-Limitations), so deployments needing exactness must wait for one.
+**Crash-consistent creation.** Submitting to the backend and creating the MCP task are two
+writes, and a crash between them must not orphan an approval or double-submit. Deduplication
+decides first, before any submission, whether a repeated `tools/call` reuses an existing
+non-terminal task (see At-most-once and deduplication). When the server does submit, whether
+an initial request or a chained `request` (see Completion), it MUST generate a fresh,
+opaque, high-entropy idempotency key for that logical submission, and MUST record a durable
+submission-intent holding that key plus the exact submission body and requester context
+needed to reproduce an equivalent request, before it contacts the backend. It then submits
+under that key. A conforming deployment MUST configure its backend to treat a repeat of the
+key with an equivalent body as the same request, return the same handle, and retain the key
+through reconciliation, so a retry after a crash recovers the original rather than creating a
+duplicate. The key identifies one submission, not the call, so distinct intents and
+successive chained requests never collide. The server MUST persist the returned handle before
+it returns `CreateTaskResult`, so the task is durable when returned (SEP-2663) and a callback
+that arrives first has a record to bind to. On restart the server MUST reconcile any
+submission-intent with no bound task, either by recovering the handle under its key or by
+cancelling the orphaned request.
 
-Deduplication applies only while the prior task is non-terminal. After a task reaches
-a terminal disposition (including `denied-not-executed`), an identical `tools/call`
-MUST start a **new** access request and a new task; the terminal denial was final and
-MUST NOT be folded into the old task.
+**At-most-once and deduplication.** The server controls both task creation and
+execution, so it MUST execute the approved tool at most once per task. To keep a client
+retry (after a poll timeout or restart) from opening a second approval task, the server
+SHOULD return the existing task's `CreateTaskResult` when it recognizes a repeated
+requestable denial within one dedup scope: the same **originating authorization
+context** (the authenticated caller or subject the task is bound to), tool, and arguments.
+It matches against both non-terminal tasks and in-progress submission-intents, so a
+concurrent retry in the window between persisting the intent and creating the task does not
+open a second approval. This is best-effort: a client-local nonce in the arguments defeats it, identical arguments
+from two distinct intents collide, and MCP has no request-level idempotency key that would
+make it exact (see Limitations). So the at-most-once guarantee is per task, and a
+non-idempotent tool can still run more than once through distinct tasks.
 
-**Retention.** The server MUST keep the task resolvable through `tasks/get` for the
-full approval window: it MUST NOT delete or expire a `working` approval task before
-the approval's expiry, and `ttlMs` MUST cover the approval window plus the server's
-result-retention period. The approval service often sets or extends the window after
-submission, so the creation-time `ttlMs` is provisional: when the server learns a
-later expiry, it MUST extend `ttlMs` (reported on `tasks/get` and
-`notifications/tasks`) so a `working` task is never expired before the current known
-approval expiry. A server SHOULD bound the maximum approval window it accepts so
-pending tasks do not accumulate without limit.
+Once a task reaches a terminal disposition it is final, permanently fenced against
+execution, and MUST NOT be reopened. A later identical `tools/call` is a new intent that
+the server evaluates fresh; it does not automatically create a new approval request and
+re-enters the approval lifecycle only if that fresh evaluation itself returns a
+requestable denial. A terminal `denied-not-executed` therefore carries
+`remediation: "unavailable"` in the full SEP-2643 sense: the client is not invited to
+retry it.
 
-**Model-facing text is untrusted and non-committal.** `statusMessage` and any
-`io.modelcontextprotocol/model-immediate-response` value are fed to the model and
-MUST NOT carry unsanitized text from untrusted sources (agent-supplied rationale,
-approver free-text); they are a prompt-injection surface. A `working` or
-`input_required` approval task MUST NOT be represented to the model as a completed
-action; if `model-immediate-response` is used, it MUST make clear the action has not
-yet occurred and may still be denied.
+**Retention.** Retention has two phases. While the task is pending, `createdAt` plus `ttlMs`
+MUST cover the current pending deadline plus `resultRetention`, where the pending deadline is
+the backend request deadline before a grant and the approval validity during post-grant
+retry, and `resultRetention` is a server-configured duration for how long a terminal result stays
+retrievable; the server MUST NOT delete or expire a `working` task before its pending
+deadline. At terminalization the server MUST extend `ttlMs` if needed so it covers
+`terminalizedAt` plus `resultRetention`. A `ttlMs` of `null` means unlimited (SEP-2663) and
+satisfies both boundaries with no extension. Because the backend
+often sets or extends the window after submission, the creation-time `ttlMs` is provisional;
+when the server learns a later deadline it MUST extend `ttlMs` (reported on `tasks/get` and
+`notifications/tasks`). A server SHOULD bound the maximum window it accepts so pending tasks
+do not accumulate without limit.
+
+**Model-facing text is untrusted.** `statusMessage` and any `model-immediate-response`
+are fed to the model and MUST NOT carry unsanitized text from untrusted sources; they
+are a prompt-injection surface. A `working` or `input_required` task MUST NOT be
+presented to the model as a completed action.
 
 ### The task handle is not authority
 
 The `taskId` is a reference to a pending decision, never a grant. Authority is the
-PDP decision, re-derived at execution against the original call envelope (see
-Completion). Possessing a `taskId` does not authorize execution.
+authorization decision, re-derived at execution against the captured call binding (see
+Completion). The server keeps three kinds of state per task, with different mutability:
 
-When it creates the task, the server MUST retain a binding record and MUST check it
-before executing. The record MUST include at least:
+- **Immutable call binding**, captured on the first `tools/call` and never changed (carried
+  in `requestState` per SEP-2322 across any pre-task synchronous input round-trip, then
+  promoted unchanged into the task): the tool name;
+  the complete tool arguments, stored in full (subject to the durable sensitive-state
+  requirement in Security Implications), since execution runs from them long after the call
+  and a digest cannot reconstruct them, and
+  optionally a digest over a canonical serialization (for example JCS canonical JSON, RFC
+  8785, with a named hash such as SHA-256) alongside them for integrity checking; and the
+  originating authorization context (the requester principal's identity, the subject or
+  resource acted on, and any delegation), captured so a different caller is rejected. An
+  approval is bound to this identity.
+- **Mutable approval-workflow state**: the current backend handle and request id, a
+  monotonically increasing submission generation, and the current approval expiry and
+  window. These change legitimately, for example when a re-evaluation returns `request` and
+  the server opens a new request (see Completion), or when the backend extends the expiry.
+  The server retains enough handle history to recognize a superseded generation.
+- **Mutable execution state**: the single execution claim and the terminal disposition,
+  set once the task reaches execution (see Completion).
 
-- the task id;
-- the tool name;
-- a canonical digest of the arguments;
-- the requester principal (and session, where applicable);
-- the subject or resource being acted on;
-- the approval request id;
-- the disposition;
-- the expiry / freshness window.
-
-The server MAY also record the policy id and version for audit and drift detection;
-this is recorded, not pinned (see Completion).
-
-**Envelope match or new approval.** At execution time the server MUST compare the
-current call against the bound envelope. If the tool, arguments, requester principal,
-or subject/resource differ, the task MUST resolve `denied-not-executed` with no side
-effect, and the changed call requires a new access request. An approval is bound to
-the exact envelope that produced the requestable denial; it never carries over to a
-different or mutated call.
+The server MUST check the immutable call binding before executing, and MAY record the
+policy id and version for audit and drift detection (recorded, not pinned). Execution
+runs from the captured binding, not from a fresh client call, so there is no "current
+call" to trust at execution time. An MRTR retry that resumes the original call, echoing it with `requestState`, MUST match the
+immutable call binding: the server MUST reject it if the tool, arguments, or originating
+caller differ. A `tasks/update` is different: it carries no tool or arguments, so the server
+authorizes the caller against the `taskId` and validates the outstanding input keys instead.
+An independent new `tools/call` is a new intent evaluated fresh; only a changed binding is
+guaranteed not to match dedup, while an identical independent intent is indistinguishable
+from a retry and MAY collide.
 
 ### Collecting submission input
 
-The access request may require inputs from the requester before or during the
-approval: a justification, a ticket reference, or fields the approval service
-defines (the AuthZEN profile's `request_schema_url`, `form_url`, and
-`request_catalogs_url`). The server collects these over the tasks input channel
-(SEP-2322 multi round-trip requests), not a standalone `elicitation/create`, since
-SEP-2260 disallows unsolicited server-to-client requests and SEP-2663 routes task
-input through `inputRequests` / `tasks/update`:
+The approval request may require inputs before or during the approval: a justification,
+a ticket reference, or fields the backend defines (its submission schema and forms; for
+example, in the ARAP binding, `request_schema_url`, `form_url`, `request_catalogs_url`).
+The server collects these over the tasks input channel (SEP-2322), not a standalone
+`elicitation/create`, since SEP-2260 disallows unsolicited server-to-client requests and
+SEP-2663 routes task input through `inputRequests` / `tasks/update`:
 
-- **Before submission (synchronous).** The server returns `resultType:
-"input_required"` on the original `tools/call`, collects the inputs, then returns a
-  `CreateTaskResult` and submits the access request. Use this when the approval
-  service will not accept the request without them.
-- **During the workflow (in-task).** The server sets the task to `input_required`
-  with the outstanding `inputRequests` (for example, an approver asks for more
-  detail, or a catalog-backed field is resolved after submission); the client answers
-  with `inputResponses` via `tasks/update`, and the task returns to `working`.
+- **Before submission (synchronous).** The server returns `resultType: "input_required"` on
+  the original `tools/call`. The client then retries the `tools/call` with `requestState` and
+  `inputResponses` (per SEP-2322); the server validates that retry against the pre-task
+  immutable call binding it captured on the first call and carried in `requestState`, submits
+  the approval request under Crash-consistent creation, and
+  returns the `CreateTaskResult` on the retry. A single JSON-RPC response cannot carry both
+  `input_required` and the task. Use this when the backend will not accept the request without
+  the inputs.
+- **During the workflow (in-task).** The server sets the task to `input_required` with
+  outstanding `inputRequests`; the client answers with `inputResponses` via
+  `tasks/update`, and the task returns to `working`.
 
-Who answers is a property of the client, not this extension. An interactive client
-renders the request for a human (the profile's `form_url` case); an autonomous agent
-client MAY answer it from context against the request schema (the
-`request_schema_url` case), resolving catalog-backed fields per
-`request_catalogs_url`. The server derives the `inputRequests` schema from those
-profile fields. Either way this is submission-time input that shapes the access
-request; it is distinct from the approval decision, which is made out of band by a
-party (human or automated) not assumed to be reachable through the session.
+Who answers is a property of the client: an interactive client renders the request for a
+human, an autonomous agent answers from context against the backend's request schema.
+An in-task round-trip requires a client that returns to the task; an agent that persisted
+its `taskId` can resume polling after a restart (SEP-2663) and answer via `tasks/update`,
+but a client that did not persist it or will not return cannot, so deployments expecting
+long gaps SHOULD collect all inputs synchronously before submission. The mapping from the
+backend's request schema onto the `inputRequests` schema is not pinned here and is
+currently implementation-specific.
 
-An in-task `input_required` round-trip requires a connected client: an agent that
-submitted and then disconnected or restarted cannot answer a later `inputRequests`.
-Deployments that expect long gaps between submission and approval SHOULD collect all
-inputs synchronously before submission. The mapping from the profile's
-`request_schema_url` (a JSON Schema) onto the SEP-2322 `inputRequests` schema is not
-pinned by this SEP and is currently implementation-specific; two servers MAY produce
-different `inputRequests` for the same access request until a canonical mapping is
-defined.
+### Lifecycle and task status
 
-### Approval lifecycle maps onto task status
+The backend resolves the approval request into a terminal state (granted, denied, expired,
+cancelled, or failed); a grant triggers the server's re-evaluation, which yields allow,
+retry, request, or deny (see Completion). Both feed the mapping below. Each row maps to an
+MCP task status and a disposition; a SEP-2643-aware server also carries an envelope while
+the call is denied. The envelope classifies the denial (present only while denied); the
+disposition records what happened to execution. They are independent axes.
 
-| Approval-profile state                                           | MCP task status                                                 |
-| ---------------------------------------------------------------- | --------------------------------------------------------------- |
-| Access request submitted, awaiting a decision                    | `working`                                                       |
-| Submission needs input from the requester (human or agent)       | `input_required`                                                |
-| Approved, re-evaluated to "allow", tool executed (once)          | `completed`, disposition `approved-executed`                    |
-| Terminal denial (rejected, revoked, expired, or not executed)    | `completed`, `isError: true`, disposition `denied-not-executed` |
-| Approved and executed, but the tool itself errored               | `completed`, `isError: true`, disposition `execution-error`     |
-| Server could not produce a tool result at all (protocol failure) | `failed`                                                        |
-| Client cancelled                                                 | `cancelled`                                                     |
+| Backend state                                                          | Task status                                    | SEP-2643 envelope        | Disposition           |
+| ---------------------------------------------------------------------- | ---------------------------------------------- | ------------------------ | --------------------- |
+| Awaiting a decision                                                    | `working`                                      | `available`, `task` hint | none yet              |
+| Needs submission input (in-task)                                       | `input_required`                               | `available`              | none yet              |
+| Re-evaluation returns retry                                            | `working` (wait, then re-evaluate)             | `available`              | none yet              |
+| Re-evaluation returns request                                          | `working` (new request)                        | `available`              | none yet              |
+| Allowed, executed once                                                 | `completed`                                    | none                     | `approved-executed`   |
+| Backend denied, or re-evaluation deny/none                             | `completed`, `isError`                         | `unavailable`            | `denied-not-executed` |
+| Approval or request expired unresolved                                 | `completed`, `isError`                         | `unavailable`            | `denied-not-executed` |
+| Executed, tool errored                                                 | `completed`, `isError`                         | none                     | `execution-error`     |
+| Execution claimed, outcome undeterminable                              | `completed`, `isError`                         | none                     | `outcome-unknown`     |
+| JSON-RPC error, or a backend/infra failure surfaced as one (retryable) | `failed` (carries the SEP-2663 `error` object) | none                     | —                     |
+| Cancelled by client (`tasks/cancel`) or backend                        | `cancelled`                                    | none                     | —                     |
 
-A terminal authorization denial is an outcome of the call, not a failure of the
-task machinery, so it is a `completed` task whose `result` is a `CallToolResult`
-with `isError: true` and disposition `denied-not-executed`. That disposition lets a
-consumer distinguish a denial (no side effect occurred) from an `execution-error`
-(the tool ran and a side effect may have occurred). `failed` is reserved for cases
-where the server could not produce a tool result at all.
+While `working`, the server tracks the approval by polling the backend's status source or
+receiving its callback. The `taskId` and every backend handle generation are durably bound
+to the task, and only the current generation is actionable, so a server that restarts
+rehydrates the task from the persisted handles and keeps serving `tasks/get`. Per the table, `failed` carries the SEP-2663 `error` object and covers a JSON-RPC protocol
+error or a backend/infra failure surfaced as a JSON-RPC internal error; unlike a denial such
+a `failed` is retryable, and it is not an authorization outcome. A task MUST enter `failed`
+only before an execution claim (see Completion); any failure after the claim MUST be a
+`completed` `CallToolResult` with `execution-error` or `outcome-unknown`, so a possible side
+effect is never hidden behind a retryable `failed`.
 
-While `working`, the server tracks the approval by polling the approval service's
-status endpoint or by receiving its callback. The MCP `taskId` and the approval
-task handle are bound for the task's lifetime, so a server that restarts can
-rehydrate the task from the persisted handle and keep serving `tasks/get`. Both the
-tasks extension and the AuthZEN task handle are durable by design, which is what
-makes resolution that outlives the session possible.
+Three clocks apply and are distinct: the backend's request deadline (how long the request
+stays open for a decision), the approval's validity once granted, and MCP retention
+(`createdAt` plus `ttlMs`, always measured from `createdAt` even when the server extends
+it per Retention). When the request deadline or approval validity passes without a usable
+approval, the task completes as a terminal denial (`denied-not-executed`, with the body
+noting expiry) and the server fences it against later execution. MCP retention is separate:
+once `ttlMs` elapses the server MAY delete a task that has not been execution-claimed
+(SEP-2663). An execution-claimed task MUST NOT be deleted before it terminalizes: at the
+claim the server extends retention through an execution deadline, and when that deadline
+arrives it terminalizes the task as `outcome-unknown` (if no stronger result is available),
+retains that result for `resultRetention`, and only then MAY delete it. A terminal task MUST
+NOT change to `failed`, which would erase its disposition.
+
+### Execution disposition
+
+`io.modelcontextprotocol/tool-approval-disposition` is this extension's machine-readable
+outcome. It is a string and MUST be present in the `_meta` of the `CallToolResult` carried
+in a completed task's `result` field, on every completed approval task, independent of
+SEP-2643. Its value is one of:
+
+- `approved-executed`: the tool was authorized and executed once.
+- `denied-not-executed`: the tool did not run (denied, expired, or unresolved), so no side
+  effect occurred.
+- `execution-error`: the tool was authorized and ran but failed; a side effect may have
+  occurred.
+- `outcome-unknown`: execution was claimed but the server cannot determine whether
+  invocation or the side effect completed.
+
+The outer `tasks/get` result carries the `Task`, whose `status` conveys
+`completed`/`failed`/`cancelled`; the disposition refines a `completed` task's execution
+outcome and is not set on `failed` or `cancelled` tasks. Future values MAY be registered. A
+client that does not recognize a disposition value MUST treat the operation as possibly
+executed and MUST NOT retry it automatically.
 
 ### Completion: re-evaluate, then execute
 
-On approval, the server MUST perform a fresh authorization evaluation that takes the
-approval as an input (for AuthZEN, placing the `approval` object at
-`context.approval`), so the policy decision point remains authoritative at
-enforcement time. An approval is an input to a new decision, not a standing grant.
-This re-evaluation is server-internal and is not observable on the MCP wire.
+On approval the server MUST re-evaluate authorization with the approval as an input, so
+the decision stays authoritative at enforcement time. An approval is an input to a new
+decision, not a standing grant, and this re-evaluation is server-internal. It runs against
+the immutable call binding and current policy; a recorded policy version is for audit, not
+pinning, so a policy change yields a fresh decision. The re-evaluation resolves to one of
+four outcomes:
 
-The re-evaluation runs against the bound call envelope (see The task handle is not
-authority) and current policy. The recorded policy version is for audit and drift
-detection, not pinning: a policy change yields a fresh allow-or-deny rather than an
-automatic denial, so an approval still valid under current policy proceeds. Envelope
-fields (tool, arguments, requester principal, subject/resource) are an exact-match
-binding; a mismatch resolves `denied-not-executed` and requires a new approval.
+- **allow**: proceed to execution.
+- **retry** (the approval is valid but a backing grant has not provisioned, or a
+  transient hold): the task stays `working`. The server waits the backend's retry-after
+  hint, or bounded exponential backoff with jitter if none is given, then re-evaluates,
+  and MUST stop once the approval expires. A retryable outcome MUST NOT be completed as a
+  denial.
+- **request** (this approval does not suffice, but a fresh approval request might): the
+  task stays `working`. The server first atomically marks the current generation consumed and
+  records a new submission-intent with its own fresh submission key (the immutable call binding
+  is unchanged), then contacts the backend under Crash-consistent creation and attaches the
+  returned handle to the new generation. Ordering it this way closes the window where a stale
+  callback could still act: a callback or poll result for a consumed generation MUST NOT cause
+  re-evaluation or execution, even when it is authentic, since the decision has moved on. A
+  server MUST bound the number of chained requests per task so this cannot loop indefinitely;
+  on reaching the bound it completes the task as a terminal denial.
+- **deny or none**: the task completes as a terminal denial.
 
-Because execution can occur long after the original request, the server SHOULD
-verify at execution time that the captured arguments and any downstream credential
-it must use are still valid. If a required credential has expired, or the action is
-materially stale, the server SHOULD NOT execute: it completes the task as a denial
-(disposition `denied-not-executed`) or returns a fresh requestable denial so the
-caller can resubmit.
+Because execution can occur long after the request, an approval is not a substitute for
+caller authentication. The intent, approval scope, and the originating caller's identity come
+from the immutable binding; every other authorization input MUST be current at execution:
+whether that caller is still a valid principal, and the subject and resource state, risk and
+environmental attributes, the downstream credential, and policy. Re-evaluating against captured risk or environment would
+defeat the risk-clearing case, so those MUST be re-read, not replayed. The server MUST
+validate the immutable call binding, and if the tool implementation, its schema, or the
+authorization mapping changed materially while the task was pending, it MUST evaluate against
+that change or fail closed. If the principal is no longer valid, a required credential has
+expired, or the action is materially stale, the server MUST NOT execute (it completes as a
+terminal denial, or keeps the task `working` if the condition is transient).
 
-The terminal outcome MUST be distinguishable so a consumer can tell whether a side
-effect occurred. Because a client that supports only `io.modelcontextprotocol/tasks`
-does not understand this extension's `_meta`, the distinction MUST be carried in the
-`CallToolResult` itself, not only in `_meta`: the result `content` (and
-`structuredContent` where used) MUST state plainly whether the tool executed, so the
-model behind any tasks client reads "denied, the tool did not run" and does not
-blindly retry. A `net.openid.authzen/disposition` value in the result `_meta` is the
-machine-readable companion for extension-aware consumers. The body and the `_meta`
-disposition MUST agree:
+Execution MUST be fenced so a crash cannot double-execute a side effect. A task that
+proceeds to execution MUST make a single atomic compare-and-set from pre-execution to
+execution-claimed; this happens at most once and is mutually exclusive with cancellation and
+expiry (a task that is denied, cancelled, or expired makes no claim). The claim is the
+irrevocable authorization-enforcement point: all validity checks, the identity and freshness
+checks above and the approval expiry, MUST hold at the moment of the claim, and a
+cancellation or expiry that precedes the claim wins (the exact cancellation boundary, see
+Cancellation). The claim does not terminalize the task: its observable status stays `working`
+until the final result is stored. Once the claim succeeds the server invokes the tool at most
+once and MUST carry it through even if the approval expiry elapses during invocation, since
+authorization was enforced at the claim. If it cannot determine whether invocation or the
+side effect completed (a crash after the claim, before or after invoking), it MUST NOT
+re-invoke, and the task completes `outcome-unknown`.
 
-- **allow**: the server executes the tool exactly once and moves the task to
-  `completed`; the `tasks/get` response carries the tool's `CallToolResult` in the
-  task's `result` field. `_meta` disposition `approved-executed`.
-- **deny** at re-evaluation (policy changed, approval unverifiable, expired with no
-  re-request path), or a freshness or credential failure that prevented execution:
-  the task is `completed` with an `isError: true` `CallToolResult` whose content says
-  the tool did not run; `_meta` disposition `denied-not-executed`.
-- **execution error**: the tool was authorized and ran but failed; `isError: true`
-  with content describing the failure and `_meta` disposition `execution-error`, since
-  a side effect may have occurred.
-
-The server MUST bound any downstream credential, cached result, or follow-on
-authorization by the approval's expiry.
+Every completed approval task MUST carry
+`io.modelcontextprotocol/tool-approval-disposition` (see Execution disposition). The
+denied-versus-executed distinction MUST also be stated in the `CallToolResult` body, not
+only in `_meta`: the `content` MUST state whether the tool ran, did not run, or may have run with the outcome unknown, and it MAY also appear in
+`structuredContent` where the tool's `outputSchema` permits, so the model behind a client that
+understands only
+`io.modelcontextprotocol/tasks` reads it. That client cannot distinguish outcomes
+programmatically without the disposition, which is why the disposition is required. Body,
+disposition, and, for a SEP-2643-aware server, the envelope MUST agree. The envelope
+appears only on a denial: because its presence asserts the operation was not performed, it
+MUST NOT appear on an `execution-error` or `outcome-unknown` result, where the server
+cannot make that assertion. The server MUST bound any downstream credential, and any
+authorization-decision or downstream-response cache it keeps, by the approval's expiry; this
+does not apply to the task's retained terminal result, which follows Retention.
 
 ### Cancellation
 
-A `tasks/cancel` request MUST cause the server to cancel the underlying access
-request and move the task to `cancelled`. Per SEP-2663, `notifications/cancelled`
-MUST NOT be used to cancel a task.
+A `tasks/cancel` request attempts the same atomic transition as the execution claim, from a
+cancellable pre-claim state to `cancelled`. Only a winning transition moves the task to
+`cancelled` and durably fences it against execution; if the execution claim already won or the
+task is already terminal, the cancel is a no-op. On a winning cancel the server MUST cancel the
+underlying approval request when the backend supports it (backend cancellation is optional; in
+the ARAP binding it is offered only when a cancellation endpoint is present) and otherwise MUST
+record the cancellation locally and ignore any later approval. Either way it is the local
+fence, not backend cancellation, that guarantees the tool does not run. Per SEP-2663,
+`notifications/cancelled` MUST NOT be used to cancel a task.
 
-A cancel can arrive after approval but before the tool has executed. To avoid
-ambiguity about whether a side effect occurred, the server resolves the race by the
-execution boundary: if it has not begun executing the tool, it MUST honor the cancel,
-skip execution, and move the task to `cancelled` (no side effect); once execution has
-begun, the cancel is ineffective and the task completes with its normal disposition.
-The server MUST NOT both execute the tool and report `cancelled`.
+A cancel can arrive after approval but before execution. The server resolves the race by
+the atomic execution claim (see Completion): if the cancel wins the compare-and-set, the
+server honors it, moves the task to `cancelled`, and does not invoke (no side effect); if
+the claim wins, the cancel is ineffective and the task completes with its execution
+disposition. The server MUST NOT both execute the tool and report `cancelled`.
 
 ### What the client carries
 
-The client carries a server-generated `taskId` only. It MUST NOT be required to
-read, store, or forward any authorization artifact. A client that supports the tasks
-extension already interoperates with an approval-gated server: it must already be
-prepared to receive a `CreateTaskResult` for any supported request, and it observes
-a task that stays `working` and then becomes `completed` (or `failed`/`cancelled`).
-This extension adds meaning, not new client wire format. Because the
-denied-versus-executed distinction is carried in the `CallToolResult` body (see
-Completion) and not only in `_meta`, a tasks-only client's model can act on it safely;
-without that rule a tasks-only client could not tell a denial from an execution error
-and could double-execute a side-effecting tool on retry.
+After task creation the client carries a server-generated `taskId` only and MUST NOT be required to read,
+store, or forward any authorization artifact. This extension adds meaning, not a new result
+shape (see Backward Compatibility): a tasks-only client reads the denied-versus-executed
+distinction from the `CallToolResult` body, an approval-aware client from the disposition
+(see Completion, Execution disposition).
+
+This extension does not emit SEP-2643's optional `authorizationContextId`. That field is
+a non-authoritative correlation handle the client would echo on retry, but this client
+forwards no authorization artifact and the `taskId` already correlates the denial with
+its resolution. The authoritative binding between an approval and the exact call is the
+server-side immutable call binding, internal to the PEP and distinct from that handle.
 
 ### End-to-end example
 
-Client calls a tool (the client has declared the `io.modelcontextprotocol/tasks`
-extension in its per-request capabilities):
+The JSON below abbreviates the SEP-2575 per-request metadata (protocol version, client
+information, and client capabilities) that a real request carries.
+
+Client calls a tool (having declared the `io.modelcontextprotocol/tasks` extension in its
+per-request capabilities):
 
 ```json
 {
@@ -479,8 +526,8 @@ extension in its per-request capabilities):
 }
 ```
 
-The server evaluates, gets a requestable denial, submits the access request, and
-returns a task handle in place of the tool result:
+The server gets a requestable denial, submits the approval request, and returns a task
+handle in place of the tool result:
 
 ```json
 {
@@ -492,27 +539,24 @@ returns a task handle in place of the tool result:
     "status": "working",
     "statusMessage": "Transfers over $25,000 require treasury approval.",
     "createdAt": "2026-06-02T10:30:00Z",
+    "lastUpdatedAt": "2026-06-02T10:30:00Z",
     "ttlMs": 604800000,
     "pollIntervalMs": 15000,
     "_meta": {
+      "io.modelcontextprotocol/authorization": {
+        "reason": "insufficient_authorization",
+        "remediation": "available",
+        "remediationHints": [{ "type": "task" }]
+      },
       "io.modelcontextprotocol/model-immediate-response": "This transfer is pending treasury approval. You can continue other work and check back."
     }
   }
 }
 ```
 
-After the approval workflow resolves out of band (whether a human acts the next day
-or an automated re-check clears in seconds), the server re-evaluates and executes.
-A later poll returns the completed task with the tool result:
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 7,
-  "method": "tasks/get",
-  "params": { "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840" }
-}
-```
+A `tasks/get` while the approval is pending returns the same `working` task with the
+envelope repeated. After the workflow resolves out of band, the server re-evaluates,
+executes, and a later `tasks/get` returns the completed task with the tool result:
 
 ```json
 {
@@ -529,179 +573,188 @@ A later poll returns the completed task with the tool result:
       "content": [
         { "type": "text", "text": "Transfer of $50,000 to acct-991 completed." }
       ],
-      "isError": false
+      "isError": false,
+      "_meta": {
+        "io.modelcontextprotocol/tool-approval-disposition": "approved-executed"
+      }
     }
   }
 }
 ```
 
+Had it been denied, the task would complete with `isError: true`, the envelope
+classifying it (`remediation: "unavailable"`), and disposition `denied-not-executed`, and
+the body stating the tool did not run.
+
+## Example binding: AuthZEN ARAP (non-normative)
+
+This section maps the abstract approval-backend contract above onto the OpenID AuthZEN
+Access Request and Approval Profile (ARAP), one backend a deployment can bind. Other
+backends map the same contract to their own constructs. Nothing here crosses the MCP
+wire: the ARAP constructs are internal to the PEP, and the client sees only the MCP task.
+
+| Abstract contract (this SEP)             | AuthZEN ARAP construct                                                                                                                                                                               |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| requestable denial                       | a decision carrying `context.access_request`                                                                                                                                                         |
+| approval request submission              | an Access Request to the Access Request Service                                                                                                                                                      |
+| durable, resumable handle                | the ARAP Task Handle                                                                                                                                                                                 |
+| approval binding material                | `binding_token`, `evaluation_id`                                                                                                                                                                     |
+| idempotent submission key                | the `Idempotency-Key` header                                                                                                                                                                         |
+| re-evaluation with the approval as input | an Access Evaluation with the `approval` object at `context.approval`                                                                                                                                |
+| re-evaluation allow                      | `decision: true`                                                                                                                                                                                     |
+| re-evaluation not allowed                | `decision: false` with `next_action`: `retry` or `request` (non-terminal, task stays `working`) or `none` (terminal denial)                                                                          |
+| authoritative status source              | the ARAP Task Status Endpoint                                                                                                                                                                        |
+| submission schema and forms              | `request_schema_url`, `form_url`, `request_catalogs_url`                                                                                                                                             |
+| cancellation (optional)                  | the ARAP cancellation endpoint, when present                                                                                                                                                         |
+| backend terminal states                  | `denied` and `expired` map to disposition `denied-not-executed`; `cancelled` to the `cancelled` task; `failed` to the `failed` task; `partial` is bulk-only and does not apply to a single tool call |
+
+Mapping a `tools/call` to an AuthZEN decision is itself a profile, the AuthZEN MCP
+profile (COAZ), which is a draft, so that mapping is not yet stable.
+
+The concrete ARAP flow, everything internal to the PEP except the client-facing MCP
+messages:
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as MCP Server (PEP)
+    participant P as AuthZEN PDP
+    participant A as Access Request Service
+
+    C->>S: tools/call
+    S->>P: Access Evaluation (COAZ mapping)
+    P-->>S: deny + context.access_request (requestable)
+    S->>A: submit Access Request (Idempotency-Key, binding_token)
+    A-->>S: Task Handle (bound to MCP taskId)
+    S-->>C: CreateTaskResult (status: working)
+    Note over P,A: Out-of-band approval workflow
+    A-->>S: approved (Task Status Endpoint or callback)
+    S->>P: Access Evaluation (context.approval)
+    P-->>S: decision: true (allow)
+    S->>S: execute tool; task = completed
+    C->>S: tasks/get
+    S-->>C: CompletedTask with result
+```
+
 ## Rationale
 
-**Server-directed creation makes the client trivial.** Under SEP-2663 a client that
-supports tasks must already handle a `CreateTaskResult` for any call, and the server
-alone decides when to return one. An approval-gated server therefore needs no new
-client wire format and no per-tool opt-in: it returns a task exactly when it hits a
-requestable denial. This is the strongest property of the design and aligns with
-"Interoperability over optimization" (graceful degradation through capability
-negotiation).
+**Server-directed creation makes the client trivial.** Under SEP-2663 a tasks client
+already handles a `CreateTaskResult` for any call and the server decides when to return
+one, so an approval-gated server needs no new result shape and no per-tool opt-in.
 
-**Build on the tasks extension rather than invent a primitive.** Tasks already
-provides a durable state machine with polling, cancellation, input, and retention.
-An approval workflow is a long-running task, and the approval profile's portable
-handle provides the durability guarantee the binding needs. Aligns with
-"Composability over specificity."
+**Build on tasks, stay backend-agnostic.** Tasks already gives a durable state machine with
+polling, cancellation, input, and retention, and an approval workflow is a long-running
+task over it. Because approval is brokered server-side and surfaced only as task status,
+the MCP contract is identical whichever party or backend decides. The SEP encodes "decided
+out of band," not "human in the loop."
 
-**Resolver-agnostic by construction.** Because approval is brokered server-side and
-surfaced only as task status, the MCP-facing contract is identical whether a human,
-a supervising agent, a policy engine, or an external system decides. The SEP does
-not encode "human in the loop"; it encodes "decided out of band, asynchronously,"
-which serves fully automated and fully manual deployments alike.
-
-**Why an extension.** Per SEP-2133, optional capabilities that build on the core and
-need time to incubate belong as extensions; "extensions are where convergence gets
-tested." This feature layers on another extension and is not universally needed, so
-it starts experimental on the Extensions Track. It is an extension rather than
-Informational guidance because it defines normative, wire-observable behavior that
-plain tasks does not: a requestable denial MUST return a task, the
-denied-versus-executed distinction MUST be carried in the `CallToolResult` body (with
-a `net.openid.authzen/disposition` `_meta` companion), and authorization artifacts
-MUST NOT cross the wire. Those rules, not mere discovery, are what earns a capability.
-If the body-convey rule were dropped and the signal left optional in `_meta`, the
-value would collapse to a discovery hint and Informational guidance would be the
-better home.
-
-**Why submission input uses the task input channel.** SEP-2260 disallows unsolicited
-server-to-client requests, and SEP-2663 routes in-task input through MRTR
-(`inputRequests` / `tasks/update`) rather than standalone elicitation. Submission
-input therefore flows through the task, not a separate elicitation call.
+**Why an extension, not Informational.** It adds wire-observable surface plain tasks does
+not: a required `io.modelcontextprotocol/tool-approval-disposition` `_meta` field, a
+requestable denial that MUST return a task, the denied-versus-executed distinction carried
+in the `CallToolResult` body, and authorization artifacts that MUST NOT cross the wire. The
+mandatory disposition field is the clearest reason this is an extension rather than
+Informational guidance.
 
 ## Limitations and Open Questions
 
-- **Resumption by a different principal is not portable at the MCP layer.** The
-  AuthZEN task handle can be polled by any caller authorized for the bound subject,
-  but MCP task access is bound to a server-defined originating authorization context,
-  `tasks/list` was removed, and sessions were removed (SEP-2567), so there is no
-  standard way for a _different_ principal, or the same agent on a new connection with
-  a new credential, to reclaim a task. Same-principal resumption across restart works
-  to the extent the server's context binding recognizes the returning caller.
-  Defining a portable task-claim or re-authorization mechanism is open; until then,
-  deployments that need cross-principal handoff arrange it out of band.
-- **Someone has to come back and consume the result.** This SEP provides the
-  primitive, not the orchestration that resumes a paused agent and acts on the
-  completed task. For a side-effecting tool this matters: the tool may execute after
-  approval with no consumer observing the outcome. Deployments MUST ensure either a
-  durable consumer that polls or that the effect is independently auditable; a
-  fire-and-forget agent that never returns is a misuse, not a supported pattern.
-- **A lost `taskId` has no protocol recourse.** With `tasks/list` and sessions both
-  removed (SEP-2663 / SEP-2567), an agent that restarts without having persisted its
-  `taskId` cannot rediscover a possibly-executed side-effecting task. Clients MUST
-  persist task IDs to durable storage; there is no protocol-level recovery.
-- **No general request idempotency in MCP.** MCP has no request-level idempotency
-  key (only the `idempotentHint` tool annotation, which describes a tool rather than
-  deduplicating a call), so the server's duplicate suppression is best-effort
-  (matching the originating context, tool, and arguments). A general idempotency
-  mechanism belongs in the core protocol or the tasks extension, not in an approval
-  extension; if one is added, this extension should adopt it. Defining one here is
-  out of scope.
-- **Extension versus Informational (resolved, flagged for the sponsor).** Much of the
-  behavior can be built on the tasks extension alone. This SEP takes it as an
-  extension because the body-convey denied-versus-executed rule, the mandatory task on
-  a requestable denial, and the `disposition` signal are normative wire-observable
-  behavior, not just discovery (see Rationale). A sponsor who judges that surface too
-  thin may prefer an Informational SEP; that is the one positioning question left
-  open.
+- **Cross-principal resumption is not portable.** MCP task access is bound to a
+  server-defined originating context, and `tasks/list` was removed by SEP-2663 (with sessions
+  removed by SEP-2567), so a different principal cannot reclaim a task. Same-principal resumption
+  across restart works to the extent the server recognizes the returning caller.
+- **Someone has to consume the result.** For a side-effecting tool the effect may land with
+  no consumer observing it, so deployments MUST ensure a durable consumer polls or the
+  effect is independently auditable.
+- **A lost `taskId` has no recourse.** With `tasks/list` and sessions removed, an agent that
+  did not persist its `taskId` cannot rediscover a possibly-executed task, so clients MUST
+  persist task IDs durably.
+- **No general request idempotency in MCP.** Cross-task duplicate suppression is therefore
+  best-effort; a general key belongs in the core or the tasks extension, and this extension
+  should adopt one if it is added.
+- **Placement of the generic disposition.** The generic execution-outcome values
+  (`execution-error`, `outcome-unknown`) could move into SEP-2643 or the tasks extension,
+  leaving the approval-specific values (`approved-executed`, `denied-not-executed`) here. A
+  cross-SEP question for the sponsors.
+- **Extension versus Informational.** A sponsor who judges the normative surface too thin
+  may prefer an Informational SEP.
 
 ## Backward Compatibility
 
-Additive for new tools and new servers. A client that supports the tasks extension but
-not this one still observes a valid task lifecycle and a final
-`completed`/`failed`/`cancelled` task; there is no new client wire format, and no
-per-tool opt-in to change.
-
-For an existing tool that previously returned a synchronous denial, however, enabling
-approval gating changes the `tools/call` response set seen by existing integrations: a
-tasks client now receives a `CreateTaskResult`, and a non-tasks client receives
-`-32003` or the degraded requestable `CallToolResult` where a plain denial used to
-appear. That is a behavior change for upgraders, not a purely additive one.
+Additive for new tools and servers: a tasks client that does not implement this extension
+still observes a valid task lifecycle and a final `completed`/`failed`/`cancelled` task,
+with no new wire format. For an existing tool that previously returned a synchronous
+denial, enabling approval gating does change the observed `tools/call` response set (a
+`CreateTaskResult`, or `-32003` / a degraded requestable `CallToolResult`, where a plain
+denial used to appear), so it is a behavior change for upgraders, not purely additive.
 
 ## Reference Implementation
 
-Required before Final (this introduces observable protocol behavior). Planned:
+Required before Final (this introduces observable protocol behavior). Per SEP-2133 an
+Extension SEP also needs at least one official-SDK reference implementation, and named
+Extension Maintainers, before review; both are open prerequisites here. Planned: an MCP
+server fronting an approval backend (for example the AuthZEN ARAP) that returns
+`CreateTaskResult` for approval-gated calls and re-evaluates before execution, with a
+human-resolved and an automatically-resolved path; and a client built only on
+`io.modelcontextprotocol/tasks`, to show it interoperates with no approval-specific code.
 
-- an MCP server that fronts an OpenID AuthZEN policy decision point and access
-  request service, returning `CreateTaskResult` for approval-gated calls and
-  re-evaluating before execution, with at least one human-resolved and one
-  automatically-resolved approval path;
-- a client built only on the `io.modelcontextprotocol/tasks` extension, to
-  demonstrate that it interoperates with no approval-specific code.
-
-A conformance scenario tagged with the assigned SEP number, plus a `sep-NNNN.yaml`
-traceability file, is required for Final. The traceability file MUST cover these
-MCP-observable statements:
+A conformance scenario plus a `sep-NNNN.yaml` traceability file is required for Final,
+covering these MCP-observable statements:
 
 - a requestable denial returns a task without executing the tool;
 - approval resumes execution at most once;
-- a terminal denial is a `completed` task whose `CallToolResult` body (not only
-  `_meta`) marks it `denied-not-executed`, distinct from an execution error;
+- a terminal denial is a `completed` task whose `CallToolResult` body (not only `_meta`)
+  marks it `denied-not-executed`, distinct from an execution error;
 - a changed envelope (tool, arguments, principal, or subject/resource) requires a new
   approval;
 - a cancelled or expired task cannot later execute;
-- result retrieval does not expose backend approval artifacts;
+- result retrieval does not expose backend artifacts;
 - submission input flows through the task input channel.
-
-Server-internal behavior such as re-evaluation is referenced from the AuthZEN profile
-and is not MCP-observable. Not yet built.
 
 ## Security Implications
 
-- **Denial remains denial.** The server MUST NOT execute on the requestable denial
-  alone, and MUST re-evaluate after approval. The policy decision point is
-  authoritative at enforcement time.
-- **Authorization artifacts stay server-side.** Binding material (`binding_token`,
-  `approval`, `evaluation_id`) is never exposed to the client, preventing replay or
-  substitution through the client surface.
-- **The task handle is not a bearer approval token.** The `taskId` references a
-  pending decision; the server MUST re-derive authority from the bound call envelope
-  and current policy at execution (see The task handle is not authority), so holding a
-  `taskId` never authorizes execution of a different or mutated call.
-- **Task access control.** A `taskId` lets a caller poll and retrieve results.
-  SEP-2663 omits `tasks/list` precisely because tasks cannot always be bound to a
-  caller; task IDs are unguessable, single-task handles. The server MUST authorize
-  `tasks/get`, `tasks/update`, and `tasks/cancel` against the task's originating
-  authorization context, and MUST NOT leak approval contents or approver identity
-  through `statusMessage`.
-- **Confused deputy.** The server binds each task to the originally evaluated
-  subject, resource, action, and context, and applies an approval only within its
-  recorded scope. It MUST NOT let a client steer execution to a different operation
-  than the one that was approved.
-- **Out-of-band resolution.** Whoever or whatever decides (human, agent, policy
-  engine, external system), authentication, eligibility, and separation of duties are
-  properties of the approval service, outside MCP, as the approval profile specifies.
-- **Expiry.** The server MUST stop honoring an approval after its expiry and MUST
-  bound any downstream credential lifetime by it.
-- **Untrusted model-facing text.** `statusMessage` and `model-immediate-response` are
-  fed to the model and MUST be sanitized; a pending task MUST NOT be presented as a
-  completed action.
-- **At-most-once execution.** The server MUST execute an approved side-effecting tool
-  at most once per task and SHOULD deduplicate a retried requestable denial (by
-  originating context, tool, and arguments) so a poll timeout and replay cannot
-  double-execute.
-- **Approval-request amplification.** A compromised or buggy agent loop is the
-  expected failure mode here, not an edge case, and approval fatigue is a known
-  bypass. Deployments MUST rate-limit access-request submission per caller and SHOULD
-  bound the number of outstanding pending tasks per caller. When a limit is hit, the
-  server MUST return a non-requestable denial (a `CallToolResult` with `isError: true`,
-  not a task and not a requestable signal) so the agent does not retry-loop.
-- **The client cannot verify the gate.** "Denial remains denial" is enforced by the
-  server; the client receives no proof that the server re-evaluated rather than
-  executed. The binding material protects the server-to-PDP-to-approval-service path,
-  not the client's trust in the server. Clients needing stronger assurance must
-  obtain it out of band.
+- **Denial remains denial.** The server MUST NOT execute on the requestable denial alone
+  and MUST re-evaluate after approval; the client gets no proof, so assurance beyond that is
+  out of band.
+- **Artifacts stay server-side.** The backend's binding material never reaches the client,
+  preventing replay or substitution through the client surface.
+- **The task handle is not a bearer token.** Authority is re-derived at execution, so a
+  `taskId` never authorizes a different or mutated call (see The task handle is not authority).
+- **Task access control.** Task IDs are unguessable single-task handles; the server MUST
+  authorize `tasks/get`, `tasks/update`, and `tasks/cancel` against the task's originating
+  context and MUST NOT leak approval contents or approver identity through `statusMessage`.
+- **Confused deputy.** An approval applies only within the originally evaluated scope; the
+  server MUST NOT let a client steer execution to a different operation.
+- **Callback authenticity.** A backend callback MUST be authenticated, and unless it carries
+  an enforceable result the server MUST treat the backend's status source as authoritative
+  and fetch before executing. A forged or replayed callback MUST NOT cause execution.
+- **Expiry.** Before an execution claim, after expiry the server MUST stop honoring the
+  approval and durably fence the task against a late approval or callback; the claim is the
+  enforcement point, so an approval valid at the claim carries through (see Completion).
+- **At-most-once execution.** A durable execution claim guards against a crash re-invoking a
+  side-effecting tool, with `outcome-unknown` when the result cannot be confirmed;
+  cross-task deduplication is best-effort.
+- **Untrusted model-facing text.** `statusMessage` and `model-immediate-response` MUST be
+  sanitized, and a pending task MUST NOT be presented as completed.
+- **Approval-request amplification.** Approval fatigue is a known bypass; deployments MUST
+  rate-limit submission per caller and SHOULD bound outstanding pending tasks, returning a
+  non-requestable denial on a limit so the agent does not retry-loop.
+- **Out-of-band resolution.** Authentication, eligibility, and separation of duties for
+  whoever decides are the backend's, outside MCP.
+- **Durable sensitive state.** Crash recovery and delayed execution require persisting the
+  submission body, requester context, and complete tool arguments, which may hold
+  credentials, payment details, PII, and approval-binding artifacts. The server MUST protect
+  these records for confidentiality and integrity, scope access to the owning task, keep them
+  out of ordinary logs, and delete them when the task's retention ends. It SHOULD NOT persist
+  bearer credentials inside arguments; where unavoidable, they MUST be encrypted and held for
+  the minimum lifetime.
 
 ## References
 
 - [SEP-2663: Tasks Extension](./2663-tasks-extension.md)
 - [SEP-2322: Multi Round-Trip Requests](./2322-MRTR.md)
 - [SEP-2133: Extensions](./2133-extensions.md)
-- [OpenID AuthZEN Access Request and Approval Profile](https://openid.github.io/authzen/authzen-access-request-approval-profile-1_0.html)
+- [SEP-2575: Stateless MCP](./2575-stateless-mcp.md)
+- [SEP-2567: Sessionless MCP](./2567-sessionless-mcp.md)
+- [SEP-2260: Associate server requests with client requests](./2260-Require-Server-requests-to-be-associated-with-Client-requests.md)
+- [SEP-2643: Structured Authorization Denials](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2643) (open PR; this extension composes it once it lands, see Limitations)
+- [OpenID AuthZEN Access Request and Approval Profile](https://openid.github.io/authzen/authzen-access-request-approval-profile-1_0.html) — the example backend binding
 - [OpenID AuthZEN Authorization API 1.0](https://openid.github.io/authzen/)

--- a/docs/seps/index.mdx
+++ b/docs/seps/index.mdx
@@ -12,8 +12,8 @@ Specification Enhancement Proposals (SEPs) are the primary mechanism for proposi
 
 ## Summary
 
+- **Draft**: 5
 - **Final**: 32
-- **Draft**: 4
 - **Accepted**: 4
 - **In-review**: 1
 
@@ -21,6 +21,7 @@ Specification Enhancement Proposals (SEPs) are the primary mechanism for proposi
 
 | SEP                                                                                  | Title                                                                         | Status                                               | Type             | Created    |
 | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- | ---------------------------------------------------- | ---------------- | ---------- |
+| [SEP-2848](/seps/2848-asynchronous-approval-for-tool-calls)                          | Asynchronous Approval for Tool Calls                                          | <Badge color="gray" shape="pill">draft</Badge>       | Extensions Track | 2026-06-02 |
 | [SEP-2663](/seps/2663-tasks-extension)                                               | Tasks Extension                                                               | <Badge color="green" shape="pill">Final</Badge>      | Extensions Track | 2026-04-27 |
 | [SEP-2596](/seps/2596-spec-feature-lifecycle-and-deprecation)                        | Specification Feature Lifecycle and Deprecation Policy                        | <Badge color="gray" shape="pill">Draft</Badge>       | Process          | 2026-04-17 |
 | [SEP-2577](/seps/2577-deprecate-roots-sampling-and-logging)                          | Deprecate Roots, Sampling, and Logging                                        | <Badge color="green" shape="pill">Final</Badge>      | Standards Track  | 2026-04-14 |

--- a/seps/2848-asynchronous-approval-for-tool-calls.md
+++ b/seps/2848-asynchronous-approval-for-tool-calls.md
@@ -1,0 +1,688 @@
+# SEP-2848: Asynchronous Approval for Tool Calls
+
+- **Status**: draft
+- **Type**: Extensions Track
+- **Created**: 2026-06-02
+- **Author(s)**: Karl McGuinness
+- **Sponsor**: None (seeking sponsor)
+- **PR**: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2848
+
+## Abstract
+
+This SEP defines an extension that lets an MCP server gate a tool call on
+out-of-session approval without holding the session open. When a server's
+authorization decision is a denial that is _requestable_ (something can still
+approve it), the server returns a task handle ([SEP-2663](./2663-tasks-extension.md),
+the `io.modelcontextprotocol/tasks` extension) in place of the tool result,
+instead of failing the call. What approves is up to the deployment: a human
+reviewer, a supervising agent, an automated policy or risk engine, an external
+ITSM or IGA system, or a combination. The task stays `working` while that workflow
+runs over seconds, minutes, hours, or days; on approval the server re-checks
+policy and executes the tool, and the result becomes available through `tasks/get`.
+The approval protocol runs entirely on the server's backend (referencing the
+OpenID AuthZEN Access Request and Approval Profile) and never appears on the MCP
+wire. The client sees only a server-generated task ID it can poll and cancel, and
+never handles an authorization artifact. The bridge is binding AuthZEN's portable
+task handle to a durable MCP task ID, so a poll resumes after the server or the
+calling agent restarts; resumption by a _different_ principal is constrained by
+MCP's task-access model and is treated under Limitations. The feature is an
+experimental extension per [SEP-2133](./2133-extensions.md), layered on the tasks
+extension.
+
+## Motivation
+
+A requestable denial is resolved by whatever the deployment's approval workflow
+designates. That resolver is often _not_ a human: it may be a supervising agent
+applying a budget, an automated policy or risk engine that re-checks once
+conditions change, an external ticketing or identity-governance system, or a human
+reviewer, or several of these in sequence. The constant is not who decides; it is
+that the decision happens **out of band and asynchronously**, and may outlive the
+request, the connection, and even the process that made the call.
+
+MCP can represent asynchronous execution (the tasks extension, SEP-2663) and
+connection-level authorization (OAuth 2.1), and per-tool-call policy can be
+externalized (for example, the OpenID AuthZEN profile). What is missing is the
+binding that says a tool call is _denied now but approvable later, by something
+else_, and that ties the pending decision to a durable task the client can come
+back to.
+
+Tasks gives the durable, pollable primitive, but says nothing about _why_ a task
+is pending or how a policy decision resolves it. The in-session input paths
+(multi round-trip input requests, and historically elicitation and sampling) all
+target the principal driving the current session and do not survive a disconnect;
+they cannot model a decision made by a different party, on a different timeline,
+through a different channel. Without this extension, a server facing a requestable
+denial either fails the call and loses the workflow, or blocks until something
+times out.
+
+The OpenID AuthZEN Access Request and Approval Profile already defines the approval
+lifecycle (a requestable denial, an access request, a portable task handle, and
+re-evaluation that keeps the policy decision point authoritative at enforcement
+time), and its task handle is designed to survive restart (cross-principal handoff
+is treated under Limitations).
+This SEP binds that handle to an MCP task so the approval workflow becomes a
+first-class, pollable MCP object, regardless of what resolves it, and defines the
+narrow, MCP-observable server behavior that connects the two.
+
+### Use cases
+
+The resolver differs by deployment; the MCP-facing shape is identical in all of
+them:
+
+- **Human reviewer.** An agent calls `wire_transfer` above a threshold; a treasury
+  manager approves out of band, possibly the next day. The agent hands off and a
+  later poll returns the executed result.
+- **Supervising agent or orchestrator.** A worker agent requests a scope; a
+  supervisor agent (or a planner holding the budget) approves programmatically in
+  seconds, with no human involved.
+- **Automated policy or risk engine.** The first call is denied because a risk
+  signal is elevated or a grant has not provisioned yet; an automated re-check
+  approves once the condition clears, no human action.
+- **External ITSM or IGA system.** The access request becomes a ServiceNow change
+  or an identity-governance request; its existing approval rules (which may be
+  fully automated) decide, and MCP reflects the outcome.
+- **Four-eyes or break-glass.** A second, different principal (human or a
+  designated approver service) must authorize a sensitive operation, audited end to
+  end by the approval service.
+
+For the no-human resolvers (supervising agent, policy or risk engine, external
+system), there is no present session: submission input is filled by the agent itself
+against the request schema, and the approval decision is made fully out of band (see
+Collecting submission input).
+
+## Specification
+
+### Relationship to existing specifications
+
+This SEP composes existing pieces and adds the binding between them:
+
+- **SEP-2663 (Tasks extension, `io.modelcontextprotocol/tasks`)** supplies the
+  durable, pollable primitive: server-directed `CreateTaskResult`
+  (`resultType: "task"`), the methods `tasks/get`, `tasks/update`, and
+  `tasks/cancel`, `notifications/tasks`, and the statuses `working`,
+  `input_required`, `completed`, `failed`, `cancelled`.
+- **SEP-2322 (Multi Round-Trip Requests)** supplies the in-task input channel
+  (`inputRequests` / `inputResponses`) used for submission-time input.
+- **SEP-2133 (Extensions)** supplies the extension and capability framing.
+- **OpenID AuthZEN Access Request and Approval Profile** supplies the approval
+  lifecycle (requestable denial context, access request submission, the portable
+  task handle, and re-evaluation via `context.approval`). A companion AuthZEN MCP
+  profile (COAZ) maps a `tools/call` to an AuthZEN Access Evaluation; COAZ is itself a
+  draft, so the `tools/call`-to-evaluation mapping is not yet stable.
+
+The MCP server is the Policy Enforcement Point (PEP) and is the _only_ party that
+speaks the approval protocol. The client speaks ordinary MCP. AuthZEN is the
+reference approval backend; the MCP-observable behavior in this SEP does not depend
+on AuthZEN internals and could be satisfied by another backend that provides an
+equivalent durable handle and re-evaluation guarantee.
+
+The composition order is:
+
+1. the server evaluates every `tools/call` as an AuthZEN Access Evaluation (the COAZ
+   mapping);
+2. a requestable denial enters the Access Request lifecycle: submit the access
+   request, bind the approval handle to the MCP `taskId`, and return a `working` task;
+3. on resolution the server re-evaluates with `context.approval`;
+4. that decision is final: an approval is an input to a new decision, not a standing
+   grant.
+
+### Server-side flow (informative)
+
+The exchange below is non-normative and shows how the approval protocol sits behind
+a single MCP task. Nothing in it is part of the MCP wire contract: the only MCP
+messages are between the Client and the Server.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as MCP Server (PEP)
+    participant P as Policy Decision Point
+    participant A as Approval Service
+
+    C->>S: tools/call
+    S->>P: Access Evaluation
+    P-->>S: deny + context.access_request (requestable)
+    S->>A: submit Access Request (binding_token)
+    A-->>S: task handle (bound to MCP taskId)
+    S-->>C: CreateTaskResult (resultType: "task", status: working)
+    Note over P,A: Out-of-band resolution<br/>(human, agent, policy, or external system)
+    A-->>S: approved (callback or poll)
+    S->>P: re-evaluate (context.approval)
+    P-->>S: allow
+    S->>S: execute tool; task = completed (result available)
+    C->>S: tasks/get
+    S-->>C: CompletedTask with result (CallToolResult)
+```
+
+Everything to the right of the MCP Server (the Policy Decision Point and Approval
+Service exchanges) is internal to the PEP and never crosses the MCP boundary. The
+AuthZEN constructs shown (`context.access_request`, `binding_token`, the task
+handle, and `context.approval`) are specified by the OpenID AuthZEN Access Request
+and Approval Profile and are referenced, not redefined, by this SEP.
+
+### Extension identifier and capability
+
+The feature is an experimental extension with identifier
+`net.openid.authzen/tool-approval` (reversed-domain prefix per SEP-2133;
+illustrative, to be confirmed with the owning group).
+
+This extension builds on the tasks extension, so a server MUST also support
+`io.modelcontextprotocol/tasks`. Both are declared in the server's `extensions`
+capability:
+
+```json
+{
+  "capabilities": {
+    "extensions": {
+      "io.modelcontextprotocol/tasks": {},
+      "net.openid.authzen/tool-approval": { "version": "0.1" }
+    }
+  }
+}
+```
+
+Per SEP-2663, task creation is **server-directed**: a client does not flag a
+request for task execution. A client signals that it can receive task handles by
+declaring the `io.modelcontextprotocol/tasks` extension in its per-request
+capabilities (SEP-2663 / SEP-2575); the server then decides per request whether to
+return a `CreateTaskResult`. A client that has not declared the tasks extension and
+issues a call the server can only satisfy through approval MUST receive either:
+
+- a `-32003` (Missing Required Client Capability) error naming
+  `io.modelcontextprotocol/tasks`, which a tasks-capable client reads as "re-issue the
+  call with the capability declared"; or
+- a normal `CallToolResult` with `isError: true` carrying requestable guidance in its
+  content (a degraded path with no asynchronous resume), for clients that will not
+  speak the tasks extension.
+
+`-32003` is a capability-negotiation error, not an "access is requestable" signal: an
+agent reads it as "I did not declare something," not "go obtain access." A server that
+wants today's non-tasks agents to act on a requestable denial SHOULD prefer the
+degraded `CallToolResult` and include machine-readable next-step guidance (see the
+client-maturity note).
+
+Declaring `net.openid.authzen/tool-approval` is an optional client signal that it
+understands approval semantics (for example, to render approval-specific progress
+UI). Correct behavior does not require it: an approval-gated task is an ordinary
+tasks-extension task, and a client that supports only `io.modelcontextprotocol/tasks`
+already interoperates.
+
+> **Client maturity (non-normative).** The canonical flow requires a client that
+> declares and drives `io.modelcontextprotocol/tasks` (receives `CreateTaskResult`,
+> polls `tasks/get`). That capability is experimental (SEP-2663) and, at the time of
+> writing, is not present in shipping MCP clients, whose task support is server-side.
+> End-to-end value is therefore gated on client tasks adoption, and interop testing
+> needs a purpose-built tasks client (the Reference Implementation clause requires
+> one). During the gap, servers may also expose approval as ordinary tools (for
+> example `request_access` / `get_request_status`) so today's agents can self-drive
+> request-poll-retry without tasks support. This SEP does not standardize that interim
+> shape, but a server that adopts it SHOULD carry the same machine-readable next-step
+> fields the Access Request profile already defines (a next-step hint, the request
+> schema, and a poll-interval hint) so interim shapes interoperate.
+
+### Denied-but-requestable returns a task
+
+When the server evaluates a `tools/call` against its policy decision point and the
+decision is "deny":
+
+1. If the denial is **not** requestable (no approval can change it), the server
+   returns the normal denied tool result: a `CallToolResult` with `isError: true`
+   describing the denial, so the model can react. (Per SEP-2663, an `isError`
+   result delivered through a task is a `completed` task, not a `failed` one.)
+2. If the denial **is** requestable, and the client declared the tasks extension,
+   the server MUST NOT execute the tool. Instead it:
+   - submits an access request to the approval service on the caller's behalf and
+     obtains a durable approval task handle;
+   - creates a durable MCP task bound to that handle and returns a
+     `CreateTaskResult` (`resultType: "task"`) with `status: "working"` and a
+     human-readable `statusMessage` (for example, "Awaiting treasury approval");
+   - MAY include an `io.modelcontextprotocol/model-immediate-response` value in the
+     result `_meta` so the model receives an immediate string (for example,
+     "This action is pending approval; you can continue other work and check back").
+
+The server MUST NOT surface approval-binding material (the AuthZEN `binding_token`,
+`evaluation_id`, `approval` object, or access-request endpoints) to the client.
+These are internal to the PEP.
+
+**At-most-once execution and deduplication.** Because the server controls both task
+creation and tool execution, it MUST execute the approved tool at most once per task.
+To keep a client retry (after a poll timeout or an agent restart) from creating a
+second approval task, and thus a second execution, the server SHOULD return the
+existing task's `CreateTaskResult` when it recognizes a repeated requestable denial
+within one dedup scope: the same **originating authorization context** (the
+authenticated caller or subject the task is bound to), the same tool, and the same
+arguments. This correlation is inherently best-effort: if the arguments carry a
+client-local value (a nonce or timestamp) two genuine retries will not match, and if
+they do not, two distinct intents with identical arguments will collide. MCP today
+has no general request-level idempotency key that would make it exact (see
+Limitations), so deployments needing exactness must wait for one.
+
+Deduplication applies only while the prior task is non-terminal. After a task reaches
+a terminal disposition (including `denied-not-executed`), an identical `tools/call`
+MUST start a **new** access request and a new task; the terminal denial was final and
+MUST NOT be folded into the old task.
+
+**Retention.** The server MUST keep the task resolvable through `tasks/get` for the
+full approval window: it MUST NOT delete or expire a `working` approval task before
+the approval's expiry, and `ttlMs` MUST cover the approval window plus the server's
+result-retention period. The approval service often sets or extends the window after
+submission, so the creation-time `ttlMs` is provisional: when the server learns a
+later expiry, it MUST extend `ttlMs` (reported on `tasks/get` and
+`notifications/tasks`) so a `working` task is never expired before the current known
+approval expiry. A server SHOULD bound the maximum approval window it accepts so
+pending tasks do not accumulate without limit.
+
+**Model-facing text is untrusted and non-committal.** `statusMessage` and any
+`io.modelcontextprotocol/model-immediate-response` value are fed to the model and
+MUST NOT carry unsanitized text from untrusted sources (agent-supplied rationale,
+approver free-text); they are a prompt-injection surface. A `working` or
+`input_required` approval task MUST NOT be represented to the model as a completed
+action; if `model-immediate-response` is used, it MUST make clear the action has not
+yet occurred and may still be denied.
+
+### The task handle is not authority
+
+The `taskId` is a reference to a pending decision, never a grant. Authority is the
+PDP decision, re-derived at execution against the original call envelope (see
+Completion). Possessing a `taskId` does not authorize execution.
+
+When it creates the task, the server MUST retain a binding record and MUST check it
+before executing. The record MUST include at least:
+
+- the task id;
+- the tool name;
+- a canonical digest of the arguments;
+- the requester principal (and session, where applicable);
+- the subject or resource being acted on;
+- the approval request id;
+- the disposition;
+- the expiry / freshness window.
+
+The server MAY also record the policy id and version for audit and drift detection;
+this is recorded, not pinned (see Completion).
+
+**Envelope match or new approval.** At execution time the server MUST compare the
+current call against the bound envelope. If the tool, arguments, requester principal,
+or subject/resource differ, the task MUST resolve `denied-not-executed` with no side
+effect, and the changed call requires a new access request. An approval is bound to
+the exact envelope that produced the requestable denial; it never carries over to a
+different or mutated call.
+
+### Collecting submission input
+
+The access request may require inputs from the requester before or during the
+approval: a justification, a ticket reference, or fields the approval service
+defines (the AuthZEN profile's `request_schema_url`, `form_url`, and
+`request_catalogs_url`). The server collects these over the tasks input channel
+(SEP-2322 multi round-trip requests), not a standalone `elicitation/create`, since
+SEP-2260 disallows unsolicited server-to-client requests and SEP-2663 routes task
+input through `inputRequests` / `tasks/update`:
+
+- **Before submission (synchronous).** The server returns `resultType:
+"input_required"` on the original `tools/call`, collects the inputs, then returns a
+  `CreateTaskResult` and submits the access request. Use this when the approval
+  service will not accept the request without them.
+- **During the workflow (in-task).** The server sets the task to `input_required`
+  with the outstanding `inputRequests` (for example, an approver asks for more
+  detail, or a catalog-backed field is resolved after submission); the client answers
+  with `inputResponses` via `tasks/update`, and the task returns to `working`.
+
+Who answers is a property of the client, not this extension. An interactive client
+renders the request for a human (the profile's `form_url` case); an autonomous agent
+client MAY answer it from context against the request schema (the
+`request_schema_url` case), resolving catalog-backed fields per
+`request_catalogs_url`. The server derives the `inputRequests` schema from those
+profile fields. Either way this is submission-time input that shapes the access
+request; it is distinct from the approval decision, which is made out of band by a
+party (human or automated) not assumed to be reachable through the session.
+
+An in-task `input_required` round-trip requires a connected client: an agent that
+submitted and then disconnected or restarted cannot answer a later `inputRequests`.
+Deployments that expect long gaps between submission and approval SHOULD collect all
+inputs synchronously before submission. The mapping from the profile's
+`request_schema_url` (a JSON Schema) onto the SEP-2322 `inputRequests` schema is not
+pinned by this SEP and is currently implementation-specific; two servers MAY produce
+different `inputRequests` for the same access request until a canonical mapping is
+defined.
+
+### Approval lifecycle maps onto task status
+
+| Approval-profile state                                           | MCP task status                                                 |
+| ---------------------------------------------------------------- | --------------------------------------------------------------- |
+| Access request submitted, awaiting a decision                    | `working`                                                       |
+| Submission needs input from the requester (human or agent)       | `input_required`                                                |
+| Approved, re-evaluated to "allow", tool executed (once)          | `completed`, disposition `approved-executed`                    |
+| Terminal denial (rejected, revoked, expired, or not executed)    | `completed`, `isError: true`, disposition `denied-not-executed` |
+| Approved and executed, but the tool itself errored               | `completed`, `isError: true`, disposition `execution-error`     |
+| Server could not produce a tool result at all (protocol failure) | `failed`                                                        |
+| Client cancelled                                                 | `cancelled`                                                     |
+
+A terminal authorization denial is an outcome of the call, not a failure of the
+task machinery, so it is a `completed` task whose `result` is a `CallToolResult`
+with `isError: true` and disposition `denied-not-executed`. That disposition lets a
+consumer distinguish a denial (no side effect occurred) from an `execution-error`
+(the tool ran and a side effect may have occurred). `failed` is reserved for cases
+where the server could not produce a tool result at all.
+
+While `working`, the server tracks the approval by polling the approval service's
+status endpoint or by receiving its callback. The MCP `taskId` and the approval
+task handle are bound for the task's lifetime, so a server that restarts can
+rehydrate the task from the persisted handle and keep serving `tasks/get`. Both the
+tasks extension and the AuthZEN task handle are durable by design, which is what
+makes resolution that outlives the session possible.
+
+### Completion: re-evaluate, then execute
+
+On approval, the server MUST perform a fresh authorization evaluation that takes the
+approval as an input (for AuthZEN, placing the `approval` object at
+`context.approval`), so the policy decision point remains authoritative at
+enforcement time. An approval is an input to a new decision, not a standing grant.
+This re-evaluation is server-internal and is not observable on the MCP wire.
+
+The re-evaluation runs against the bound call envelope (see The task handle is not
+authority) and current policy. The recorded policy version is for audit and drift
+detection, not pinning: a policy change yields a fresh allow-or-deny rather than an
+automatic denial, so an approval still valid under current policy proceeds. Envelope
+fields (tool, arguments, requester principal, subject/resource) are an exact-match
+binding; a mismatch resolves `denied-not-executed` and requires a new approval.
+
+Because execution can occur long after the original request, the server SHOULD
+verify at execution time that the captured arguments and any downstream credential
+it must use are still valid. If a required credential has expired, or the action is
+materially stale, the server SHOULD NOT execute: it completes the task as a denial
+(disposition `denied-not-executed`) or returns a fresh requestable denial so the
+caller can resubmit.
+
+The terminal outcome MUST be distinguishable so a consumer can tell whether a side
+effect occurred. Because a client that supports only `io.modelcontextprotocol/tasks`
+does not understand this extension's `_meta`, the distinction MUST be carried in the
+`CallToolResult` itself, not only in `_meta`: the result `content` (and
+`structuredContent` where used) MUST state plainly whether the tool executed, so the
+model behind any tasks client reads "denied, the tool did not run" and does not
+blindly retry. A `net.openid.authzen/disposition` value in the result `_meta` is the
+machine-readable companion for extension-aware consumers. The body and the `_meta`
+disposition MUST agree:
+
+- **allow**: the server executes the tool exactly once and moves the task to
+  `completed`; the `tasks/get` response carries the tool's `CallToolResult` in the
+  task's `result` field. `_meta` disposition `approved-executed`.
+- **deny** at re-evaluation (policy changed, approval unverifiable, expired with no
+  re-request path), or a freshness or credential failure that prevented execution:
+  the task is `completed` with an `isError: true` `CallToolResult` whose content says
+  the tool did not run; `_meta` disposition `denied-not-executed`.
+- **execution error**: the tool was authorized and ran but failed; `isError: true`
+  with content describing the failure and `_meta` disposition `execution-error`, since
+  a side effect may have occurred.
+
+The server MUST bound any downstream credential, cached result, or follow-on
+authorization by the approval's expiry.
+
+### Cancellation
+
+A `tasks/cancel` request MUST cause the server to cancel the underlying access
+request and move the task to `cancelled`. Per SEP-2663, `notifications/cancelled`
+MUST NOT be used to cancel a task.
+
+A cancel can arrive after approval but before the tool has executed. To avoid
+ambiguity about whether a side effect occurred, the server resolves the race by the
+execution boundary: if it has not begun executing the tool, it MUST honor the cancel,
+skip execution, and move the task to `cancelled` (no side effect); once execution has
+begun, the cancel is ineffective and the task completes with its normal disposition.
+The server MUST NOT both execute the tool and report `cancelled`.
+
+### What the client carries
+
+The client carries a server-generated `taskId` only. It MUST NOT be required to
+read, store, or forward any authorization artifact. A client that supports the tasks
+extension already interoperates with an approval-gated server: it must already be
+prepared to receive a `CreateTaskResult` for any supported request, and it observes
+a task that stays `working` and then becomes `completed` (or `failed`/`cancelled`).
+This extension adds meaning, not new client wire format. Because the
+denied-versus-executed distinction is carried in the `CallToolResult` body (see
+Completion) and not only in `_meta`, a tasks-only client's model can act on it safely;
+without that rule a tasks-only client could not tell a denial from an execution error
+and could double-execute a side-effecting tool on retry.
+
+### End-to-end example
+
+Client calls a tool (the client has declared the `io.modelcontextprotocol/tasks`
+extension in its per-request capabilities):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "wire_transfer",
+    "arguments": { "to": "acct-991", "amount": 50000 }
+  }
+}
+```
+
+The server evaluates, gets a requestable denial, submits the access request, and
+returns a task handle in place of the tool result:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "resultType": "task",
+    "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840",
+    "status": "working",
+    "statusMessage": "Transfers over $25,000 require treasury approval.",
+    "createdAt": "2026-06-02T10:30:00Z",
+    "ttlMs": 604800000,
+    "pollIntervalMs": 15000,
+    "_meta": {
+      "io.modelcontextprotocol/model-immediate-response": "This transfer is pending treasury approval. You can continue other work and check back."
+    }
+  }
+}
+```
+
+After the approval workflow resolves out of band (whether a human acts the next day
+or an automated re-check clears in seconds), the server re-evaluates and executes.
+A later poll returns the completed task with the tool result:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "method": "tasks/get",
+  "params": { "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840" }
+}
+```
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "result": {
+    "resultType": "complete",
+    "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840",
+    "status": "completed",
+    "createdAt": "2026-06-02T10:30:00Z",
+    "lastUpdatedAt": "2026-06-03T09:05:00Z",
+    "ttlMs": 604800000,
+    "result": {
+      "content": [
+        { "type": "text", "text": "Transfer of $50,000 to acct-991 completed." }
+      ],
+      "isError": false
+    }
+  }
+}
+```
+
+## Rationale
+
+**Server-directed creation makes the client trivial.** Under SEP-2663 a client that
+supports tasks must already handle a `CreateTaskResult` for any call, and the server
+alone decides when to return one. An approval-gated server therefore needs no new
+client wire format and no per-tool opt-in: it returns a task exactly when it hits a
+requestable denial. This is the strongest property of the design and aligns with
+"Interoperability over optimization" (graceful degradation through capability
+negotiation).
+
+**Build on the tasks extension rather than invent a primitive.** Tasks already
+provides a durable state machine with polling, cancellation, input, and retention.
+An approval workflow is a long-running task, and the approval profile's portable
+handle provides the durability guarantee the binding needs. Aligns with
+"Composability over specificity."
+
+**Resolver-agnostic by construction.** Because approval is brokered server-side and
+surfaced only as task status, the MCP-facing contract is identical whether a human,
+a supervising agent, a policy engine, or an external system decides. The SEP does
+not encode "human in the loop"; it encodes "decided out of band, asynchronously,"
+which serves fully automated and fully manual deployments alike.
+
+**Why an extension.** Per SEP-2133, optional capabilities that build on the core and
+need time to incubate belong as extensions; "extensions are where convergence gets
+tested." This feature layers on another extension and is not universally needed, so
+it starts experimental on the Extensions Track. It is an extension rather than
+Informational guidance because it defines normative, wire-observable behavior that
+plain tasks does not: a requestable denial MUST return a task, the
+denied-versus-executed distinction MUST be carried in the `CallToolResult` body (with
+a `net.openid.authzen/disposition` `_meta` companion), and authorization artifacts
+MUST NOT cross the wire. Those rules, not mere discovery, are what earns a capability.
+If the body-convey rule were dropped and the signal left optional in `_meta`, the
+value would collapse to a discovery hint and Informational guidance would be the
+better home.
+
+**Why submission input uses the task input channel.** SEP-2260 disallows unsolicited
+server-to-client requests, and SEP-2663 routes in-task input through MRTR
+(`inputRequests` / `tasks/update`) rather than standalone elicitation. Submission
+input therefore flows through the task, not a separate elicitation call.
+
+## Limitations and Open Questions
+
+- **Resumption by a different principal is not portable at the MCP layer.** The
+  AuthZEN task handle can be polled by any caller authorized for the bound subject,
+  but MCP task access is bound to a server-defined originating authorization context,
+  `tasks/list` was removed, and sessions were removed (SEP-2567), so there is no
+  standard way for a _different_ principal, or the same agent on a new connection with
+  a new credential, to reclaim a task. Same-principal resumption across restart works
+  to the extent the server's context binding recognizes the returning caller.
+  Defining a portable task-claim or re-authorization mechanism is open; until then,
+  deployments that need cross-principal handoff arrange it out of band.
+- **Someone has to come back and consume the result.** This SEP provides the
+  primitive, not the orchestration that resumes a paused agent and acts on the
+  completed task. For a side-effecting tool this matters: the tool may execute after
+  approval with no consumer observing the outcome. Deployments MUST ensure either a
+  durable consumer that polls or that the effect is independently auditable; a
+  fire-and-forget agent that never returns is a misuse, not a supported pattern.
+- **A lost `taskId` has no protocol recourse.** With `tasks/list` and sessions both
+  removed (SEP-2663 / SEP-2567), an agent that restarts without having persisted its
+  `taskId` cannot rediscover a possibly-executed side-effecting task. Clients MUST
+  persist task IDs to durable storage; there is no protocol-level recovery.
+- **No general request idempotency in MCP.** MCP has no request-level idempotency
+  key (only the `idempotentHint` tool annotation, which describes a tool rather than
+  deduplicating a call), so the server's duplicate suppression is best-effort
+  (matching the originating context, tool, and arguments). A general idempotency
+  mechanism belongs in the core protocol or the tasks extension, not in an approval
+  extension; if one is added, this extension should adopt it. Defining one here is
+  out of scope.
+- **Extension versus Informational (resolved, flagged for the sponsor).** Much of the
+  behavior can be built on the tasks extension alone. This SEP takes it as an
+  extension because the body-convey denied-versus-executed rule, the mandatory task on
+  a requestable denial, and the `disposition` signal are normative wire-observable
+  behavior, not just discovery (see Rationale). A sponsor who judges that surface too
+  thin may prefer an Informational SEP; that is the one positioning question left
+  open.
+
+## Backward Compatibility
+
+Additive for new tools and new servers. A client that supports the tasks extension but
+not this one still observes a valid task lifecycle and a final
+`completed`/`failed`/`cancelled` task; there is no new client wire format, and no
+per-tool opt-in to change.
+
+For an existing tool that previously returned a synchronous denial, however, enabling
+approval gating changes the `tools/call` response set seen by existing integrations: a
+tasks client now receives a `CreateTaskResult`, and a non-tasks client receives
+`-32003` or the degraded requestable `CallToolResult` where a plain denial used to
+appear. That is a behavior change for upgraders, not a purely additive one.
+
+## Reference Implementation
+
+Required before Final (this introduces observable protocol behavior). Planned:
+
+- an MCP server that fronts an OpenID AuthZEN policy decision point and access
+  request service, returning `CreateTaskResult` for approval-gated calls and
+  re-evaluating before execution, with at least one human-resolved and one
+  automatically-resolved approval path;
+- a client built only on the `io.modelcontextprotocol/tasks` extension, to
+  demonstrate that it interoperates with no approval-specific code.
+
+A conformance scenario tagged with the assigned SEP number, plus a `sep-NNNN.yaml`
+traceability file, is required for Final. The traceability file MUST cover these
+MCP-observable statements:
+
+- a requestable denial returns a task without executing the tool;
+- approval resumes execution at most once;
+- a terminal denial is a `completed` task whose `CallToolResult` body (not only
+  `_meta`) marks it `denied-not-executed`, distinct from an execution error;
+- a changed envelope (tool, arguments, principal, or subject/resource) requires a new
+  approval;
+- a cancelled or expired task cannot later execute;
+- result retrieval does not expose backend approval artifacts;
+- submission input flows through the task input channel.
+
+Server-internal behavior such as re-evaluation is referenced from the AuthZEN profile
+and is not MCP-observable. Not yet built.
+
+## Security Implications
+
+- **Denial remains denial.** The server MUST NOT execute on the requestable denial
+  alone, and MUST re-evaluate after approval. The policy decision point is
+  authoritative at enforcement time.
+- **Authorization artifacts stay server-side.** Binding material (`binding_token`,
+  `approval`, `evaluation_id`) is never exposed to the client, preventing replay or
+  substitution through the client surface.
+- **The task handle is not a bearer approval token.** The `taskId` references a
+  pending decision; the server MUST re-derive authority from the bound call envelope
+  and current policy at execution (see The task handle is not authority), so holding a
+  `taskId` never authorizes execution of a different or mutated call.
+- **Task access control.** A `taskId` lets a caller poll and retrieve results.
+  SEP-2663 omits `tasks/list` precisely because tasks cannot always be bound to a
+  caller; task IDs are unguessable, single-task handles. The server MUST authorize
+  `tasks/get`, `tasks/update`, and `tasks/cancel` against the task's originating
+  authorization context, and MUST NOT leak approval contents or approver identity
+  through `statusMessage`.
+- **Confused deputy.** The server binds each task to the originally evaluated
+  subject, resource, action, and context, and applies an approval only within its
+  recorded scope. It MUST NOT let a client steer execution to a different operation
+  than the one that was approved.
+- **Out-of-band resolution.** Whoever or whatever decides (human, agent, policy
+  engine, external system), authentication, eligibility, and separation of duties are
+  properties of the approval service, outside MCP, as the approval profile specifies.
+- **Expiry.** The server MUST stop honoring an approval after its expiry and MUST
+  bound any downstream credential lifetime by it.
+- **Untrusted model-facing text.** `statusMessage` and `model-immediate-response` are
+  fed to the model and MUST be sanitized; a pending task MUST NOT be presented as a
+  completed action.
+- **At-most-once execution.** The server MUST execute an approved side-effecting tool
+  at most once per task and SHOULD deduplicate a retried requestable denial (by
+  originating context, tool, and arguments) so a poll timeout and replay cannot
+  double-execute.
+- **Approval-request amplification.** A compromised or buggy agent loop is the
+  expected failure mode here, not an edge case, and approval fatigue is a known
+  bypass. Deployments MUST rate-limit access-request submission per caller and SHOULD
+  bound the number of outstanding pending tasks per caller. When a limit is hit, the
+  server MUST return a non-requestable denial (a `CallToolResult` with `isError: true`,
+  not a task and not a requestable signal) so the agent does not retry-loop.
+- **The client cannot verify the gate.** "Denial remains denial" is enforced by the
+  server; the client receives no proof that the server re-evaluated rather than
+  executed. The binding material protects the server-to-PDP-to-approval-service path,
+  not the client's trust in the server. Clients needing stronger assurance must
+  obtain it out of band.
+
+## References
+
+- [SEP-2663: Tasks Extension](./2663-tasks-extension.md)
+- [SEP-2322: Multi Round-Trip Requests](./2322-MRTR.md)
+- [SEP-2133: Extensions](./2133-extensions.md)
+- [OpenID AuthZEN Access Request and Approval Profile](https://openid.github.io/authzen/authzen-access-request-approval-profile-1_0.html)
+- [OpenID AuthZEN Authorization API 1.0](https://openid.github.io/authzen/)

--- a/seps/2848-asynchronous-approval-for-tool-calls.md
+++ b/seps/2848-asynchronous-approval-for-tool-calls.md
@@ -5,90 +5,55 @@
 - **Created**: 2026-06-02
 - **Author(s)**: Karl McGuinness
 - **Sponsor**: None (seeking sponsor)
+- **Working Group**: MCP Fine-Grained Authorization WG (proposed)
+- **Extension Maintainers**: TBD (required before review per SEP-2133)
 - **PR**: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2848
 
 ## Abstract
 
-This SEP defines an extension that lets an MCP server gate a tool call on
-out-of-session approval without holding the session open. When a server's
-authorization decision is a denial that is _requestable_ (something can still
-approve it), the server returns a task handle ([SEP-2663](./2663-tasks-extension.md),
-the `io.modelcontextprotocol/tasks` extension) in place of the tool result,
-instead of failing the call. What approves is up to the deployment: a human
-reviewer, a supervising agent, an automated policy or risk engine, an external
-ITSM or IGA system, or a combination. The task stays `working` while that workflow
-runs over seconds, minutes, hours, or days; on approval the server re-checks
-policy and executes the tool, and the result becomes available through `tasks/get`.
-The approval protocol runs entirely on the server's backend (referencing the
-OpenID AuthZEN Access Request and Approval Profile) and never appears on the MCP
-wire. The client sees only a server-generated task ID it can poll and cancel, and
-never handles an authorization artifact. The bridge is binding AuthZEN's portable
-task handle to a durable MCP task ID, so a poll resumes after the server or the
-calling agent restarts; resumption by a _different_ principal is constrained by
-MCP's task-access model and is treated under Limitations. The feature is an
-experimental extension per [SEP-2133](./2133-extensions.md), layered on the tasks
-extension.
+This SEP defines an extension that lets an MCP server gate a tool call on an out-of-band
+approval without keeping the original request open. When the server's authorization decision is a
+denial that is _requestable_ (something can still approve it), the server returns a task
+handle ([SEP-2663](./2663-tasks-extension.md)) in place of the tool result instead of
+failing the call. The task stays `working` while the deployment's resolver decides out of band; on approval
+the server re-checks policy, executes the tool, and makes the result available through
+`tasks/get`.
+
+The approval protocol runs on the server's approval backend and never crosses the MCP
+wire: the client sees only a task ID it can poll and cancel, and handles no authorization
+artifact. Binding the backend's durable, resumable handle to a durable MCP task ID lets a
+poll resume after a restart. The backend is pluggable, with the OpenID AuthZEN Access
+Request and Approval Profile (ARAP) as a worked example (see Example binding). The feature
+is an experimental extension per [SEP-2133](./2133-extensions.md), layered on tasks.
 
 ## Motivation
 
-A requestable denial is resolved by whatever the deployment's approval workflow
-designates. That resolver is often _not_ a human: it may be a supervising agent
-applying a budget, an automated policy or risk engine that re-checks once
-conditions change, an external ticketing or identity-governance system, or a human
-reviewer, or several of these in sequence. The constant is not who decides; it is
-that the decision happens **out of band and asynchronously**, and may outlive the
-request, the connection, and even the process that made the call.
-
-MCP can represent asynchronous execution (the tasks extension, SEP-2663) and
-connection-level authorization (OAuth 2.1), and per-tool-call policy can be
-externalized (for example, the OpenID AuthZEN profile). What is missing is the
-binding that says a tool call is _denied now but approvable later, by something
-else_, and that ties the pending decision to a durable task the client can come
-back to.
-
-Tasks gives the durable, pollable primitive, but says nothing about _why_ a task
-is pending or how a policy decision resolves it. The in-session input paths
-(multi round-trip input requests, and historically elicitation and sampling) all
-target the principal driving the current session and do not survive a disconnect;
-they cannot model a decision made by a different party, on a different timeline,
-through a different channel. Without this extension, a server facing a requestable
-denial either fails the call and loses the workflow, or blocks until something
-times out.
-
-The OpenID AuthZEN Access Request and Approval Profile already defines the approval
-lifecycle (a requestable denial, an access request, a portable task handle, and
-re-evaluation that keeps the policy decision point authoritative at enforcement
-time), and its task handle is designed to survive restart (cross-principal handoff
-is treated under Limitations).
-This SEP binds that handle to an MCP task so the approval workflow becomes a
-first-class, pollable MCP object, regardless of what resolves it, and defines the
-narrow, MCP-observable server behavior that connects the two.
+A requestable denial is resolved by whatever the deployment designates, often not a human,
+and sometimes several resolvers in sequence (see Use cases). What is constant is that the
+decision
+happens **out of band and asynchronously**, and may outlive the request, the connection,
+and the process that made the call. MCP already has asynchronous execution (tasks,
+SEP-2663), connection-level authorization (OAuth 2.1), and externalized per-call policy;
+what is missing is the binding that says a call is denied now but approvable later by
+something else, and ties that pending decision to a durable task. The input paths tied to
+the original request do not survive a disconnect, so without this binding a server facing a
+requestable
+denial either fails the call and loses the workflow, or blocks until something times out.
+This SEP defines the binding and the narrow, MCP-observable behavior around it.
 
 ### Use cases
 
-The resolver differs by deployment; the MCP-facing shape is identical in all of
-them:
+The MCP-facing shape is identical across resolvers:
 
-- **Human reviewer.** An agent calls `wire_transfer` above a threshold; a treasury
-  manager approves out of band, possibly the next day. The agent hands off and a
-  later poll returns the executed result.
-- **Supervising agent or orchestrator.** A worker agent requests a scope; a
-  supervisor agent (or a planner holding the budget) approves programmatically in
-  seconds, with no human involved.
-- **Automated policy or risk engine.** The first call is denied because a risk
-  signal is elevated or a grant has not provisioned yet; an automated re-check
-  approves once the condition clears, no human action.
-- **External ITSM or IGA system.** The access request becomes a ServiceNow change
-  or an identity-governance request; its existing approval rules (which may be
-  fully automated) decide, and MCP reflects the outcome.
-- **Four-eyes or break-glass.** A second, different principal (human or a
-  designated approver service) must authorize a sensitive operation, audited end to
-  end by the approval service.
+- **Human reviewer** approves out of band, possibly the next day (for example
+  `wire_transfer` above a threshold).
+- **Supervising agent or orchestrator** approves programmatically in seconds.
+- **Automated policy or risk engine** clears once a condition or grant provisions.
+- **External ITSM or IGA system** decides by its own, possibly automated, rules.
+- **Four-eyes or break-glass**: a second principal authorizes a sensitive operation.
 
-For the no-human resolvers (supervising agent, policy or risk engine, external
-system), there is no present session: submission input is filled by the agent itself
-against the request schema, and the approval decision is made fully out of band (see
-Collecting submission input).
+For the no-human resolvers there is no session, so submission input is filled by the agent
+against the backend's schema (see Collecting submission input).
 
 ## Specification
 
@@ -96,357 +61,441 @@ Collecting submission input).
 
 This SEP composes existing pieces and adds the binding between them:
 
-- **SEP-2663 (Tasks extension, `io.modelcontextprotocol/tasks`)** supplies the
-  durable, pollable primitive: server-directed `CreateTaskResult`
-  (`resultType: "task"`), the methods `tasks/get`, `tasks/update`, and
-  `tasks/cancel`, `notifications/tasks`, and the statuses `working`,
-  `input_required`, `completed`, `failed`, `cancelled`.
-- **SEP-2322 (Multi Round-Trip Requests)** supplies the in-task input channel
-  (`inputRequests` / `inputResponses`) used for submission-time input.
+- **SEP-2663 (Tasks extension, `io.modelcontextprotocol/tasks`)** supplies the durable,
+  pollable primitive: server-directed `CreateTaskResult` (`resultType: "task"`), the
+  methods `tasks/get`, `tasks/update`, `tasks/cancel`, `notifications/tasks`, and the
+  statuses `working`, `input_required`, `completed`, `failed`, `cancelled`.
+- **SEP-2322 (Multi Round-Trip Requests)** supplies the request round-trip channel
+  (`inputRequests` / `inputResponses` carried in `requestState`) for pre-task submission
+  input; in-task input uses SEP-2663's `tasks/update`.
 - **SEP-2133 (Extensions)** supplies the extension and capability framing.
-- **OpenID AuthZEN Access Request and Approval Profile** supplies the approval
-  lifecycle (requestable denial context, access request submission, the portable
-  task handle, and re-evaluation via `context.approval`). A companion AuthZEN MCP
-  profile (COAZ) maps a `tools/call` to an AuthZEN Access Evaluation; COAZ is itself a
-  draft, so the `tools/call`-to-evaluation mapping is not yet stable.
+- **SEP-2643 (Structured Authorization Denials)** supplies the portable denial
+  envelope, `io.modelcontextprotocol/authorization`, which classifies the failure and
+  states the remediation posture. A server that also implements SEP-2643 emits it as
+  the denial classification while a call is denied; this extension's
+  `io.modelcontextprotocol/tool-approval-disposition` carries the execution outcome.
+  Envelope behavior below applies only to servers that implement SEP-2643.
+- **An approval backend** supplies the approval lifecycle: it accepts an approval request
+  idempotently under a caller-supplied submission key, returns a durable resumable handle,
+  resolves the request out of band into a terminal state (granted, denied, expired,
+  cancelled, or failed), and on a grant returns approval material the server uses as an input
+  to re-evaluation. The server, not the backend, performs that re-evaluation through its
+  authorization decision so the decision stays authoritative. The backend bounds the approval
+  by an expiry and MAY support cancellation. This SEP references that abstract contract, not any single backend.
+  The OpenID AuthZEN ARAP is a worked example (see Example binding: AuthZEN ARAP).
 
-The MCP server is the Policy Enforcement Point (PEP) and is the _only_ party that
-speaks the approval protocol. The client speaks ordinary MCP. AuthZEN is the
-reference approval backend; the MCP-observable behavior in this SEP does not depend
-on AuthZEN internals and could be satisfied by another backend that provides an
-equivalent durable handle and re-evaluation guarantee.
+The MCP server is the Policy Enforcement Point (PEP) and the only party that speaks the
+approval protocol; the client speaks ordinary MCP. The backend is pluggable, and a
+deployment binds it to whatever provides the contract above. Whether the generic
+execution and disposition semantics should live here or move into SEP-2643 or the tasks
+extension is open (see Limitations).
 
 The composition order is:
 
-1. the server evaluates every `tools/call` as an AuthZEN Access Evaluation (the COAZ
-   mapping);
-2. a requestable denial enters the Access Request lifecycle: submit the access
-   request, bind the approval handle to the MCP `taskId`, and return a `working` task;
-3. on resolution the server re-evaluates with `context.approval`;
-4. that decision is final: an approval is an input to a new decision, not a standing
-   grant.
+1. the server evaluates every `tools/call` against its authorization policy;
+2. a requestable denial enters the approval lifecycle: submit the request, bind the
+   backend's handle to the MCP `taskId`, and return a `working` task;
+3. on resolution the server re-evaluates with the approval as an input;
+4. that decision is authoritative: an approval is an input to a new decision, not a
+   standing grant.
 
 ### Server-side flow (informative)
 
-The exchange below is non-normative and shows how the approval protocol sits behind
-a single MCP task. Nothing in it is part of the MCP wire contract: the only MCP
-messages are between the Client and the Server.
+Non-normative. The only MCP messages are between Client and Server; everything to the
+right of the server is internal to the PEP and never crosses the MCP boundary.
 
 ```mermaid
 sequenceDiagram
     participant C as Client
     participant S as MCP Server (PEP)
-    participant P as Policy Decision Point
-    participant A as Approval Service
+    participant P as Authorization decision
+    participant A as Approval backend
 
     C->>S: tools/call
-    S->>P: Access Evaluation
-    P-->>S: deny + context.access_request (requestable)
-    S->>A: submit Access Request (binding_token)
-    A-->>S: task handle (bound to MCP taskId)
+    S->>P: authorization check
+    P-->>S: deny, requestable
+    S->>A: submit approval request (binding material)
+    A-->>S: durable handle (bound to MCP taskId)
     S-->>C: CreateTaskResult (resultType: "task", status: working)
     Note over P,A: Out-of-band resolution<br/>(human, agent, policy, or external system)
-    A-->>S: approved (callback or poll)
-    S->>P: re-evaluate (context.approval)
+    A-->>S: resolved (callback or poll)
+    S->>P: re-evaluate with approval
     P-->>S: allow
     S->>S: execute tool; task = completed (result available)
     C->>S: tasks/get
     S-->>C: CompletedTask with result (CallToolResult)
 ```
 
-Everything to the right of the MCP Server (the Policy Decision Point and Approval
-Service exchanges) is internal to the PEP and never crosses the MCP boundary. The
-AuthZEN constructs shown (`context.access_request`, `binding_token`, the task
-handle, and `context.approval`) are specified by the OpenID AuthZEN Access Request
-and Approval Profile and are referenced, not redefined, by this SEP.
+The backend's constructs (the requestable-denial signal, binding material, the durable
+handle, and the approval input to re-evaluation) are defined by the backend and
+referenced, not redefined, by this SEP. For the AuthZEN ARAP mapping, see Example
+binding: AuthZEN ARAP.
 
 ### Extension identifier and capability
 
-The feature is an experimental extension with identifier
-`net.openid.authzen/tool-approval` (reversed-domain prefix per SEP-2133;
-illustrative, to be confirmed with the owning group).
-
-This extension builds on the tasks extension, so a server MUST also support
-`io.modelcontextprotocol/tasks`. Both are declared in the server's `extensions`
-capability:
+The extension identifier is `io.modelcontextprotocol/tool-approval` (reversed-domain
+prefix per SEP-2133; illustrative, to be confirmed with the owning group). It builds on
+the tasks extension, so a server MUST also support `io.modelcontextprotocol/tasks`.
+Both are declared in the server's `extensions` capability:
 
 ```json
 {
   "capabilities": {
     "extensions": {
       "io.modelcontextprotocol/tasks": {},
-      "net.openid.authzen/tool-approval": { "version": "0.1" }
+      "io.modelcontextprotocol/tool-approval": {}
     }
   }
 }
 ```
 
-Per SEP-2663, task creation is **server-directed**: a client does not flag a
-request for task execution. A client signals that it can receive task handles by
-declaring the `io.modelcontextprotocol/tasks` extension in its per-request
-capabilities (SEP-2663 / SEP-2575); the server then decides per request whether to
-return a `CreateTaskResult`. A client that has not declared the tasks extension and
-issues a call the server can only satisfy through approval MUST receive either:
+Task creation is server-directed (SEP-2663): the client only declares the tasks extension,
+and the server decides per request whether to return a `CreateTaskResult`. A client that
+has not declared tasks but issues a call the server can satisfy only through approval MUST
+receive either a `-32003` (Missing Required Client Capability) error naming
+`io.modelcontextprotocol/tasks`, or a normal `CallToolResult` with `isError: true`
+carrying requestable guidance (a degraded path with no async resume). Since `-32003` reads
+as a capability gap rather than "go obtain access," a server that wants non-tasks agents to
+act on a requestable denial SHOULD prefer the degraded `CallToolResult` with next-step
+guidance.
 
-- a `-32003` (Missing Required Client Capability) error naming
-  `io.modelcontextprotocol/tasks`, which a tasks-capable client reads as "re-issue the
-  call with the capability declared"; or
-- a normal `CallToolResult` with `isError: true` carrying requestable guidance in its
-  content (a degraded path with no asynchronous resume), for clients that will not
-  speak the tasks extension.
+Declaring `io.modelcontextprotocol/tool-approval` is an optional client signal that it
+understands approval semantics (for example, to render approval-specific UI). Correct
+behavior does not require it, since an approval-gated task is an ordinary
+tasks-extension task.
 
-`-32003` is a capability-negotiation error, not an "access is requestable" signal: an
-agent reads it as "I did not declare something," not "go obtain access." A server that
-wants today's non-tasks agents to act on a requestable denial SHOULD prefer the
-degraded `CallToolResult` and include machine-readable next-step guidance (see the
-client-maturity note).
-
-Declaring `net.openid.authzen/tool-approval` is an optional client signal that it
-understands approval semantics (for example, to render approval-specific progress
-UI). Correct behavior does not require it: an approval-gated task is an ordinary
-tasks-extension task, and a client that supports only `io.modelcontextprotocol/tasks`
-already interoperates.
-
-> **Client maturity (non-normative).** The canonical flow requires a client that
-> declares and drives `io.modelcontextprotocol/tasks` (receives `CreateTaskResult`,
-> polls `tasks/get`). That capability is experimental (SEP-2663) and, at the time of
-> writing, is not present in shipping MCP clients, whose task support is server-side.
-> End-to-end value is therefore gated on client tasks adoption, and interop testing
-> needs a purpose-built tasks client (the Reference Implementation clause requires
-> one). During the gap, servers may also expose approval as ordinary tools (for
-> example `request_access` / `get_request_status`) so today's agents can self-drive
-> request-poll-retry without tasks support. This SEP does not standardize that interim
-> shape, but a server that adopts it SHOULD carry the same machine-readable next-step
-> fields the Access Request profile already defines (a next-step hint, the request
-> schema, and a poll-interval hint) so interim shapes interoperate.
+> **Client maturity (non-normative).** The canonical flow needs a client that drives
+> `io.modelcontextprotocol/tasks`, which is experimental and not yet in shipping clients,
+> so end-to-end value and interop testing depend on tasks-client adoption. In the interim a
+> server MAY also expose approval as ordinary tools (for example `request_access` /
+> `get_request_status`) carrying the same next-step fields (a hint, the request schema, a
+> poll interval); this SEP does not standardize that shape.
 
 ### Denied-but-requestable returns a task
 
-When the server evaluates a `tools/call` against its policy decision point and the
-decision is "deny":
+When the server evaluates a `tools/call` and the decision is "deny":
 
-1. If the denial is **not** requestable (no approval can change it), the server
-   returns the normal denied tool result: a `CallToolResult` with `isError: true`
-   describing the denial, so the model can react. (Per SEP-2663, an `isError`
-   result delivered through a task is a `completed` task, not a `failed` one.)
-2. If the denial **is** requestable, and the client declared the tasks extension,
-   the server MUST NOT execute the tool. Instead it:
-   - submits an access request to the approval service on the caller's behalf and
-     obtains a durable approval task handle;
-   - creates a durable MCP task bound to that handle and returns a
-     `CreateTaskResult` (`resultType: "task"`) with `status: "working"` and a
-     human-readable `statusMessage` (for example, "Awaiting treasury approval");
-   - MAY include an `io.modelcontextprotocol/model-immediate-response` value in the
-     result `_meta` so the model receives an immediate string (for example,
-     "This action is pending approval; you can continue other work and check back").
+1. If the denial is **not** requestable, the server returns the normal denied tool
+   result: a `CallToolResult` with `isError: true` describing the denial. (Per SEP-2663,
+   an `isError` result delivered through a task is a `completed` task, not a `failed`
+   one.)
+2. If the denial **is** requestable and the client declared the tasks extension, the
+   server MUST NOT execute the tool. Instead it:
+   - records a durable submission-intent with a fresh, opaque idempotency key before
+     contacting the backend, submits the approval request under that key, and persists the
+     returned handle (see Crash-consistent creation);
+   - creates the durable MCP task bound to that handle and returns a `CreateTaskResult`
+     (`resultType: "task"`) with `status: "working"` and a human-readable
+     `statusMessage`;
+   - if it implements SEP-2643, includes the denial envelope in the result `_meta` under
+     `io.modelcontextprotocol/authorization` (`reason: "insufficient_authorization"`,
+     `remediation: "available"`, a `remediationHints` entry of `type: "task"`), and MUST
+     repeat that envelope on every `tasks/get` result while the task is non-terminal, so
+     a client resuming after a restart with only the `taskId` still reads the pending
+     classification;
+   - MAY include an `io.modelcontextprotocol/model-immediate-response` value in `_meta`
+     so the model receives an immediate string.
 
-The server MUST NOT surface approval-binding material (the AuthZEN `binding_token`,
-`evaluation_id`, `approval` object, or access-request endpoints) to the client.
-These are internal to the PEP.
+The server MUST NOT surface the backend's binding material or endpoints to the client
+(for example, in the ARAP binding, `binding_token`, `evaluation_id`, the `approval`
+object, and access-request endpoints). These are internal to the PEP.
 
-**At-most-once execution and deduplication.** Because the server controls both task
-creation and tool execution, it MUST execute the approved tool at most once per task.
-To keep a client retry (after a poll timeout or an agent restart) from creating a
-second approval task, and thus a second execution, the server SHOULD return the
-existing task's `CreateTaskResult` when it recognizes a repeated requestable denial
-within one dedup scope: the same **originating authorization context** (the
-authenticated caller or subject the task is bound to), the same tool, and the same
-arguments. This correlation is inherently best-effort: if the arguments carry a
-client-local value (a nonce or timestamp) two genuine retries will not match, and if
-they do not, two distinct intents with identical arguments will collide. MCP today
-has no general request-level idempotency key that would make it exact (see
-Limitations), so deployments needing exactness must wait for one.
+**Crash-consistent creation.** Submitting to the backend and creating the MCP task are two
+writes, and a crash between them must not orphan an approval or double-submit. Deduplication
+decides first, before any submission, whether a repeated `tools/call` reuses an existing
+non-terminal task (see At-most-once and deduplication). When the server does submit, whether
+an initial request or a chained `request` (see Completion), it MUST generate a fresh,
+opaque, high-entropy idempotency key for that logical submission, and MUST record a durable
+submission-intent holding that key plus the exact submission body and requester context
+needed to reproduce an equivalent request, before it contacts the backend. It then submits
+under that key. A conforming deployment MUST configure its backend to treat a repeat of the
+key with an equivalent body as the same request, return the same handle, and retain the key
+through reconciliation, so a retry after a crash recovers the original rather than creating a
+duplicate. The key identifies one submission, not the call, so distinct intents and
+successive chained requests never collide. The server MUST persist the returned handle before
+it returns `CreateTaskResult`, so the task is durable when returned (SEP-2663) and a callback
+that arrives first has a record to bind to. On restart the server MUST reconcile any
+submission-intent with no bound task, either by recovering the handle under its key or by
+cancelling the orphaned request.
 
-Deduplication applies only while the prior task is non-terminal. After a task reaches
-a terminal disposition (including `denied-not-executed`), an identical `tools/call`
-MUST start a **new** access request and a new task; the terminal denial was final and
-MUST NOT be folded into the old task.
+**At-most-once and deduplication.** The server controls both task creation and
+execution, so it MUST execute the approved tool at most once per task. To keep a client
+retry (after a poll timeout or restart) from opening a second approval task, the server
+SHOULD return the existing task's `CreateTaskResult` when it recognizes a repeated
+requestable denial within one dedup scope: the same **originating authorization
+context** (the authenticated caller or subject the task is bound to), tool, and arguments.
+It matches against both non-terminal tasks and in-progress submission-intents, so a
+concurrent retry in the window between persisting the intent and creating the task does not
+open a second approval. This is best-effort: a client-local nonce in the arguments defeats it, identical arguments
+from two distinct intents collide, and MCP has no request-level idempotency key that would
+make it exact (see Limitations). So the at-most-once guarantee is per task, and a
+non-idempotent tool can still run more than once through distinct tasks.
 
-**Retention.** The server MUST keep the task resolvable through `tasks/get` for the
-full approval window: it MUST NOT delete or expire a `working` approval task before
-the approval's expiry, and `ttlMs` MUST cover the approval window plus the server's
-result-retention period. The approval service often sets or extends the window after
-submission, so the creation-time `ttlMs` is provisional: when the server learns a
-later expiry, it MUST extend `ttlMs` (reported on `tasks/get` and
-`notifications/tasks`) so a `working` task is never expired before the current known
-approval expiry. A server SHOULD bound the maximum approval window it accepts so
-pending tasks do not accumulate without limit.
+Once a task reaches a terminal disposition it is final, permanently fenced against
+execution, and MUST NOT be reopened. A later identical `tools/call` is a new intent that
+the server evaluates fresh; it does not automatically create a new approval request and
+re-enters the approval lifecycle only if that fresh evaluation itself returns a
+requestable denial. A terminal `denied-not-executed` therefore carries
+`remediation: "unavailable"` in the full SEP-2643 sense: the client is not invited to
+retry it.
 
-**Model-facing text is untrusted and non-committal.** `statusMessage` and any
-`io.modelcontextprotocol/model-immediate-response` value are fed to the model and
-MUST NOT carry unsanitized text from untrusted sources (agent-supplied rationale,
-approver free-text); they are a prompt-injection surface. A `working` or
-`input_required` approval task MUST NOT be represented to the model as a completed
-action; if `model-immediate-response` is used, it MUST make clear the action has not
-yet occurred and may still be denied.
+**Retention.** Retention has two phases. While the task is pending, `createdAt` plus `ttlMs`
+MUST cover the current pending deadline plus `resultRetention`, where the pending deadline is
+the backend request deadline before a grant and the approval validity during post-grant
+retry, and `resultRetention` is a server-configured duration for how long a terminal result stays
+retrievable; the server MUST NOT delete or expire a `working` task before its pending
+deadline. At terminalization the server MUST extend `ttlMs` if needed so it covers
+`terminalizedAt` plus `resultRetention`. A `ttlMs` of `null` means unlimited (SEP-2663) and
+satisfies both boundaries with no extension. Because the backend
+often sets or extends the window after submission, the creation-time `ttlMs` is provisional;
+when the server learns a later deadline it MUST extend `ttlMs` (reported on `tasks/get` and
+`notifications/tasks`). A server SHOULD bound the maximum window it accepts so pending tasks
+do not accumulate without limit.
+
+**Model-facing text is untrusted.** `statusMessage` and any `model-immediate-response`
+are fed to the model and MUST NOT carry unsanitized text from untrusted sources; they
+are a prompt-injection surface. A `working` or `input_required` task MUST NOT be
+presented to the model as a completed action.
 
 ### The task handle is not authority
 
 The `taskId` is a reference to a pending decision, never a grant. Authority is the
-PDP decision, re-derived at execution against the original call envelope (see
-Completion). Possessing a `taskId` does not authorize execution.
+authorization decision, re-derived at execution against the captured call binding (see
+Completion). The server keeps three kinds of state per task, with different mutability:
 
-When it creates the task, the server MUST retain a binding record and MUST check it
-before executing. The record MUST include at least:
+- **Immutable call binding**, captured on the first `tools/call` and never changed (carried
+  in `requestState` per SEP-2322 across any pre-task synchronous input round-trip, then
+  promoted unchanged into the task): the tool name;
+  the complete tool arguments, stored in full (subject to the durable sensitive-state
+  requirement in Security Implications), since execution runs from them long after the call
+  and a digest cannot reconstruct them, and
+  optionally a digest over a canonical serialization (for example JCS canonical JSON, RFC
+  8785, with a named hash such as SHA-256) alongside them for integrity checking; and the
+  originating authorization context (the requester principal's identity, the subject or
+  resource acted on, and any delegation), captured so a different caller is rejected. An
+  approval is bound to this identity.
+- **Mutable approval-workflow state**: the current backend handle and request id, a
+  monotonically increasing submission generation, and the current approval expiry and
+  window. These change legitimately, for example when a re-evaluation returns `request` and
+  the server opens a new request (see Completion), or when the backend extends the expiry.
+  The server retains enough handle history to recognize a superseded generation.
+- **Mutable execution state**: the single execution claim and the terminal disposition,
+  set once the task reaches execution (see Completion).
 
-- the task id;
-- the tool name;
-- a canonical digest of the arguments;
-- the requester principal (and session, where applicable);
-- the subject or resource being acted on;
-- the approval request id;
-- the disposition;
-- the expiry / freshness window.
-
-The server MAY also record the policy id and version for audit and drift detection;
-this is recorded, not pinned (see Completion).
-
-**Envelope match or new approval.** At execution time the server MUST compare the
-current call against the bound envelope. If the tool, arguments, requester principal,
-or subject/resource differ, the task MUST resolve `denied-not-executed` with no side
-effect, and the changed call requires a new access request. An approval is bound to
-the exact envelope that produced the requestable denial; it never carries over to a
-different or mutated call.
+The server MUST check the immutable call binding before executing, and MAY record the
+policy id and version for audit and drift detection (recorded, not pinned). Execution
+runs from the captured binding, not from a fresh client call, so there is no "current
+call" to trust at execution time. An MRTR retry that resumes the original call, echoing it with `requestState`, MUST match the
+immutable call binding: the server MUST reject it if the tool, arguments, or originating
+caller differ. A `tasks/update` is different: it carries no tool or arguments, so the server
+authorizes the caller against the `taskId` and validates the outstanding input keys instead.
+An independent new `tools/call` is a new intent evaluated fresh; only a changed binding is
+guaranteed not to match dedup, while an identical independent intent is indistinguishable
+from a retry and MAY collide.
 
 ### Collecting submission input
 
-The access request may require inputs from the requester before or during the
-approval: a justification, a ticket reference, or fields the approval service
-defines (the AuthZEN profile's `request_schema_url`, `form_url`, and
-`request_catalogs_url`). The server collects these over the tasks input channel
-(SEP-2322 multi round-trip requests), not a standalone `elicitation/create`, since
-SEP-2260 disallows unsolicited server-to-client requests and SEP-2663 routes task
-input through `inputRequests` / `tasks/update`:
+The approval request may require inputs before or during the approval: a justification,
+a ticket reference, or fields the backend defines (its submission schema and forms; for
+example, in the ARAP binding, `request_schema_url`, `form_url`, `request_catalogs_url`).
+The server collects these over the tasks input channel (SEP-2322), not a standalone
+`elicitation/create`, since SEP-2260 disallows unsolicited server-to-client requests and
+SEP-2663 routes task input through `inputRequests` / `tasks/update`:
 
-- **Before submission (synchronous).** The server returns `resultType:
-"input_required"` on the original `tools/call`, collects the inputs, then returns a
-  `CreateTaskResult` and submits the access request. Use this when the approval
-  service will not accept the request without them.
-- **During the workflow (in-task).** The server sets the task to `input_required`
-  with the outstanding `inputRequests` (for example, an approver asks for more
-  detail, or a catalog-backed field is resolved after submission); the client answers
-  with `inputResponses` via `tasks/update`, and the task returns to `working`.
+- **Before submission (synchronous).** The server returns `resultType: "input_required"` on
+  the original `tools/call`. The client then retries the `tools/call` with `requestState` and
+  `inputResponses` (per SEP-2322); the server validates that retry against the pre-task
+  immutable call binding it captured on the first call and carried in `requestState`, submits
+  the approval request under Crash-consistent creation, and
+  returns the `CreateTaskResult` on the retry. A single JSON-RPC response cannot carry both
+  `input_required` and the task. Use this when the backend will not accept the request without
+  the inputs.
+- **During the workflow (in-task).** The server sets the task to `input_required` with
+  outstanding `inputRequests`; the client answers with `inputResponses` via
+  `tasks/update`, and the task returns to `working`.
 
-Who answers is a property of the client, not this extension. An interactive client
-renders the request for a human (the profile's `form_url` case); an autonomous agent
-client MAY answer it from context against the request schema (the
-`request_schema_url` case), resolving catalog-backed fields per
-`request_catalogs_url`. The server derives the `inputRequests` schema from those
-profile fields. Either way this is submission-time input that shapes the access
-request; it is distinct from the approval decision, which is made out of band by a
-party (human or automated) not assumed to be reachable through the session.
+Who answers is a property of the client: an interactive client renders the request for a
+human, an autonomous agent answers from context against the backend's request schema.
+An in-task round-trip requires a client that returns to the task; an agent that persisted
+its `taskId` can resume polling after a restart (SEP-2663) and answer via `tasks/update`,
+but a client that did not persist it or will not return cannot, so deployments expecting
+long gaps SHOULD collect all inputs synchronously before submission. The mapping from the
+backend's request schema onto the `inputRequests` schema is not pinned here and is
+currently implementation-specific.
 
-An in-task `input_required` round-trip requires a connected client: an agent that
-submitted and then disconnected or restarted cannot answer a later `inputRequests`.
-Deployments that expect long gaps between submission and approval SHOULD collect all
-inputs synchronously before submission. The mapping from the profile's
-`request_schema_url` (a JSON Schema) onto the SEP-2322 `inputRequests` schema is not
-pinned by this SEP and is currently implementation-specific; two servers MAY produce
-different `inputRequests` for the same access request until a canonical mapping is
-defined.
+### Lifecycle and task status
 
-### Approval lifecycle maps onto task status
+The backend resolves the approval request into a terminal state (granted, denied, expired,
+cancelled, or failed); a grant triggers the server's re-evaluation, which yields allow,
+retry, request, or deny (see Completion). Both feed the mapping below. Each row maps to an
+MCP task status and a disposition; a SEP-2643-aware server also carries an envelope while
+the call is denied. The envelope classifies the denial (present only while denied); the
+disposition records what happened to execution. They are independent axes.
 
-| Approval-profile state                                           | MCP task status                                                 |
-| ---------------------------------------------------------------- | --------------------------------------------------------------- |
-| Access request submitted, awaiting a decision                    | `working`                                                       |
-| Submission needs input from the requester (human or agent)       | `input_required`                                                |
-| Approved, re-evaluated to "allow", tool executed (once)          | `completed`, disposition `approved-executed`                    |
-| Terminal denial (rejected, revoked, expired, or not executed)    | `completed`, `isError: true`, disposition `denied-not-executed` |
-| Approved and executed, but the tool itself errored               | `completed`, `isError: true`, disposition `execution-error`     |
-| Server could not produce a tool result at all (protocol failure) | `failed`                                                        |
-| Client cancelled                                                 | `cancelled`                                                     |
+| Backend state | Task status | SEP-2643 envelope | Disposition |
+| --- | --- | --- | --- |
+| Awaiting a decision | `working` | `available`, `task` hint | none yet |
+| Needs submission input (in-task) | `input_required` | `available` | none yet |
+| Re-evaluation returns retry | `working` (wait, then re-evaluate) | `available` | none yet |
+| Re-evaluation returns request | `working` (new request) | `available` | none yet |
+| Allowed, executed once | `completed` | none | `approved-executed` |
+| Backend denied, or re-evaluation deny/none | `completed`, `isError` | `unavailable` | `denied-not-executed` |
+| Approval or request expired unresolved | `completed`, `isError` | `unavailable` | `denied-not-executed` |
+| Executed, tool errored | `completed`, `isError` | none | `execution-error` |
+| Execution claimed, outcome undeterminable | `completed`, `isError` | none | `outcome-unknown` |
+| JSON-RPC error, or a backend/infra failure surfaced as one (retryable) | `failed` (carries the SEP-2663 `error` object) | none | — |
+| Cancelled by client (`tasks/cancel`) or backend | `cancelled` | none | — |
 
-A terminal authorization denial is an outcome of the call, not a failure of the
-task machinery, so it is a `completed` task whose `result` is a `CallToolResult`
-with `isError: true` and disposition `denied-not-executed`. That disposition lets a
-consumer distinguish a denial (no side effect occurred) from an `execution-error`
-(the tool ran and a side effect may have occurred). `failed` is reserved for cases
-where the server could not produce a tool result at all.
+While `working`, the server tracks the approval by polling the backend's status source or
+receiving its callback. The `taskId` and every backend handle generation are durably bound
+to the task, and only the current generation is actionable, so a server that restarts
+rehydrates the task from the persisted handles and keeps serving `tasks/get`. Per the table, `failed` carries the SEP-2663 `error` object and covers a JSON-RPC protocol
+error or a backend/infra failure surfaced as a JSON-RPC internal error; unlike a denial such
+a `failed` is retryable, and it is not an authorization outcome. A task MUST enter `failed`
+only before an execution claim (see Completion); any failure after the claim MUST be a
+`completed` `CallToolResult` with `execution-error` or `outcome-unknown`, so a possible side
+effect is never hidden behind a retryable `failed`.
 
-While `working`, the server tracks the approval by polling the approval service's
-status endpoint or by receiving its callback. The MCP `taskId` and the approval
-task handle are bound for the task's lifetime, so a server that restarts can
-rehydrate the task from the persisted handle and keep serving `tasks/get`. Both the
-tasks extension and the AuthZEN task handle are durable by design, which is what
-makes resolution that outlives the session possible.
+Three clocks apply and are distinct: the backend's request deadline (how long the request
+stays open for a decision), the approval's validity once granted, and MCP retention
+(`createdAt` plus `ttlMs`, always measured from `createdAt` even when the server extends
+it per Retention). When the request deadline or approval validity passes without a usable
+approval, the task completes as a terminal denial (`denied-not-executed`, with the body
+noting expiry) and the server fences it against later execution. MCP retention is separate:
+once `ttlMs` elapses the server MAY delete a task that has not been execution-claimed
+(SEP-2663). An execution-claimed task MUST NOT be deleted before it terminalizes: at the
+claim the server extends retention through an execution deadline, and when that deadline
+arrives it terminalizes the task as `outcome-unknown` (if no stronger result is available),
+retains that result for `resultRetention`, and only then MAY delete it. A terminal task MUST
+NOT change to `failed`, which would erase its disposition.
+
+### Execution disposition
+
+`io.modelcontextprotocol/tool-approval-disposition` is this extension's machine-readable
+outcome. It is a string and MUST be present in the `_meta` of the `CallToolResult` carried
+in a completed task's `result` field, on every completed approval task, independent of
+SEP-2643. Its value is one of:
+
+- `approved-executed`: the tool was authorized and executed once.
+- `denied-not-executed`: the tool did not run (denied, expired, or unresolved), so no side
+  effect occurred.
+- `execution-error`: the tool was authorized and ran but failed; a side effect may have
+  occurred.
+- `outcome-unknown`: execution was claimed but the server cannot determine whether
+  invocation or the side effect completed.
+
+The outer `tasks/get` result carries the `Task`, whose `status` conveys
+`completed`/`failed`/`cancelled`; the disposition refines a `completed` task's execution
+outcome and is not set on `failed` or `cancelled` tasks. Future values MAY be registered. A
+client that does not recognize a disposition value MUST treat the operation as possibly
+executed and MUST NOT retry it automatically.
 
 ### Completion: re-evaluate, then execute
 
-On approval, the server MUST perform a fresh authorization evaluation that takes the
-approval as an input (for AuthZEN, placing the `approval` object at
-`context.approval`), so the policy decision point remains authoritative at
-enforcement time. An approval is an input to a new decision, not a standing grant.
-This re-evaluation is server-internal and is not observable on the MCP wire.
+On approval the server MUST re-evaluate authorization with the approval as an input, so
+the decision stays authoritative at enforcement time. An approval is an input to a new
+decision, not a standing grant, and this re-evaluation is server-internal. It runs against
+the immutable call binding and current policy; a recorded policy version is for audit, not
+pinning, so a policy change yields a fresh decision. The re-evaluation resolves to one of
+four outcomes:
 
-The re-evaluation runs against the bound call envelope (see The task handle is not
-authority) and current policy. The recorded policy version is for audit and drift
-detection, not pinning: a policy change yields a fresh allow-or-deny rather than an
-automatic denial, so an approval still valid under current policy proceeds. Envelope
-fields (tool, arguments, requester principal, subject/resource) are an exact-match
-binding; a mismatch resolves `denied-not-executed` and requires a new approval.
+- **allow**: proceed to execution.
+- **retry** (the approval is valid but a backing grant has not provisioned, or a
+  transient hold): the task stays `working`. The server waits the backend's retry-after
+  hint, or bounded exponential backoff with jitter if none is given, then re-evaluates,
+  and MUST stop once the approval expires. A retryable outcome MUST NOT be completed as a
+  denial.
+- **request** (this approval does not suffice, but a fresh approval request might): the
+  task stays `working`. The server first atomically marks the current generation consumed and
+  records a new submission-intent with its own fresh submission key (the immutable call binding
+  is unchanged), then contacts the backend under Crash-consistent creation and attaches the
+  returned handle to the new generation. Ordering it this way closes the window where a stale
+  callback could still act: a callback or poll result for a consumed generation MUST NOT cause
+  re-evaluation or execution, even when it is authentic, since the decision has moved on. A
+  server MUST bound the number of chained requests per task so this cannot loop indefinitely;
+  on reaching the bound it completes the task as a terminal denial.
+- **deny or none**: the task completes as a terminal denial.
 
-Because execution can occur long after the original request, the server SHOULD
-verify at execution time that the captured arguments and any downstream credential
-it must use are still valid. If a required credential has expired, or the action is
-materially stale, the server SHOULD NOT execute: it completes the task as a denial
-(disposition `denied-not-executed`) or returns a fresh requestable denial so the
-caller can resubmit.
+Because execution can occur long after the request, an approval is not a substitute for
+caller authentication. The intent, approval scope, and the originating caller's identity come
+from the immutable binding; every other authorization input MUST be current at execution:
+whether that caller is still a valid principal, and the subject and resource state, risk and
+environmental attributes, the downstream credential, and policy. Re-evaluating against captured risk or environment would
+defeat the risk-clearing case, so those MUST be re-read, not replayed. The server MUST
+validate the immutable call binding, and if the tool implementation, its schema, or the
+authorization mapping changed materially while the task was pending, it MUST evaluate against
+that change or fail closed. If the principal is no longer valid, a required credential has
+expired, or the action is materially stale, the server MUST NOT execute (it completes as a
+terminal denial, or keeps the task `working` if the condition is transient).
 
-The terminal outcome MUST be distinguishable so a consumer can tell whether a side
-effect occurred. Because a client that supports only `io.modelcontextprotocol/tasks`
-does not understand this extension's `_meta`, the distinction MUST be carried in the
-`CallToolResult` itself, not only in `_meta`: the result `content` (and
-`structuredContent` where used) MUST state plainly whether the tool executed, so the
-model behind any tasks client reads "denied, the tool did not run" and does not
-blindly retry. A `net.openid.authzen/disposition` value in the result `_meta` is the
-machine-readable companion for extension-aware consumers. The body and the `_meta`
-disposition MUST agree:
+Execution MUST be fenced so a crash cannot double-execute a side effect. A task that
+proceeds to execution MUST make a single atomic compare-and-set from pre-execution to
+execution-claimed; this happens at most once and is mutually exclusive with cancellation and
+expiry (a task that is denied, cancelled, or expired makes no claim). The claim is the
+irrevocable authorization-enforcement point: all validity checks, the identity and freshness
+checks above and the approval expiry, MUST hold at the moment of the claim, and a
+cancellation or expiry that precedes the claim wins (the exact cancellation boundary, see
+Cancellation). The claim does not terminalize the task: its observable status stays `working`
+until the final result is stored. Once the claim succeeds the server invokes the tool at most
+once and MUST carry it through even if the approval expiry elapses during invocation, since
+authorization was enforced at the claim. If it cannot determine whether invocation or the
+side effect completed (a crash after the claim, before or after invoking), it MUST NOT
+re-invoke, and the task completes `outcome-unknown`.
 
-- **allow**: the server executes the tool exactly once and moves the task to
-  `completed`; the `tasks/get` response carries the tool's `CallToolResult` in the
-  task's `result` field. `_meta` disposition `approved-executed`.
-- **deny** at re-evaluation (policy changed, approval unverifiable, expired with no
-  re-request path), or a freshness or credential failure that prevented execution:
-  the task is `completed` with an `isError: true` `CallToolResult` whose content says
-  the tool did not run; `_meta` disposition `denied-not-executed`.
-- **execution error**: the tool was authorized and ran but failed; `isError: true`
-  with content describing the failure and `_meta` disposition `execution-error`, since
-  a side effect may have occurred.
-
-The server MUST bound any downstream credential, cached result, or follow-on
-authorization by the approval's expiry.
+Every completed approval task MUST carry
+`io.modelcontextprotocol/tool-approval-disposition` (see Execution disposition). The
+denied-versus-executed distinction MUST also be stated in the `CallToolResult` body, not
+only in `_meta`: the `content` MUST state whether the tool ran, did not run, or may have run with the outcome unknown, and it MAY also appear in
+`structuredContent` where the tool's `outputSchema` permits, so the model behind a client that
+understands only
+`io.modelcontextprotocol/tasks` reads it. That client cannot distinguish outcomes
+programmatically without the disposition, which is why the disposition is required. Body,
+disposition, and, for a SEP-2643-aware server, the envelope MUST agree. The envelope
+appears only on a denial: because its presence asserts the operation was not performed, it
+MUST NOT appear on an `execution-error` or `outcome-unknown` result, where the server
+cannot make that assertion. The server MUST bound any downstream credential, and any
+authorization-decision or downstream-response cache it keeps, by the approval's expiry; this
+does not apply to the task's retained terminal result, which follows Retention.
 
 ### Cancellation
 
-A `tasks/cancel` request MUST cause the server to cancel the underlying access
-request and move the task to `cancelled`. Per SEP-2663, `notifications/cancelled`
-MUST NOT be used to cancel a task.
+A `tasks/cancel` request attempts the same atomic transition as the execution claim, from a
+cancellable pre-claim state to `cancelled`. Only a winning transition moves the task to
+`cancelled` and durably fences it against execution; if the execution claim already won or the
+task is already terminal, the cancel is a no-op. On a winning cancel the server MUST cancel the
+underlying approval request when the backend supports it (backend cancellation is optional; in
+the ARAP binding it is offered only when a cancellation endpoint is present) and otherwise MUST
+record the cancellation locally and ignore any later approval. Either way it is the local
+fence, not backend cancellation, that guarantees the tool does not run. Per SEP-2663,
+`notifications/cancelled` MUST NOT be used to cancel a task.
 
-A cancel can arrive after approval but before the tool has executed. To avoid
-ambiguity about whether a side effect occurred, the server resolves the race by the
-execution boundary: if it has not begun executing the tool, it MUST honor the cancel,
-skip execution, and move the task to `cancelled` (no side effect); once execution has
-begun, the cancel is ineffective and the task completes with its normal disposition.
-The server MUST NOT both execute the tool and report `cancelled`.
+A cancel can arrive after approval but before execution. The server resolves the race by
+the atomic execution claim (see Completion): if the cancel wins the compare-and-set, the
+server honors it, moves the task to `cancelled`, and does not invoke (no side effect); if
+the claim wins, the cancel is ineffective and the task completes with its execution
+disposition. The server MUST NOT both execute the tool and report `cancelled`.
 
 ### What the client carries
 
-The client carries a server-generated `taskId` only. It MUST NOT be required to
-read, store, or forward any authorization artifact. A client that supports the tasks
-extension already interoperates with an approval-gated server: it must already be
-prepared to receive a `CreateTaskResult` for any supported request, and it observes
-a task that stays `working` and then becomes `completed` (or `failed`/`cancelled`).
-This extension adds meaning, not new client wire format. Because the
-denied-versus-executed distinction is carried in the `CallToolResult` body (see
-Completion) and not only in `_meta`, a tasks-only client's model can act on it safely;
-without that rule a tasks-only client could not tell a denial from an execution error
-and could double-execute a side-effecting tool on retry.
+After task creation the client carries a server-generated `taskId` only and MUST NOT be required to read,
+store, or forward any authorization artifact. This extension adds meaning, not a new result
+shape (see Backward Compatibility): a tasks-only client reads the denied-versus-executed
+distinction from the `CallToolResult` body, an approval-aware client from the disposition
+(see Completion, Execution disposition).
+
+This extension does not emit SEP-2643's optional `authorizationContextId`. That field is
+a non-authoritative correlation handle the client would echo on retry, but this client
+forwards no authorization artifact and the `taskId` already correlates the denial with
+its resolution. The authoritative binding between an approval and the exact call is the
+server-side immutable call binding, internal to the PEP and distinct from that handle.
 
 ### End-to-end example
 
-Client calls a tool (the client has declared the `io.modelcontextprotocol/tasks`
-extension in its per-request capabilities):
+The JSON below abbreviates the SEP-2575 per-request metadata (protocol version, client
+information, and client capabilities) that a real request carries.
+
+Client calls a tool (having declared the `io.modelcontextprotocol/tasks` extension in its
+per-request capabilities):
 
 ```json
 {
@@ -460,8 +509,8 @@ extension in its per-request capabilities):
 }
 ```
 
-The server evaluates, gets a requestable denial, submits the access request, and
-returns a task handle in place of the tool result:
+The server gets a requestable denial, submits the approval request, and returns a task
+handle in place of the tool result:
 
 ```json
 {
@@ -473,27 +522,24 @@ returns a task handle in place of the tool result:
     "status": "working",
     "statusMessage": "Transfers over $25,000 require treasury approval.",
     "createdAt": "2026-06-02T10:30:00Z",
+    "lastUpdatedAt": "2026-06-02T10:30:00Z",
     "ttlMs": 604800000,
     "pollIntervalMs": 15000,
     "_meta": {
+      "io.modelcontextprotocol/authorization": {
+        "reason": "insufficient_authorization",
+        "remediation": "available",
+        "remediationHints": [{ "type": "task" }]
+      },
       "io.modelcontextprotocol/model-immediate-response": "This transfer is pending treasury approval. You can continue other work and check back."
     }
   }
 }
 ```
 
-After the approval workflow resolves out of band (whether a human acts the next day
-or an automated re-check clears in seconds), the server re-evaluates and executes.
-A later poll returns the completed task with the tool result:
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 7,
-  "method": "tasks/get",
-  "params": { "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840" }
-}
-```
+A `tasks/get` while the approval is pending returns the same `working` task with the
+envelope repeated. After the workflow resolves out of band, the server re-evaluates,
+executes, and a later `tasks/get` returns the completed task with the tool result:
 
 ```json
 {
@@ -510,179 +556,188 @@ A later poll returns the completed task with the tool result:
       "content": [
         { "type": "text", "text": "Transfer of $50,000 to acct-991 completed." }
       ],
-      "isError": false
+      "isError": false,
+      "_meta": {
+        "io.modelcontextprotocol/tool-approval-disposition": "approved-executed"
+      }
     }
   }
 }
 ```
 
+Had it been denied, the task would complete with `isError: true`, the envelope
+classifying it (`remediation: "unavailable"`), and disposition `denied-not-executed`, and
+the body stating the tool did not run.
+
+## Example binding: AuthZEN ARAP (non-normative)
+
+This section maps the abstract approval-backend contract above onto the OpenID AuthZEN
+Access Request and Approval Profile (ARAP), one backend a deployment can bind. Other
+backends map the same contract to their own constructs. Nothing here crosses the MCP
+wire: the ARAP constructs are internal to the PEP, and the client sees only the MCP task.
+
+| Abstract contract (this SEP) | AuthZEN ARAP construct |
+| --- | --- |
+| requestable denial | a decision carrying `context.access_request` |
+| approval request submission | an Access Request to the Access Request Service |
+| durable, resumable handle | the ARAP Task Handle |
+| approval binding material | `binding_token`, `evaluation_id` |
+| idempotent submission key | the `Idempotency-Key` header |
+| re-evaluation with the approval as input | an Access Evaluation with the `approval` object at `context.approval` |
+| re-evaluation allow | `decision: true` |
+| re-evaluation not allowed | `decision: false` with `next_action`: `retry` or `request` (non-terminal, task stays `working`) or `none` (terminal denial) |
+| authoritative status source | the ARAP Task Status Endpoint |
+| submission schema and forms | `request_schema_url`, `form_url`, `request_catalogs_url` |
+| cancellation (optional) | the ARAP cancellation endpoint, when present |
+| backend terminal states | `denied` and `expired` map to disposition `denied-not-executed`; `cancelled` to the `cancelled` task; `failed` to the `failed` task; `partial` is bulk-only and does not apply to a single tool call |
+
+Mapping a `tools/call` to an AuthZEN decision is itself a profile, the AuthZEN MCP
+profile (COAZ), which is a draft, so that mapping is not yet stable.
+
+The concrete ARAP flow, everything internal to the PEP except the client-facing MCP
+messages:
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as MCP Server (PEP)
+    participant P as AuthZEN PDP
+    participant A as Access Request Service
+
+    C->>S: tools/call
+    S->>P: Access Evaluation (COAZ mapping)
+    P-->>S: deny + context.access_request (requestable)
+    S->>A: submit Access Request (Idempotency-Key, binding_token)
+    A-->>S: Task Handle (bound to MCP taskId)
+    S-->>C: CreateTaskResult (status: working)
+    Note over P,A: Out-of-band approval workflow
+    A-->>S: approved (Task Status Endpoint or callback)
+    S->>P: Access Evaluation (context.approval)
+    P-->>S: decision: true (allow)
+    S->>S: execute tool; task = completed
+    C->>S: tasks/get
+    S-->>C: CompletedTask with result
+```
+
 ## Rationale
 
-**Server-directed creation makes the client trivial.** Under SEP-2663 a client that
-supports tasks must already handle a `CreateTaskResult` for any call, and the server
-alone decides when to return one. An approval-gated server therefore needs no new
-client wire format and no per-tool opt-in: it returns a task exactly when it hits a
-requestable denial. This is the strongest property of the design and aligns with
-"Interoperability over optimization" (graceful degradation through capability
-negotiation).
+**Server-directed creation makes the client trivial.** Under SEP-2663 a tasks client
+already handles a `CreateTaskResult` for any call and the server decides when to return
+one, so an approval-gated server needs no new result shape and no per-tool opt-in.
 
-**Build on the tasks extension rather than invent a primitive.** Tasks already
-provides a durable state machine with polling, cancellation, input, and retention.
-An approval workflow is a long-running task, and the approval profile's portable
-handle provides the durability guarantee the binding needs. Aligns with
-"Composability over specificity."
+**Build on tasks, stay backend-agnostic.** Tasks already gives a durable state machine with
+polling, cancellation, input, and retention, and an approval workflow is a long-running
+task over it. Because approval is brokered server-side and surfaced only as task status,
+the MCP contract is identical whichever party or backend decides. The SEP encodes "decided
+out of band," not "human in the loop."
 
-**Resolver-agnostic by construction.** Because approval is brokered server-side and
-surfaced only as task status, the MCP-facing contract is identical whether a human,
-a supervising agent, a policy engine, or an external system decides. The SEP does
-not encode "human in the loop"; it encodes "decided out of band, asynchronously,"
-which serves fully automated and fully manual deployments alike.
-
-**Why an extension.** Per SEP-2133, optional capabilities that build on the core and
-need time to incubate belong as extensions; "extensions are where convergence gets
-tested." This feature layers on another extension and is not universally needed, so
-it starts experimental on the Extensions Track. It is an extension rather than
-Informational guidance because it defines normative, wire-observable behavior that
-plain tasks does not: a requestable denial MUST return a task, the
-denied-versus-executed distinction MUST be carried in the `CallToolResult` body (with
-a `net.openid.authzen/disposition` `_meta` companion), and authorization artifacts
-MUST NOT cross the wire. Those rules, not mere discovery, are what earns a capability.
-If the body-convey rule were dropped and the signal left optional in `_meta`, the
-value would collapse to a discovery hint and Informational guidance would be the
-better home.
-
-**Why submission input uses the task input channel.** SEP-2260 disallows unsolicited
-server-to-client requests, and SEP-2663 routes in-task input through MRTR
-(`inputRequests` / `tasks/update`) rather than standalone elicitation. Submission
-input therefore flows through the task, not a separate elicitation call.
+**Why an extension, not Informational.** It adds wire-observable surface plain tasks does
+not: a required `io.modelcontextprotocol/tool-approval-disposition` `_meta` field, a
+requestable denial that MUST return a task, the denied-versus-executed distinction carried
+in the `CallToolResult` body, and authorization artifacts that MUST NOT cross the wire. The
+mandatory disposition field is the clearest reason this is an extension rather than
+Informational guidance.
 
 ## Limitations and Open Questions
 
-- **Resumption by a different principal is not portable at the MCP layer.** The
-  AuthZEN task handle can be polled by any caller authorized for the bound subject,
-  but MCP task access is bound to a server-defined originating authorization context,
-  `tasks/list` was removed, and sessions were removed (SEP-2567), so there is no
-  standard way for a _different_ principal, or the same agent on a new connection with
-  a new credential, to reclaim a task. Same-principal resumption across restart works
-  to the extent the server's context binding recognizes the returning caller.
-  Defining a portable task-claim or re-authorization mechanism is open; until then,
-  deployments that need cross-principal handoff arrange it out of band.
-- **Someone has to come back and consume the result.** This SEP provides the
-  primitive, not the orchestration that resumes a paused agent and acts on the
-  completed task. For a side-effecting tool this matters: the tool may execute after
-  approval with no consumer observing the outcome. Deployments MUST ensure either a
-  durable consumer that polls or that the effect is independently auditable; a
-  fire-and-forget agent that never returns is a misuse, not a supported pattern.
-- **A lost `taskId` has no protocol recourse.** With `tasks/list` and sessions both
-  removed (SEP-2663 / SEP-2567), an agent that restarts without having persisted its
-  `taskId` cannot rediscover a possibly-executed side-effecting task. Clients MUST
-  persist task IDs to durable storage; there is no protocol-level recovery.
-- **No general request idempotency in MCP.** MCP has no request-level idempotency
-  key (only the `idempotentHint` tool annotation, which describes a tool rather than
-  deduplicating a call), so the server's duplicate suppression is best-effort
-  (matching the originating context, tool, and arguments). A general idempotency
-  mechanism belongs in the core protocol or the tasks extension, not in an approval
-  extension; if one is added, this extension should adopt it. Defining one here is
-  out of scope.
-- **Extension versus Informational (resolved, flagged for the sponsor).** Much of the
-  behavior can be built on the tasks extension alone. This SEP takes it as an
-  extension because the body-convey denied-versus-executed rule, the mandatory task on
-  a requestable denial, and the `disposition` signal are normative wire-observable
-  behavior, not just discovery (see Rationale). A sponsor who judges that surface too
-  thin may prefer an Informational SEP; that is the one positioning question left
-  open.
+- **Cross-principal resumption is not portable.** MCP task access is bound to a
+  server-defined originating context, and `tasks/list` was removed by SEP-2663 (with sessions
+  removed by SEP-2567), so a different principal cannot reclaim a task. Same-principal resumption
+  across restart works to the extent the server recognizes the returning caller.
+- **Someone has to consume the result.** For a side-effecting tool the effect may land with
+  no consumer observing it, so deployments MUST ensure a durable consumer polls or the
+  effect is independently auditable.
+- **A lost `taskId` has no recourse.** With `tasks/list` and sessions removed, an agent that
+  did not persist its `taskId` cannot rediscover a possibly-executed task, so clients MUST
+  persist task IDs durably.
+- **No general request idempotency in MCP.** Cross-task duplicate suppression is therefore
+  best-effort; a general key belongs in the core or the tasks extension, and this extension
+  should adopt one if it is added.
+- **Placement of the generic disposition.** The generic execution-outcome values
+  (`execution-error`, `outcome-unknown`) could move into SEP-2643 or the tasks extension,
+  leaving the approval-specific values (`approved-executed`, `denied-not-executed`) here. A
+  cross-SEP question for the sponsors.
+- **Extension versus Informational.** A sponsor who judges the normative surface too thin
+  may prefer an Informational SEP.
 
 ## Backward Compatibility
 
-Additive for new tools and new servers. A client that supports the tasks extension but
-not this one still observes a valid task lifecycle and a final
-`completed`/`failed`/`cancelled` task; there is no new client wire format, and no
-per-tool opt-in to change.
-
-For an existing tool that previously returned a synchronous denial, however, enabling
-approval gating changes the `tools/call` response set seen by existing integrations: a
-tasks client now receives a `CreateTaskResult`, and a non-tasks client receives
-`-32003` or the degraded requestable `CallToolResult` where a plain denial used to
-appear. That is a behavior change for upgraders, not a purely additive one.
+Additive for new tools and servers: a tasks client that does not implement this extension
+still observes a valid task lifecycle and a final `completed`/`failed`/`cancelled` task,
+with no new wire format. For an existing tool that previously returned a synchronous
+denial, enabling approval gating does change the observed `tools/call` response set (a
+`CreateTaskResult`, or `-32003` / a degraded requestable `CallToolResult`, where a plain
+denial used to appear), so it is a behavior change for upgraders, not purely additive.
 
 ## Reference Implementation
 
-Required before Final (this introduces observable protocol behavior). Planned:
+Required before Final (this introduces observable protocol behavior). Per SEP-2133 an
+Extension SEP also needs at least one official-SDK reference implementation, and named
+Extension Maintainers, before review; both are open prerequisites here. Planned: an MCP
+server fronting an approval backend (for example the AuthZEN ARAP) that returns
+`CreateTaskResult` for approval-gated calls and re-evaluates before execution, with a
+human-resolved and an automatically-resolved path; and a client built only on
+`io.modelcontextprotocol/tasks`, to show it interoperates with no approval-specific code.
 
-- an MCP server that fronts an OpenID AuthZEN policy decision point and access
-  request service, returning `CreateTaskResult` for approval-gated calls and
-  re-evaluating before execution, with at least one human-resolved and one
-  automatically-resolved approval path;
-- a client built only on the `io.modelcontextprotocol/tasks` extension, to
-  demonstrate that it interoperates with no approval-specific code.
-
-A conformance scenario tagged with the assigned SEP number, plus a `sep-NNNN.yaml`
-traceability file, is required for Final. The traceability file MUST cover these
-MCP-observable statements:
+A conformance scenario plus a `sep-NNNN.yaml` traceability file is required for Final,
+covering these MCP-observable statements:
 
 - a requestable denial returns a task without executing the tool;
 - approval resumes execution at most once;
-- a terminal denial is a `completed` task whose `CallToolResult` body (not only
-  `_meta`) marks it `denied-not-executed`, distinct from an execution error;
+- a terminal denial is a `completed` task whose `CallToolResult` body (not only `_meta`)
+  marks it `denied-not-executed`, distinct from an execution error;
 - a changed envelope (tool, arguments, principal, or subject/resource) requires a new
   approval;
 - a cancelled or expired task cannot later execute;
-- result retrieval does not expose backend approval artifacts;
+- result retrieval does not expose backend artifacts;
 - submission input flows through the task input channel.
-
-Server-internal behavior such as re-evaluation is referenced from the AuthZEN profile
-and is not MCP-observable. Not yet built.
 
 ## Security Implications
 
-- **Denial remains denial.** The server MUST NOT execute on the requestable denial
-  alone, and MUST re-evaluate after approval. The policy decision point is
-  authoritative at enforcement time.
-- **Authorization artifacts stay server-side.** Binding material (`binding_token`,
-  `approval`, `evaluation_id`) is never exposed to the client, preventing replay or
-  substitution through the client surface.
-- **The task handle is not a bearer approval token.** The `taskId` references a
-  pending decision; the server MUST re-derive authority from the bound call envelope
-  and current policy at execution (see The task handle is not authority), so holding a
-  `taskId` never authorizes execution of a different or mutated call.
-- **Task access control.** A `taskId` lets a caller poll and retrieve results.
-  SEP-2663 omits `tasks/list` precisely because tasks cannot always be bound to a
-  caller; task IDs are unguessable, single-task handles. The server MUST authorize
-  `tasks/get`, `tasks/update`, and `tasks/cancel` against the task's originating
-  authorization context, and MUST NOT leak approval contents or approver identity
-  through `statusMessage`.
-- **Confused deputy.** The server binds each task to the originally evaluated
-  subject, resource, action, and context, and applies an approval only within its
-  recorded scope. It MUST NOT let a client steer execution to a different operation
-  than the one that was approved.
-- **Out-of-band resolution.** Whoever or whatever decides (human, agent, policy
-  engine, external system), authentication, eligibility, and separation of duties are
-  properties of the approval service, outside MCP, as the approval profile specifies.
-- **Expiry.** The server MUST stop honoring an approval after its expiry and MUST
-  bound any downstream credential lifetime by it.
-- **Untrusted model-facing text.** `statusMessage` and `model-immediate-response` are
-  fed to the model and MUST be sanitized; a pending task MUST NOT be presented as a
-  completed action.
-- **At-most-once execution.** The server MUST execute an approved side-effecting tool
-  at most once per task and SHOULD deduplicate a retried requestable denial (by
-  originating context, tool, and arguments) so a poll timeout and replay cannot
-  double-execute.
-- **Approval-request amplification.** A compromised or buggy agent loop is the
-  expected failure mode here, not an edge case, and approval fatigue is a known
-  bypass. Deployments MUST rate-limit access-request submission per caller and SHOULD
-  bound the number of outstanding pending tasks per caller. When a limit is hit, the
-  server MUST return a non-requestable denial (a `CallToolResult` with `isError: true`,
-  not a task and not a requestable signal) so the agent does not retry-loop.
-- **The client cannot verify the gate.** "Denial remains denial" is enforced by the
-  server; the client receives no proof that the server re-evaluated rather than
-  executed. The binding material protects the server-to-PDP-to-approval-service path,
-  not the client's trust in the server. Clients needing stronger assurance must
-  obtain it out of band.
+- **Denial remains denial.** The server MUST NOT execute on the requestable denial alone
+  and MUST re-evaluate after approval; the client gets no proof, so assurance beyond that is
+  out of band.
+- **Artifacts stay server-side.** The backend's binding material never reaches the client,
+  preventing replay or substitution through the client surface.
+- **The task handle is not a bearer token.** Authority is re-derived at execution, so a
+  `taskId` never authorizes a different or mutated call (see The task handle is not authority).
+- **Task access control.** Task IDs are unguessable single-task handles; the server MUST
+  authorize `tasks/get`, `tasks/update`, and `tasks/cancel` against the task's originating
+  context and MUST NOT leak approval contents or approver identity through `statusMessage`.
+- **Confused deputy.** An approval applies only within the originally evaluated scope; the
+  server MUST NOT let a client steer execution to a different operation.
+- **Callback authenticity.** A backend callback MUST be authenticated, and unless it carries
+  an enforceable result the server MUST treat the backend's status source as authoritative
+  and fetch before executing. A forged or replayed callback MUST NOT cause execution.
+- **Expiry.** Before an execution claim, after expiry the server MUST stop honoring the
+  approval and durably fence the task against a late approval or callback; the claim is the
+  enforcement point, so an approval valid at the claim carries through (see Completion).
+- **At-most-once execution.** A durable execution claim guards against a crash re-invoking a
+  side-effecting tool, with `outcome-unknown` when the result cannot be confirmed;
+  cross-task deduplication is best-effort.
+- **Untrusted model-facing text.** `statusMessage` and `model-immediate-response` MUST be
+  sanitized, and a pending task MUST NOT be presented as completed.
+- **Approval-request amplification.** Approval fatigue is a known bypass; deployments MUST
+  rate-limit submission per caller and SHOULD bound outstanding pending tasks, returning a
+  non-requestable denial on a limit so the agent does not retry-loop.
+- **Out-of-band resolution.** Authentication, eligibility, and separation of duties for
+  whoever decides are the backend's, outside MCP.
+- **Durable sensitive state.** Crash recovery and delayed execution require persisting the
+  submission body, requester context, and complete tool arguments, which may hold
+  credentials, payment details, PII, and approval-binding artifacts. The server MUST protect
+  these records for confidentiality and integrity, scope access to the owning task, keep them
+  out of ordinary logs, and delete them when the task's retention ends. It SHOULD NOT persist
+  bearer credentials inside arguments; where unavoidable, they MUST be encrypted and held for
+  the minimum lifetime.
 
 ## References
 
 - [SEP-2663: Tasks Extension](./2663-tasks-extension.md)
 - [SEP-2322: Multi Round-Trip Requests](./2322-MRTR.md)
 - [SEP-2133: Extensions](./2133-extensions.md)
-- [OpenID AuthZEN Access Request and Approval Profile](https://openid.github.io/authzen/authzen-access-request-approval-profile-1_0.html)
+- [SEP-2575: Stateless MCP](./2575-stateless-mcp.md)
+- [SEP-2567: Sessionless MCP](./2567-sessionless-mcp.md)
+- [SEP-2260: Associate server requests with client requests](./2260-Require-Server-requests-to-be-associated-with-Client-requests.md)
+- [SEP-2643: Structured Authorization Denials](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2643) (open PR; this extension composes it once it lands, see Limitations)
+- [OpenID AuthZEN Access Request and Approval Profile](https://openid.github.io/authzen/authzen-access-request-approval-profile-1_0.html) — the example backend binding
 - [OpenID AuthZEN Authorization API 1.0](https://openid.github.io/authzen/)


### PR DESCRIPTION
## Summary

Draft **Extensions Track** SEP introducing an experimental extension,
`io.modelcontextprotocol/tool-approval`, that lets an MCP server gate a tool call on an
**out-of-band approval** without keeping the original request open. When the server's
authorization decision is a denial that is *requestable* (something can still approve it),
the server returns a task handle (SEP-2663 Tasks) in place of the tool result instead of
failing the call. The task stays `working` while the approval resolves out of band; on
approval the server re-evaluates policy and executes the tool, and the result is retrieved
via `tasks/get`.

The approval backend is **pluggable**. What approves is up to the deployment (a human
reviewer, a supervising agent, a policy or risk engine, an external ITSM/IGA system); the
approval protocol runs entirely server-side and never crosses the MCP wire; the client
carries only a server-generated `taskId`. The OpenID AuthZEN Access Request and Approval
Profile (ARAP) is included as a **non-normative example binding**, not a required backend.

## What it builds on

- **SEP-2663 (Tasks extension)** — the durable, server-directed task primitive.
- **SEP-2322 (MRTR)** — the pre-task request round-trip channel for submission input.
- **SEP-2643 (Structured Authorization Denials)** — its
  `io.modelcontextprotocol/authorization` envelope is composed as the portable denial
  classification.
- **SEP-2133 (Extensions)** — extension and capability framing.
- **AuthZEN ARAP** — a worked example backend binding (non-normative).

## Why this is worth a SEP

Tasks gives durable async execution but says nothing about *why* a call is pending or how a
decision resolves it, and no in-session primitive survives a disconnect. This SEP defines
the narrow, MCP-observable binding: a requestable denial returns a task, authorization
artifacts never cross the wire, a required `io.modelcontextprotocol/tool-approval-disposition`
distinguishes a denial (no side effect) from an execution error or an unconfirmed outcome,
and at-most-once execution under a durable claim.

## What changed in this revision

Decoupled from AuthZEN (generic pluggable backend; ARAP demoted to an example binding;
`io.modelcontextprotocol/*` identifiers) and substantially hardened after review:

- **Crash-consistency** — durable submission-intent, a per-submission idempotency key,
  persist-handle-before-return, restart reconciliation, and a generation fence so a stale
  chained-request callback cannot act.
- **Execution safety** — one atomic execution claim (at-most-once, the cancellation boundary
  and authorization-enforcement point), `outcome-unknown` when a result cannot be confirmed,
  and an execution deadline so a claimed task always terminalizes observably.
- **Authoritative enforcement** — the caller identity and intent are pinned by an immutable
  call binding, while dynamic authorization state (principal validity, resource, risk,
  environment, credential, policy) is re-read at execution, not replayed.
- **Composition** — composes SEP-2643's denial envelope, defines the disposition wire
  contract, reserves `failed` for JSON-RPC errors, and adds a three-clock retention model.
- **Security** — durable sensitive-state protection, authenticated callbacks with
  authoritative status retrieval, and an expiry fence.

## Open questions for reviewers (Limitations section)

- **Cross-principal resumption** is not portable at the MCP layer (`tasks/list` and sessions
  removed); same-principal resume across restart works.
- **Result-consumption orchestration** is out of scope; deployments must ensure a durable
  consumer or an independently auditable effect.
- **Placement of the generic disposition** — the execution-outcome values could move into
  SEP-2643 or Tasks; the approval-specific parts stay here.
- **Extension vs Informational** — posed for sponsor/Core Maintainer input.

## Status

`draft`. **Working Group and Extension Maintainers are TBD**, and an official-SDK reference
implementation is a prerequisite for review (SEP-2133) that is not yet met. The MCP
Fine-Grained Authorization WG is the proposed home given the authorization focus, while the
extension builds directly on Tasks. A prototype (an MCP server fronting an approval backend,
plus a tasks-only client) and a conformance scenario are required before Final.

## References

- [SEP-2643: Structured Authorization Denials](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2643) (open PR)
- [OpenID AuthZEN Access Request and Approval Profile](https://openid.github.io/authzen/authzen-access-request-approval-profile-1_0.html) — example backend binding
- [OpenID AuthZEN Authorization API 1.0](https://openid.github.io/authzen/)
