### PR TITLE
Add redirects for renamed draft spec pages and fix dead tasks link

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -545,12 +545,57 @@
       "destination": "/specification/draft/basic/versioning"
     },
     {
+      "source": "/specification/draft/basic/utilities/cancellation",
+      "destination": "/specification/draft/basic/patterns/cancellation"
+    },
+    {
+      "source": "/specification/draft/basic/utilities/progress",
+      "destination": "/specification/draft/basic/patterns/progress"
+    },
+    {
+      "source": "/specification/draft/basic/utilities/subscriptions",
+      "destination": "/specification/draft/basic/patterns/subscriptions"
+    },
+    {
+      "source": "/specification/draft/basic/utilities/ping",
+      "destination": "/specification/draft/basic/index"
+    },
+    {
+      "source": "/specification/draft/basic/utilities/tasks",
+      "destination": "/specification/draft/changelog"
+    },
+    {
       "source": "/specification/versioning",
       "destination": "/docs/learn/versioning"
     },
     {
       "source": "/specification/latest",
       "destination": "/specification/2025-11-25",
+      "permanent": false
+    },
+    {
+      "source": "/specification/latest/basic/lifecycle",
+      "destination": "/specification/2025-11-25/basic/lifecycle",
+      "permanent": false
+    },
+    {
+      "source": "/specification/latest/basic/utilities/cancellation",
+      "destination": "/specification/2025-11-25/basic/utilities/cancellation",
+      "permanent": false
+    },
+    {
+      "source": "/specification/latest/basic/utilities/ping",
+      "destination": "/specification/2025-11-25/basic/utilities/ping",
+      "permanent": false
+    },
+    {
+      "source": "/specification/latest/basic/utilities/progress",
+      "destination": "/specification/2025-11-25/basic/utilities/progress",
+      "permanent": false
+    },
+    {
+      "source": "/specification/latest/basic/utilities/tasks",
+      "destination": "/specification/2025-11-25/basic/utilities/tasks",
       "permanent": false
     },
     {

--- a/docs/seps/2322-MRTR.mdx
+++ b/docs/seps/2322-MRTR.mdx
@@ -878,7 +878,7 @@ The workflow here would look like this:
 
 ### Persistent Tool Workflow
 
-The persistent tool workflow will leverage Tasks. [`Tasks`](https://modelcontextprotocol.io/specification/draft/basic/utilities/tasks) already provide a mechanism to indicate that more information is needed to complete the request. The `input_required` Task Status allows the server to indicate that additional information is needed to complete processing the task.
+The persistent tool workflow will leverage Tasks. [`Tasks`](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks) already provide a mechanism to indicate that more information is needed to complete the request. The `input_required` Task Status allows the server to indicate that additional information is needed to complete processing the task.
 
 The workflow for `Tasks` is as follows:
 

--- a/seps/2322-MRTR.md
+++ b/seps/2322-MRTR.md
@@ -860,7 +860,7 @@ The workflow here would look like this:
 
 ### Persistent Tool Workflow
 
-The persistent tool workflow will leverage Tasks. [`Tasks`](https://modelcontextprotocol.io/specification/draft/basic/utilities/tasks) already provide a mechanism to indicate that more information is needed to complete the request. The `input_required` Task Status allows the server to indicate that additional information is needed to complete processing the task.
+The persistent tool workflow will leverage Tasks. [`Tasks`](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks) already provide a mechanism to indicate that more information is needed to complete the request. The `input_required` Task Status allows the server to indicate that additional information is needed to complete processing the task.
 
 The workflow for `Tasks` is as follows:
 


### PR DESCRIPTION
## What this does

The draft restructure renamed `basic/utilities/` to `basic/patterns/` and removed the ping/tasks pages without adding redirects, so the old draft URLs 404 on the live site today (e.g. `/specification/draft/basic/utilities/cancellation`).

## Changes

- Add redirects for the five old draft utilities paths (cancellation/progress/subscriptions → `basic/patterns/*`; ping → `basic/index`; tasks → `changelog`).
- Add non-permanent `/specification/latest/basic/lifecycle` and `/specification/latest/basic/utilities/*` redirects pinned to `2025-11-25`, so existing guide links survive when `latest` is repointed at the next release.
- Fix the dead link in SEP-2322 (`seps/2322-MRTR.md` source), which pointed at the removed draft tasks page; now pinned to the 2025-11-25 version that still hosts it.

## After merge

When the next dated version directory is cut, the release checklist should add the equivalent dated redirects (`/specification/<date>/basic/utilities/*` → `patterns/*`, `basic/lifecycle` → `basic/versioning`). A version-parameterized redirect was deliberately not used: it would hijack the still-live utilities pages of 2025-11-25 and earlier versions.

## Verification

All redirect targets verified to exist; `npm run prep` link checker passes clean.