### PR TITLE
fix(docs): replace dead Python auth sample link in authorization tutorial

### DIFF
--- a/docs/docs/tutorials/security/authorization.mdx
+++ b/docs/docs/tutorials/security/authorization.mdx
@@ -616,7 +616,7 @@ For more details about implementing MCP servers in TypeScript, refer to the [Typ
 
 <Tab title='Python'>
 
-You can see the complete Python project in the [sample repository](https://github.com/localden/min-py-mcp-auth).
+You can see the complete Python project in the [sample repository](https://github.com/modelcontextprotocol/python-sdk/tree/main/examples/servers/simple-auth).
 
 To simplify our authorization interaction, in Python scenarios we rely on [FastMCP](https://gofastmcp.com/getting-started/welcome). Many of the conventions around authorization, like the endpoints and token validation logic, are consistent across languages, but some offer simpler ways of integrating them in production scenarios.
 


### PR DESCRIPTION
## Summary

Fixes the dead link in the Python tab of the authorization tutorial.

`localden/min-py-mcp-auth` returns 404. Replaced with the official `modelcontextprotocol/python-sdk` simple-auth example, which is the canonical OAuth2 resource-server reference under the org.

Closes #1790

## Changes

- `docs/docs/tutorials/security/authorization.mdx` line 619: URL updated

## Testing

- `npm run check:docs` format and comments checks pass
- Replacement URL verified live (HTTP 200)
