### PR TITLE
docs: explain tool selection in The Complete Flow

### DIFF
--- a/docs/docs/learn/server-concepts.mdx
+++ b/docs/docs/learn/server-concepts.mdx
@@ -277,4 +277,8 @@ Consider a personalized AI travel planner application, with three connected serv
    - `createCalendarEvent()` - Adds the trip to the user's calendar
    - `sendEmail()` - Sends confirmation with trip details
 
+   **Why does the AI call `checkWeather()`?** The prompt template defines the _intent_ ("plan a vacation"), not a fixed script of tool calls. None of the prompt's arguments mention weather—the AI decides to check it by reasoning over the task and the tool descriptions that connected servers advertise (discovered via `tools/list`). Forecasts are useful for trip planning, so the model requests `checkWeather()` on its own. Tool selection is AI-driven inference, not something the template dictates.
+
+   **What if no Weather Server is connected?** The AI can only call tools that connected servers expose. If no Weather Server is present, `checkWeather()` is not available, and the AI proceeds with the tools it has. Weather here is an optional enrichment rather than a requirement—the workflow adapts to whichever capabilities are connected.
+
 **The result:** Through multiple MCP servers, the user researched and booked a Barcelona trip tailored to their schedule. The "Plan a Vacation" prompt guided the AI to combine Resources (calendar availability and travel history) with Tools (searching flights, booking hotels, updating calendars) across different servers—gathering context and executing the booking. A task that could have taken hours was completed in minutes using MCP.


### PR DESCRIPTION
## Summary

Closes #2966.

"The Complete Flow" walks through a multi-server travel example where, in step 3, the AI calls `checkWeather()`. The issue points out that the docs never explain why — the `plan-vacation` prompt arguments (destination, dates, budget, travelers) say nothing about weather. This adds a short clarification right after the tool steps answering the three questions raised:

- **Why does the AI call `checkWeather()`?** Tool selection is model-driven inference over the tools that connected servers advertise (via `tools/list`), not a fixed script encoded in the prompt template.
- **What if no Weather Server is connected?** The AI can only call tools that connected servers expose; without a Weather Server, `checkWeather()` isn't available and the flow proceeds with the tools it has — weather is an optional enrichment, not a requirement.

This stays consistent with the page's existing framing that tools are model-controlled and discovered via `tools/list`.

## Changes

- `docs/docs/learn/server-concepts.mdx`: two short paragraphs in "The Complete Flow".

Docs-only. `npm run check:docs:format` and `check:docs:js-comments` pass.

## AI assistance disclosure

This change was drafted with AI assistance (Claude Code). I reviewed the wording for technical accuracy against the rest of the page and the MCP tool model.

<!-- oss-radar:idempotency=auto-20260623-105023.w1.modelcontextprotocol_modelcontextprotocol.2966 -->