### PR TITLE
Rename Lifecycle to Versioning and Compatibility

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -321,7 +321,7 @@
                 "group": "Base Protocol",
                 "pages": [
                   "specification/draft/basic/index",
-                  "specification/draft/basic/lifecycle",
+                  "specification/draft/basic/versioning",
                   "specification/draft/basic/patterns",
                   {
                     "group": "Transports",
@@ -545,6 +545,10 @@
     {
       "source": "/clients",
       "destination": "/docs/getting-started/intro"
+    },
+    {
+      "source": "/specification/draft/basic/lifecycle",
+      "destination": "/specification/draft/basic/versioning"
     },
     {
       "source": "/specification/versioning",

--- a/docs/specification/draft/basic/index.mdx
+++ b/docs/specification/draft/basic/index.mdx
@@ -7,14 +7,14 @@ title: Overview
 The Model Context Protocol consists of several key components that work together:
 
 - **Base Protocol**: Core JSON-RPC message types
-- **Lifecycle Management**: Protocol version negotiation and per-request capability declaration
-- **Message Patterns**: Messaging patterns supported by the core protocol including request/response, multi round-trip requests (MRTR), and subscribe and notify
+- **Versioning and Compatibility**: Protocol version negotiation, extension negotiation, and interoperability with earlier protocol revisions
+- **Message Patterns**: Messaging patterns supported by the core protocol including request and response, multi round-trip requests (MRTR), and subscribe and notify
 - **Authorization**: Authentication and authorization framework for HTTP-based transports
 - **Server Features**: Resources, prompts, and tools exposed by servers
 - **Client Features**: Elicitation, sampling and root directory lists provided by clients
 - **Utilities**: Cross-cutting concerns like logging and argument completion
 
-All implementations **MUST** support the base protocol, lifecycle management,
+All implementations **MUST** support the base protocol, versioning,
 and the message patterns. Other components **MAY** be implemented based on the specific needs of the
 application.
 
@@ -129,6 +129,45 @@ The Model Context Protocol (MCP) supports several [Message Patterns](/specificat
 2. **[Multi Round-Trip Requests (MRTR)](/specification/draft/basic/patterns#multi-round-trip-requests)**: A server requires additional client input (sampling, elicitation, or roots) to complete a request.
 3. **[Subscribe and Notify](/specification/draft/basic/patterns#subscribe-and-notify)**: A client subscribes to a stream of notifications from the server, which are sent as they occur.
 
+## Statelessness
+
+The Model Context Protocol (MCP) is a **stateless protocol**: all the
+information needed to process a request is contained in the request itself.
+A server processes each request independently; no state should be inferred
+from previous requests, even those on the same connection or stream.
+
+Specifically:
+
+- Servers **MUST NOT** rely on prior requests over the same connection to
+  establish context (e.g., capabilities, protocol version, client identity).
+  Every request supplies this metadata in its [`_meta`](#meta) field.
+- Servers **SHOULD** be prepared to handle requests associated with multiple
+  tasks, threads, or conversations.
+- Servers **SHOULD NOT** require that a client reuse the same connection or process to
+  perform related operations.
+- Clients **SHOULD NOT** use an individual task, thread, or conversation as the
+  lifetime boundary for the stdio process.
+- State that needs to span multiple requests (e.g., long-running tasks,
+  application-level handles) **MUST** be referenced by an explicit identifier
+  the client passes on each request.
+
+<Note>
+  This implies that an open connection, such as a STDIO process, is not a
+  conversation or session: clients may interleave unrelated requests on the same
+  transport, and a server must not treat connection or process identity as a
+  proxy for conversation or session continuity.
+</Note>
+
+Long-lived requests like
+[`subscriptions/listen`](/specification/draft/basic/utilities/subscriptions)
+remain request/response; the response is just an open stream of notifications.
+Their state is scoped to the request itself, not to the connection underneath.
+
+<Info>
+  For a walkthrough of how the per-request model maps to SDK code, see the
+  [Architecture guide](/docs/learn/architecture#example).
+</Info>
+
 ## Auth
 
 MCP provides an [Authorization](/specification/draft/basic/authorization) framework for use with HTTP.
@@ -241,7 +280,7 @@ may reserve particular names for purpose-specific metadata, as declared in those
 Every client request **MUST** include the following `io.modelcontextprotocol/*` fields
 in `_meta`. Servers use these to identify the client and the protocol version in use
 without relying on any prior connection state. See
-[Lifecycle][lifecycle] for version negotiation rules.
+[Versioning and Compatibility][lifecycle] for version negotiation rules.
 
 | Key                                          | Type                 | Required | Description                                               |
 | -------------------------------------------- | -------------------- | -------- | --------------------------------------------------------- |
@@ -261,7 +300,7 @@ On notifications delivered via a [`subscriptions/listen`][subscriptions-listen] 
 the server **MUST** include `io.modelcontextprotocol/subscriptionId` in `_meta` so the
 client can correlate the notification with the originating subscription request.
 
-[lifecycle]: /specification/draft/basic/lifecycle
+[lifecycle]: /specification/draft/basic/versioning
 [subscriptions-listen]: /specification/draft/basic/utilities/subscriptions
 
 **OpenTelemetry trace context:**

--- a/docs/specification/draft/basic/transports/index.mdx
+++ b/docs/specification/draft/basic/transports/index.mdx
@@ -84,6 +84,6 @@ Earlier protocol revisions established a connection-scoped session with an
 `initialize` handshake and allowed servers to initiate JSON-RPC requests.
 Clients and servers that interoperate with those revisions detect the
 counterpart's era and fall back as described in
-[Lifecycle: Backward Compatibility](/specification/draft/basic/lifecycle#backward-compatibility-with-initialization-based-versions),
+[Versioning: Backward Compatibility](/specification/draft/basic/versioning#backward-compatibility-with-initialization-based-versions),
 which includes a compatibility matrix for implementors. Each binding page
 describes its transport-specific detection mechanics.

--- a/docs/specification/draft/basic/transports/stdio.mdx
+++ b/docs/specification/draft/basic/transports/stdio.mdx
@@ -146,9 +146,9 @@ request arrives after `initialize` and would process an era-ambiguous method
 (such as `tools/call`) under legacy semantics. Probing yields a
 deterministic failure instead.
 
-See [Lifecycle: Backward Compatibility][lifecycle-compat] for the era model
+See [Versioning: Backward Compatibility][lifecycle-compat] for the era model
 and a compatibility matrix for implementors.
 
 [server-discover]: /specification/draft/schema#discoverrequest
 [unsupported-version]: /specification/draft/schema#unsupportedprotocolversionerror
-[lifecycle-compat]: /specification/draft/basic/lifecycle#backward-compatibility-with-initialization-based-versions
+[lifecycle-compat]: /specification/draft/basic/versioning#backward-compatibility-with-initialization-based-versions

--- a/docs/specification/draft/basic/transports/streamable-http.mdx
+++ b/docs/specification/draft/basic/transports/streamable-http.mdx
@@ -238,7 +238,7 @@ version is unknown to the server, or is a known version the server has chosen
 not to support), it **MUST** respond with `400 Bad Request` and an
 [`UnsupportedProtocolVersionError`][unsupported-version]
 listing its supported versions. See
-[Lifecycle: Protocol Version Negotiation][lifecycle-version]
+[Versioning: Protocol Version Negotiation][lifecycle-version]
 for the negotiation flow.
 
 If the server does not implement the requested RPC method, it **MUST** respond
@@ -254,7 +254,7 @@ server that does not support such clients **MUST** reject a request without
 the header per [Server Validation](#server-validation).
 
 [unsupported-version]: /specification/draft/schema#unsupportedprotocolversionerror
-[lifecycle-version]: /specification/draft/basic/lifecycle#protocol-version-negotiation
+[lifecycle-version]: /specification/draft/basic/versioning#protocol-version-negotiation
 
 ### Standard Request Headers
 
@@ -612,7 +612,7 @@ falling back: modern servers also use `400` for
   back to `initialize` and continue with the legacy version for subsequent
   requests.
 
-See [Lifecycle: Backward Compatibility][lifecycle-compat] for the era model
+See [Versioning: Backward Compatibility][lifecycle-compat] for the era model
 and a compatibility matrix for implementors.
 
 ### Earlier Streamable HTTP Revisions
@@ -684,4 +684,4 @@ protocol version 2024-11-05) as follows:
        server running the old HTTP+SSE transport, and should use that
        transport for all subsequent communication.
 
-[lifecycle-compat]: /specification/draft/basic/lifecycle#backward-compatibility-with-initialization-based-versions
+[lifecycle-compat]: /specification/draft/basic/versioning#backward-compatibility-with-initialization-based-versions

--- a/docs/specification/draft/basic/versioning.mdx
+++ b/docs/specification/draft/basic/versioning.mdx
@@ -1,17 +1,16 @@
 ---
-title: Lifecycle
+title: Versioning and Compatibility
 ---
 
 <div id="enable-section-numbers" />
 
-This page defines the lifecycle of MCP interactions: how a client and server
-establish mutual understanding of protocol version and capabilities, how
-optional extensions are negotiated, and how implementations interoperate
-with earlier, handshake-based protocol revisions.
+This page defines how a client and server agree on what they are speaking:
+the protocol version, declared on every request; optional extensions,
+negotiated through capabilities; and interoperability with earlier,
+handshake-based protocol revisions.
 
-MCP has no connection-scoped lifecycle. Every request carries the
-information needed to process it, and the server processes each request
-independently:
+There is no negotiation handshake. Every request carries its protocol
+version, and the server accepts or rejects each request independently:
 
 ```mermaid
 sequenceDiagram
@@ -27,11 +26,6 @@ sequenceDiagram
     end
 ```
 
-<Info>
-  For a walkthrough of how the per-request model maps to SDK code, see the
-  [Architecture guide](/docs/learn/architecture#example).
-</Info>
-
 ## Terminology
 
 This page uses the following terms for interoperability across protocol
@@ -43,41 +37,6 @@ revisions:
   `initialize` handshake (`2025-11-25` and earlier).
 - **Dual-era**: an implementation that supports both modern and legacy
   versions.
-
-## Statelessness
-
-The Model Context Protocol (MCP) is a **stateless protocol**: all the
-information needed to process a request is contained in the request itself.
-A server processes each request independently; no state should be inferred
-from previous requests, even those on the same connection or stream.
-
-Specifically:
-
-- Servers **MUST NOT** rely on prior requests over the same connection to
-  establish context (e.g., capabilities, protocol version, client identity).
-  Every request supplies this metadata in its
-  [`_meta`](/specification/draft/basic/index#meta) field.
-- Servers **SHOULD** be prepared to handle requests associated with multiple
-  tasks, threads, or conversations.
-- Servers **SHOULD NOT** require that a client reuse the same connection or process to
-  perform related operations.
-- Clients **SHOULD NOT** use an individual task, thread, or conversation as the
-  lifetime boundary for the stdio process.
-- State that needs to span multiple requests (e.g., long-running tasks,
-  application-level handles) **MUST** be referenced by an explicit identifier
-  the client passes on each request.
-
-<Note>
-  This implies that an open connection, such as a STDIO process, is not a
-  conversation or session: clients may interleave unrelated requests on the same
-  transport, and a server must not treat connection or process identity as a
-  proxy for conversation or session continuity.
-</Note>
-
-Long-lived requests like
-[`subscriptions/listen`](/specification/draft/basic/utilities/subscriptions)
-remain request/response; the response is just an open stream of notifications.
-Their state is scoped to the request itself, not to the connection underneath.
 
 ## Protocol Version Negotiation
 

--- a/docs/specification/draft/server/discover.mdx
+++ b/docs/specification/draft/server/discover.mdx
@@ -81,7 +81,7 @@ is useful in two scenarios:
   [stdio: Backward Compatibility](/specification/draft/basic/transports/stdio#backward-compatibility)
   for the fallback rules.
 
-See [Protocol Version Negotiation](/specification/draft/basic/lifecycle#protocol-version-negotiation)
+See [Protocol Version Negotiation](/specification/draft/basic/versioning#protocol-version-negotiation)
 for the full version-selection flow. For HTTP-specific status codes returned for
 unknown methods, see the [Protocol Version Header](/specification/draft/basic/transports/streamable-http#protocol-version-header)
 section in Transports.


### PR DESCRIPTION
> [!NOTE]
> Stacked on #2845 (which is stacked on #2844). Review the diff against `refactor/transport-docs`.

## Motivation and Context

The draft made MCP stateless, and the Lifecycle page no longer describes a lifecycle. There is no initialize/operate/shutdown sequence: initialization became per-request `_meta`, and shutdown is a transport-binding concern documented on the binding pages (the only real lifecycle left is the channel's, and it lives there). Comparable stateless protocols name this material versioning/conformance, not lifecycle; lifecycle sections belong to connection-oriented protocols (TLS, QUIC, WebSocket).

What remains on the page has a single theme: how two implementations agree on what they are speaking.

## Changes

- Rename `basic/lifecycle.mdx` to `basic/versioning.mdx`, titled "Versioning and Compatibility": protocol version negotiation, extension negotiation, era terminology, and backward compatibility with the matrix. Redirect added; section anchors unchanged.
- Move the statelessness section to the base-protocol overview (`basic/index.mdx`), where the execution model belongs, next to Messages and Message Patterns.
- Update the components list and the conformance sentence in the overview, navigation, and all draft-internal links. Released spec versions keep their Lifecycle pages, since those protocol revisions genuinely had one.

## How was this tested?

`npm run prep` passes and `mint broken-links` is clean.