### PR TITLE
fix(docs): handle multiple tool calls in process_query

### DIFF
--- a/docs/docs/develop/build-client.mdx
+++ b/docs/docs/develop/build-client.mdx
@@ -187,44 +187,42 @@ async def process_query(self, query: str) -> str:
     # Process response and handle tool calls
     final_text = []
 
-    assistant_message_content = []
+    while response.stop_reason == "tool_use":
+        # Collect any text blocks in this response
+        for content in response.content:
+            if content.type == "text":
+                final_text.append(content.text)
+
+        # Add the full assistant turn to the conversation
+        messages.append({"role": "assistant", "content": response.content})
+
+        # Execute all tool calls and gather results
+        tool_results = []
+        for content in response.content:
+            if content.type == "tool_use":
+                result = await self.session.call_tool(content.name, content.input)
+                final_text.append(f"[Calling tool {content.name} with args {content.input}]")
+                tool_results.append({
+                    "type": "tool_result",
+                    "tool_use_id": content.id,
+                    "content": result.content
+                })
+
+        # Add all tool results in a single user message
+        messages.append({"role": "user", "content": tool_results})
+
+        # Get next response from Claude
+        response = self.anthropic.messages.create(
+            model="claude-sonnet-4-20250514",
+            max_tokens=1000,
+            messages=messages,
+            tools=available_tools
+        )
+
+    # Collect the final text response
     for content in response.content:
-        if content.type == 'text':
+        if content.type == "text":
             final_text.append(content.text)
-            assistant_message_content.append(content)
-        elif content.type == 'tool_use':
-            tool_name = content.name
-            tool_args = content.input
-
-            # Execute tool call
-            result = await self.session.call_tool(tool_name, tool_args)
-            final_text.append(f"[Calling tool {tool_name} with args {tool_args}]")
-
-            assistant_message_content.append(content)
-            messages.append({
-                "role": "assistant",
-                "content": assistant_message_content
-            })
-            messages.append({
-                "role": "user",
-                "content": [
-                    {
-                        "type": "tool_result",
-                        "tool_use_id": content.id,
-                        "content": result.content
-                    }
-                ]
-            })
-
-            # Get next response from Claude
-            response = self.anthropic.messages.create(
-                model="claude-sonnet-4-20250514",
-                max_tokens=1000,
-                messages=messages,
-                tools=available_tools
-            )
-
-            final_text.append(response.content[0].text)
 
     return "\n".join(final_text)
 ```

--- a/docs/docs/develop/build-client.mdx
+++ b/docs/docs/develop/build-client.mdx
@@ -187,26 +187,32 @@ async def process_query(self, query: str) -> str:
     # Process response and handle tool calls
     final_text = []
 
-    while response.stop_reason == "tool_use":
-        # Collect any text blocks in this response
+    # Cap the number of tool-use turns so a misbehaving tool loop can't run forever
+    MAX_TOOL_TURNS = 10
+    for _ in range(MAX_TOOL_TURNS):
+        tool_uses = []
         for content in response.content:
             if content.type == "text":
                 final_text.append(content.text)
+            elif content.type == "tool_use":
+                tool_uses.append(content)
+
+        if not tool_uses:
+            return "\n".join(final_text)
 
         # Add the full assistant turn to the conversation
         messages.append({"role": "assistant", "content": response.content})
 
         # Execute all tool calls and gather results
         tool_results = []
-        for content in response.content:
-            if content.type == "tool_use":
-                result = await self.session.call_tool(content.name, content.input)
-                final_text.append(f"[Calling tool {content.name} with args {content.input}]")
-                tool_results.append({
-                    "type": "tool_result",
-                    "tool_use_id": content.id,
-                    "content": result.content
-                })
+        for tool_use in tool_uses:
+            result = await self.session.call_tool(tool_use.name, tool_use.input)
+            final_text.append(f"[Calling tool {tool_use.name} with args {tool_use.input}]")
+            tool_results.append({
+                "type": "tool_result",
+                "tool_use_id": tool_use.id,
+                "content": result.content
+            })
 
         # Add all tool results in a single user message
         messages.append({"role": "user", "content": tool_results})
@@ -219,11 +225,7 @@ async def process_query(self, query: str) -> str:
             tools=available_tools
         )
 
-    # Collect the final text response
-    for content in response.content:
-        if content.type == "text":
-            final_text.append(content.text)
-
+    final_text.append(f"[Stopped after {MAX_TOOL_TURNS} tool-use turns]")
     return "\n".join(final_text)
 ```
 


### PR DESCRIPTION
## Problem

The `process_query` function in the Python client quickstart (`docs/docs/develop/build-client.mdx`) has two bugs when the model returns multiple tool calls in a single response:

1. **Corrupted conversation history** — the `for` loop appends `assistant_message_content` to `messages` and fires a new API call *inside* the loop, once per tool call. On the second iteration, `assistant_message_content` has grown and the history is malformed.

2. **Crash on non-text first block** — after the loop, the code accesses `response.content[0].text` unconditionally. If the first content block is a tool use block, this raises `AttributeError`.

Both bugs are silent when only one tool call is returned per turn but surface as soon as the model decides to batch tool calls.

## Fix

Replace the `for` loop with a `while response.stop_reason == "tool_use"` loop that:
- Appends the full assistant turn (`response.content`) to history once per turn
- Collects *all* tool results for that turn before making the next API call
- Falls through to collect the final text response after all tool rounds complete

This matches the agentic loop pattern described in the [Anthropic tool use docs](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use#handling-tool-use-and-tool-result-content-blocks).