### PR TITLE
docs: fix elicitation example to use requestedSchema

### DIFF
--- a/docs/docs/learn/client-concepts.mdx
+++ b/docs/docs/learn/client-concepts.mdx
@@ -55,7 +55,7 @@ The flow enables dynamic information gathering. Servers can request specific dat
   method: "elicitation/create",
   params: {
     message: "Please confirm your Barcelona vacation booking details:",
-    schema: {
+    requestedSchema: {
       type: "object",
       properties: {
         confirmBooking: {


### PR DESCRIPTION
## What

Fixes the elicitation request example in `docs/docs/learn/client-concepts.mdx`.
The example used a `schema` field:

```typescript
{
  method: "elicitation/create",
  params: {
    message: "...",
    schema: { ... }   // ❌
  }
}
```

but the canonical field name is **`requestedSchema`**. This matches:

- `schema/draft/schema.ts` / `schema/2025-06-18/schema.ts` (`ElicitRequest.params.requestedSchema`)
- `schema/draft/examples/ElicitRequest/elicitation-request.json`
- the specification page `docs/specification/2025-06-18/client/elicitation.mdx`

## Why

A reader copying the learn-page example would send `params.schema`, which a
spec-compliant client ignores (it reads `params.requestedSchema`), so the
elicitation form would be empty. The fix aligns the learn doc with the spec.

## Change

One-line field rename `schema:` → `requestedSchema:` in the elicitation
components example. No other content changed.
