### PR TITLE
docs: simplify Mcp-Param client note for missing inputSchema

### DIFF
--- a/docs/seps/2243-http-standardization.mdx
+++ b/docs/seps/2243-http-standardization.mdx
@@ -455,7 +455,7 @@ When constructing a `tools/call` request via HTTP transport, the client MUST:
 1. Encode the values according to the rules in [Value Encoding](#value-encoding)
 1. Append a `Mcp-Param-{Name}: {Value}` header to the request:
 
-> **Implementation Note**: Clients MUST construct `Mcp-Param-*` headers using the most recently obtained `inputSchema` for the tool. A client that has never obtained the tool's `inputSchema` SHOULD send the request without `Mcp-Param-*` headers. If the server rejects the request because required `Mcp-Param-*` headers are missing or do not match the body, the client SHOULD call `tools/list` to obtain the current `inputSchema`, then retry the original request with the appropriate headers. Clients MAY pre-load tool definitions via other means (e.g., from a previous session or configuration) to enable header emission without a prior `tools/list` call.
+> **Implementation Note**: If the server rejects the request because required `Mcp-Param-*` headers are missing or do not match the body, the client SHOULD call `tools/list` to obtain the current `inputSchema`, then retry the original request with the appropriate headers.
 
 #### Server Behavior
 

--- a/docs/specification/draft/basic/transports/streamable-http.mdx
+++ b/docs/specification/draft/basic/transports/streamable-http.mdx
@@ -538,16 +538,10 @@ When constructing a `tools/call` request via HTTP transport, the client
 
 <Note>
 
-Clients **MUST** construct `Mcp-Param-*` headers using the most recently
-obtained `inputSchema` for the tool. A client that has never obtained the
-tool's `inputSchema` **SHOULD** send the request without `Mcp-Param-*`
-headers. If the server rejects the request because required `Mcp-Param-*`
-headers are missing or do not match the body, the client **SHOULD** call
+If the server rejects the request because required `Mcp-Param-*` headers
+are missing or do not match the body, the client **SHOULD** call
 `tools/list` to obtain the current `inputSchema`, then retry the original
-request with the appropriate headers. Clients **MAY** pre-load tool
-definitions via other means (e.g., from a previous session or
-configuration) to enable header emission without a prior `tools/list`
-call.
+request with the appropriate headers.
 
 </Note>
 

--- a/seps/2243-http-standardization.md
+++ b/seps/2243-http-standardization.md
@@ -439,7 +439,7 @@ When constructing a `tools/call` request via HTTP transport, the client MUST:
 1. Encode the values according to the rules in [Value Encoding](#value-encoding)
 1. Append a `Mcp-Param-{Name}: {Value}` header to the request:
 
-> **Implementation Note**: Clients MUST construct `Mcp-Param-*` headers using the most recently obtained `inputSchema` for the tool. A client that has never obtained the tool's `inputSchema` SHOULD send the request without `Mcp-Param-*` headers. If the server rejects the request because required `Mcp-Param-*` headers are missing or do not match the body, the client SHOULD call `tools/list` to obtain the current `inputSchema`, then retry the original request with the appropriate headers. Clients MAY pre-load tool definitions via other means (e.g., from a previous session or configuration) to enable header emission without a prior `tools/list` call.
+> **Implementation Note**: If the server rejects the request because required `Mcp-Param-*` headers are missing or do not match the body, the client SHOULD call `tools/list` to obtain the current `inputSchema`, then retry the original request with the appropriate headers.
 
 #### Server Behavior
 


### PR DESCRIPTION
## Summary

Remove the ambiguous `inputSchema` availability implementation note from the `Mcp-Param-*` client guidance and retain only the reject → `tools/list` → retry path.

Clients are already required to inspect `inputSchema` when constructing custom headers (step 3 in Client Behavior). The removed note suggested an invalid state where a client might call a tool without ever having fetched the schema.

Updates the same text in:
- `docs/specification/draft/basic/transports/streamable-http.mdx`
- `docs/seps/2243-http-standardization.mdx`
- `seps/2243-http-standardization.md`

Fixes #2974

## Test plan

- [x] `prettier --check` on edited files
- [ ] CI validate + format workflows
