### PR TITLE
Mark Archestra.AI as supporting OAuth Client Credentials

### DIFF
--- a/docs/extensions/client-matrix.mdx
+++ b/docs/extensions/client-matrix.mdx
@@ -41,7 +41,7 @@ This list is maintained by the community. If you notice any inaccuracies or woul
 | [MCPJam](https://www.mcpjam.com/)                        |               <CHECK />               |                                                                       |                                                                      |
 | [ChatGPT](https://chatgpt.com/)                          |               <CHECK />               |                                                                       |                                                                      |
 | [Cursor](https://cursor.com/)                            |               <CHECK />               |                                                                       |                                                                      |
-| [Archestra.AI](https://www.archestra.ai/)                |               <CHECK />               |                                                                       |                              <CHECK />                               |
+| [Archestra.AI](https://www.archestra.ai/)                |               <CHECK />               |                               <CHECK />                               |                              <CHECK />                               |
 
 <Note>
 


### PR DESCRIPTION
Archestra's MCP gateway authenticates machine-to-machine callers with the OAuth 2.0 client credentials grant (`grant_type=client_credentials`) — issuing and validating bearer tokens with no interactive user login. Adds the missing check for Archestra.AI in the OAuth Client Credentials column.