### PR TITLE
Add SDK vulnerability disclosure process and stdio trust boundary to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,6 +73,22 @@ executes those configurations. Reports about "arbitrary command execution" via S
 transport configuration, whether in MCP client applications or SDKs, are not
 vulnerabilities. Process spawning is a core feature of the STDIO transport mechanism.
 
+#### STDIO Transport Trust Boundary
+
+When using the stdio transport, the client spawns the server as a local subprocess in the
+designated environment (e.g., OS, containerized sandbox) and both run with equivalent
+environment-level privilege. The SDK does not defend either peer against a malicious
+counterpart across the stdio channel: a malicious server already has arbitrary code
+execution by virtue of being run, and a malicious client already has full process control
+over the server it spawned.
+
+Out of scope (file as a regular issue, no CVE/GHSA): reports whose only impact is that one
+stdio peer can crash, hang, exhaust resources of, or otherwise deny service to the other.
+If the affected SDK code is reachable via any of the supported remote transports or results
+in vulnerabilities such as a sandbox escape, the report remains in scope. Deployments that
+run stdio servers at reduced privilege (containers, sandboxes) are responsible for enforcing
+isolation at that boundary; the SDK's stdio transport is not a sandbox.
+
 #### Server Capabilities and Side Effects
 
 MCP servers provide capabilities that may have significant effects on the system or
@@ -171,6 +187,24 @@ from flaws in the MCP specification or official SDK implementations:
   multi-tenant deployments
 
 This list is not exhaustive.
+
+## SDK Vulnerability Disclosure
+
+Security reports against the official MCP SDKs are handled through GitHub Security
+Advisories on the affected SDK's repository. Private vulnerability reporting is enabled on
+every official SDK repository in the modelcontextprotocol organization.
+
+When a report is received, the maintainers of that SDK assess whether the same issue
+affects other official SDKs. Many MCP vulnerabilities stem from shared patterns, transport
+implementations, or spec-level behavior that multiple SDKs implement the same way. The
+receiving maintainers coordinate with the maintainers of other potentially affected SDKs to
+determine which are impacted and to what degree, so that fixes and advisories can be
+released together rather than leaving some SDKs exposed after others have published.
+
+If the root cause is a defect in the specification rather than an implementation bug, the
+coordinating maintainers will discuss this with the specification maintainers.
+
+CVEs are assigned through GitHub's CNA as part of the GHSA workflow.
 
 ### Reporting Guidelines
 

--- a/docs/community/security.mdx
+++ b/docs/community/security.mdx
@@ -48,7 +48,7 @@ vulnerabilities. One of the most common is stdio peer attacks, summarized below.
 ### Stdio transport trust boundary
 
 When using the stdio transport, the client spawns the server as a local subprocess and both
-run with equivalent environment-level privilege. The SDK does not defend either peer
+might run with equivalent environment-level privilege. The SDK does not defend either peer
 against a malicious counterpart across the stdio channel: a malicious server already has
 arbitrary code execution by virtue of being run, and a malicious client already has full
 process control over the server it spawned.

--- a/docs/community/security.mdx
+++ b/docs/community/security.mdx
@@ -1,0 +1,67 @@
+---
+title: Security Policy
+description: How to report security vulnerabilities in the Model Context Protocol specification and SDKs, what is in and out of scope, and how SDK maintainers coordinate disclosure.
+---
+
+This page summarizes how security reports are handled across the Model Context Protocol
+project. The full policy, including the trust model and the complete list of behaviors that
+are intentional and not eligible as vulnerabilities, lives in
+[SECURITY.md](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/SECURITY.md)
+in the specification repository.
+
+## Reporting a vulnerability
+
+Report security issues through GitHub Security Advisories on the affected repository.
+Private vulnerability reporting is enabled on the specification repository and on every
+official SDK repository in the [modelcontextprotocol](https://github.com/modelcontextprotocol)
+organization.
+
+Do not report security issues through public issues, discussions, or pull requests.
+
+## SDK disclosure and cross-SDK coordination
+
+When a report is filed against an SDK, the maintainers of that SDK assess whether the same
+issue affects other official SDKs. Many MCP vulnerabilities stem from shared patterns,
+transport implementations, or spec-level behavior that multiple SDKs implement the same
+way. The receiving maintainers coordinate with the maintainers of other potentially
+affected SDKs to determine which are impacted and to what degree, so that fixes and
+advisories can be released together rather than leaving some SDKs exposed after others have
+published.
+
+If the root cause is a defect in the specification rather than an implementation bug, the
+coordinating maintainers will discuss this with the specification maintainers.
+
+CVEs are assigned through GitHub's CNA as part of the GHSA workflow.
+
+## Scope
+
+The following are considered security vulnerabilities when they arise from flaws in the
+specification or official SDKs: protocol-level vulnerabilities, authentication or
+authorization bypasses, implementation bugs such as injection or memory-safety issues,
+sandbox escapes, session hijacking, token leakage, and cross-tenant access.
+
+The full
+[SECURITY.md](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/SECURITY.md)
+documents the MCP trust model and a list of intentional behaviors that are not
+vulnerabilities. One of the most common is stdio peer attacks, summarized below.
+
+### Stdio transport trust boundary
+
+When using the stdio transport, the client spawns the server as a local subprocess and both
+run with equivalent environment-level privilege. The SDK does not defend either peer
+against a malicious counterpart across the stdio channel: a malicious server already has
+arbitrary code execution by virtue of being run, and a malicious client already has full
+process control over the server it spawned.
+
+Reports whose only impact is that one stdio peer can crash, hang, exhaust resources of, or
+otherwise deny service to the other are out of scope and should be filed as regular issues
+rather than as a GHSA. If the affected SDK code is reachable via any of the supported
+remote transports, or results in a sandbox escape, the report remains in scope. Deployments
+that run stdio servers at reduced privilege are responsible for enforcing isolation at that
+boundary. The SDK's stdio transport is not a sandbox.
+
+## Security Interest Group
+
+The [Security Interest Group](/community/interest-groups/security) is the venue for
+discussing MCP-specific threats, reviewing security-relevant proposals, and routing
+disclosure questions that don't fit a single repository.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -487,6 +487,7 @@
               "community/contributor-ladder",
               "community/feature-lifecycle",
               "community/sdk-tiers",
+              "community/security",
               "community/antitrust"
             ]
           },


### PR DESCRIPTION
Adds the SDK vulnerability disclosure process and the stdio transport trust boundary to SECURITY.md, and adds a community docs page at `/community/security` so the policy is discoverable from the docs site.

The stdio section documents that stdio peers run with equivalent privilege and the SDK does not defend either against the other. Reports whose only impact is one stdio peer denying service to the other are out of scope for GHSA/CVE and should be filed as regular issues. The same code reachable via a remote transport remains in scope.

The SDK disclosure section documents that reports go to GHSA on the affected SDK repository, with maintainers coordinating across SDKs to determine which are impacted before publishing, and discussing spec-level root causes with the specification maintainers.

The new `docs/community/security.mdx` page summarizes the policy for the docs site and links back to SECURITY.md as the canonical reference.