### PR TITLE
Fix Header Names on Extensions Page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -100,7 +100,7 @@
             ]
           },
           {
-            "group": "MCP Tasks",
+            "group": "Tasks",
             "pages": [
               "extensions/tasks/overview"
             ]

--- a/docs/extensions/apps/overview.mdx
+++ b/docs/extensions/apps/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: MCP Apps
+sidebarTitle: Overview
 description: Interactive UI applications that render inside MCP hosts like Claude Desktop
 ---
 

--- a/docs/extensions/apps/overview.mdx
+++ b/docs/extensions/apps/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: MCP Apps
+title: Overview
 description: Interactive UI applications that render inside MCP hosts like Claude Desktop
 ---
 

--- a/docs/extensions/auth/overview.mdx
+++ b/docs/extensions/auth/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: Authorization Extensions
+sidebarTitle: Overview
 description: Supplementary authorization mechanisms for the Model Context Protocol
 ---
 

--- a/docs/extensions/auth/overview.mdx
+++ b/docs/extensions/auth/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Authorization Extensions
+title: Overview
 description: Supplementary authorization mechanisms for the Model Context Protocol
 ---
 

--- a/docs/extensions/tasks/overview.mdx
+++ b/docs/extensions/tasks/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: MCP Tasks
+title: Overview
 description: Asynchronous task execution for long-running MCP operations
 ---
 

--- a/docs/extensions/tasks/overview.mdx
+++ b/docs/extensions/tasks/overview.mdx
@@ -1,14 +1,15 @@
 ---
-title: Overview
+title: Tasks
+sidebarTitle: Overview
 description: Asynchronous task execution for long-running MCP operations
 ---
 
 The [experimental-ext-tasks repository](https://github.com/modelcontextprotocol/experimental-ext-tasks) contains the full specification and documentation for MCP Tasks.
 
 <Card
-  title="modelcontextprotocol/experimental-ext-tasks"
+  title="modelcontextprotocol/ext-tasks"
   icon="github"
-  href="https://github.com/modelcontextprotocol/experimental-ext-tasks"
+  href="https://github.com/modelcontextprotocol/ext-tasks"
 >
   Full specification and documentation for MCP Tasks.
 </Card>


### PR DESCRIPTION
## Motivation and Context
The Extension Page Tab layout does not match the rest of the site.

Currently it's Extension Name -> Extension Name. This PR switches it to be 
Extension Name -> Overview

Also rename MCP Tasks to just Tasks, no need to have the MCP prefix.
We are leaving MCP Apps as MCP Apps as this matches the current branding/community naming.  

This was discussed as a docs issue in Core Maintainers meeting on 6/3

## Breaking Changes
no

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
