### PR TITLE
schema: add self-describing `$id` to generated schema.json

### DIFF
--- a/schema/2024-11-05/schema.json
+++ b/schema/2024-11-05/schema.json
@@ -1,4 +1,5 @@
 {
+    "$id": "https://modelcontextprotocol.io/schemas/2024-11-05/schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "Annotated": {

--- a/schema/2025-03-26/schema.json
+++ b/schema/2025-03-26/schema.json
@@ -1,4 +1,5 @@
 {
+    "$id": "https://modelcontextprotocol.io/schemas/2025-03-26/schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "Annotations": {

--- a/schema/2025-06-18/schema.json
+++ b/schema/2025-06-18/schema.json
@@ -1,4 +1,5 @@
 {
+    "$id": "https://modelcontextprotocol.io/schemas/2025-06-18/schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "Annotations": {

--- a/schema/2025-11-25/schema.json
+++ b/schema/2025-11-25/schema.json
@@ -1,4 +1,5 @@
 {
+    "$id": "https://modelcontextprotocol.io/schemas/2025-11-25/schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$defs": {
         "Annotations": {

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -1,4 +1,5 @@
 {
+    "$id": "https://modelcontextprotocol.io/schemas/draft/schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$defs": {
         "Annotations": {

--- a/scripts/generate-schemas.ts
+++ b/scripts/generate-schemas.ts
@@ -16,6 +16,30 @@ const MODERN_SCHEMAS = ['2025-11-25', 'draft'];
 // All schema versions to generate
 const ALL_SCHEMAS = [...LEGACY_SCHEMAS, ...MODERN_SCHEMAS];
 
+/**
+ * Build the canonical `$id` for a given schema version, so the generated
+ * `schema.json` is self-describing about which MCP protocol version it
+ * represents (independent of the directory it lives in).
+ */
+function schemaId(version: string): string {
+  return `https://modelcontextprotocol.io/schemas/${version}/schema.json`;
+}
+
+/**
+ * Add a top-level `$id` to a generated schema document.
+ *
+ * `typescript-json-schema --id` is intentionally not used here: it additionally
+ * rewrites every internal `$ref` to an absolute URL. We only want the
+ * self-describing `$id` while keeping the existing fragment-only refs, so we
+ * inject it directly after the opening brace (before `$schema`).
+ */
+function addSchemaId(content: string, version: string): string {
+  return content.replace(
+    /^\{\n/,
+    `{\n    "$id": ${JSON.stringify(schemaId(version))},\n`
+  );
+}
+
 // Check if we're in check mode (validate existing schemas match generated ones)
 const CHECK_MODE = process.argv.includes('--check');
 
@@ -76,6 +100,8 @@ async function generateSchema(version: string, check: boolean = false): Promise<
         expectedSchema = expectedSchema.replace(/#\/definitions\//g, '#/$defs/');
       }
 
+      expectedSchema = addSchemaId(expectedSchema, version);
+
       // Compare
       if (existingSchema.trim() !== expectedSchema.trim()) {
         console.error(`  ✗ Schema ${version} is out of date!`);
@@ -103,6 +129,13 @@ async function generateSchema(version: string, check: boolean = false): Promise<
     if (!LEGACY_SCHEMAS.includes(version)) {
       applyJsonSchema202012Transformations(schemaJson);
     }
+
+    // Add the self-describing `$id` for the protocol version
+    writeFileSync(
+      schemaJson,
+      addSchemaId(readFileSync(schemaJson, 'utf-8'), version),
+      'utf-8'
+    );
 
     console.log(`  ✓ Generated schema for ${version}`);
     return true;


### PR DESCRIPTION
## Summary

Closes #394.

The generated `schema.json` files carry a `$schema` field (the JSON Schema dialect they use), but nothing that identifies **which MCP protocol version** the document represents. Tooling and humans can't tell e.g. `2025-11-25` from `draft` by inspecting the file — they have to know which directory it came from.

This adds a top-level `$id` to every generated schema:

```json
{
    "$id": "https://modelcontextprotocol.io/schemas/draft/schema.json",
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    ...
```

The URI follows the `modelcontextprotocol.io/schemas/<version>/` convention already used for the registry schemas (see `docs/registry/remote-servers.mdx`).

## Implementation notes

- The `$id` is injected in `scripts/generate-schemas.ts` rather than via `typescript-json-schema --id`. The `--id` flag *also* rewrites every internal `$ref` to an absolute URL (`#/$defs/Role` → `https://…/schema.json#/$defs/Role`), which would churn 100–270 lines per file. Injecting the field directly keeps the diff to a single added line per schema and leaves the existing fragment-only refs untouched.
- Both the generate and the `--check` code paths apply the same injection, so `npm run check:schema:json` stays in sync.
- This is build-time metadata only — no message shapes or protocol semantics change. Approach follows @jonathanhefner's suggestion in #394.

## Verification

- `npm run check:schema` passes (`tsc` + eslint + prettier, the `--check` regeneration match, 127 example validations, and the generated `schema.mdx` comparison).
- Diff is exactly one added line per `schema.json` across all five versions, plus the generator change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)