### PR TITLE
docs: complete account linking guidance in enterprise-managed authori…

### DIFF
--- a/docs/extensions/auth/enterprise-managed-authorization.mdx
+++ b/docs/extensions/auth/enterprise-managed-authorization.mdx
@@ -123,7 +123,7 @@ To require enterprise-managed authorization:
 
 2. **Map IdP claims to permissions** — ID-JAG tokens carry claims (scope and resource information) that your server uses to determine who the employee is and what the employee can access. Define your authorization logic based on these claims.
 
-3. **Handle Account Linking** - ID-JAG tokens will always contain a subject claim and may additionally contain an email claim that can be used to
+3. **Handle Account Linking** - ID-JAG tokens will always contain a subject claim and may additionally contain an email claim that can be used to link the enterprise identity to an existing account in your system. Use the subject claim as the primary stable identifier for the user, and fall back to the email claim for matching against pre-existing accounts that were created before enterprise-managed authorization was configured.
 
 ## Client support
 


### PR DESCRIPTION
Complete the incomplete sentence in the "For MCP Authorization Servers" section regarding account linking with ID-JAG token claims.

## Motivation and Context
The enterprise-managed authorization documentation had an incomplete bullet point (point 3 under "For MCP Authorization Servers") that cut off mid-sentence. This left implementers without guidance on how to handle account linking using subject and email claims from ID-JAG tokens.

## How Has This Been Tested?
Documentation-only change. Verified the rendered content reads correctly and provides actionable guidance for MCP Authorization Server implementers.

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
The completed sentence advises implementers to use the subject claim as the primary stable identifier and fall back to the email claim for matching pre-existing accounts created before enterprise-managed authorization was configured.
