### PR TITLE
docs: clarify SEP-2243 HeaderMismatch error code

### DIFF
--- a/docs/seps/2243-http-standardization.mdx
+++ b/docs/seps/2243-http-standardization.mdx
@@ -796,3 +796,9 @@ Implementation requirements:
 - **Server SDKs**: Provide a mechanism (attribute/decorator) for marking parameters with `x-mcp-header`
 - **Client SDKs**: Implement the client behavior for extracting and encoding header values
 - **Validation**: Both sides must validate header/body consistency
+
+## Changes since SEP became Final
+
+This SEP is preserved as a historical record of what was accepted. The list below tracks changes made to the specification after this SEP reached Final status. Refer to the current [specification](https://modelcontextprotocol.io/specification) for the authoritative, up-to-date requirements.
+
+- **`HeaderMismatch` error code reassigned from `-32001` to `-32020`.** This SEP originally assigned `HeaderMismatch` to `-32001`. The error-code allocation update in [#2907](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2907) reassigned `HeaderMismatch` to `-32020`. All references to `-32001` above should be read as `-32020` when implementing against the current specification.

--- a/docs/seps/2549-TTL-for-list-results.mdx
+++ b/docs/seps/2549-TTL-for-list-results.mdx
@@ -177,7 +177,7 @@ Servers MUST apply the same cacheScope to all response pages for a given list re
 
 ### Error handling
 
-- For backwards compatibility, If `ttlMs` is missing, clients SHOULD assume a default ttlMs of 0 (immediately stale) and rely on their own caching heuristics or notifications.
+- For backwards compatibility, If `ttlMs` is missing, clients SHOULD assume a default `ttlMs` of `0` (immediately stale) and rely on their own caching heuristics or notifications.
 - If `ttlMs` is present but is a negative integer, the client SHOULD ignore it and behave as if it were 0 (immediately stale).
 
 ## Rationale

--- a/seps/2243-http-standardization.md
+++ b/seps/2243-http-standardization.md
@@ -780,3 +780,9 @@ Implementation requirements:
 - **Server SDKs**: Provide a mechanism (attribute/decorator) for marking parameters with `x-mcp-header`
 - **Client SDKs**: Implement the client behavior for extracting and encoding header values
 - **Validation**: Both sides must validate header/body consistency
+
+## Changes since SEP became Final
+
+This SEP is preserved as a historical record of what was accepted. The list below tracks changes made to the specification after this SEP reached Final status. Refer to the current [specification](https://modelcontextprotocol.io/specification) for the authoritative, up-to-date requirements.
+
+- **`HeaderMismatch` error code reassigned from `-32001` to `-32020`.** This SEP originally assigned `HeaderMismatch` to `-32001`. The error-code allocation update in [#2907](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2907) reassigned `HeaderMismatch` to `-32020`. All references to `-32001` above should be read as `-32020` when implementing against the current specification.


### PR DESCRIPTION
Fixes #2991

## Motivation and Context

[SEP-2243](https://modelcontextprotocol.io/seps/2243-http-standardization) still documented `HeaderMismatch` as `-32001`, but [the current draft specification](https://modelcontextprotocol.io/specification/draft/basic/transports/streamable-http#server-validation) and schema use `-32020` after the error-code renumbering in modelcontextprotocol/modelcontextprotocol#2907.

SEP-2243|Draft Spec
-|-
<img width="1748" height="1566" alt="2026-06-30 at 09 32 28" src="https://github.com/user-attachments/assets/5243bfd2-9c4c-4400-8461-db3556f63394" />|<img width="1752" height="1580" alt="2026-06-30 at 09 30 35" src="https://github.com/user-attachments/assets/596c5a3d-4827-4b42-8be4-1115a1f02937" />

This updates the SEP text, examples, and conformance tables to use `-32020`, and adds a note explaining that SEP-2243 originally assigned `HeaderMismatch` to `-32001` before the draft spec renumbered it.

## How Has This Been Tested?

Documentation-only change.

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

This came up during modelcontextprotocol/rust-sdk#907.