### PR TITLE
docs: add Code of Conduct appeals channel (appeals@modelcontextprotocol.io)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -104,6 +104,25 @@ toward or disparagement of classes of individuals.
 **Consequence**: A permanent ban from any sort of public interaction within the
 community.
 
+## Appeals
+
+If you believe an enforcement action taken against you was made in error, you may appeal
+it by emailing appeals@modelcontextprotocol.io. This channel exists specifically for
+appealing Code of Conduct enforcement actions, including organization-level bans.
+
+Because appeals are handled over email rather than on GitHub, you can reach the team even
+if your access to GitHub repositories, issues, or pull requests has been removed as part
+of an enforcement action.
+
+When submitting an appeal, please include:
+
+- The account or username affected by the action
+- The action you are appealing (for example, a temporary or permanent ban)
+- Why you believe the action should be reconsidered
+
+Appeals are reviewed by the moderation and lead maintainer team. We will consider your
+request and respond as promptly and fairly as we can.
+
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0,

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -122,7 +122,7 @@ When submitting an appeal, please include:
   any surrounding context
 
 Appeals are reviewed by the moderation and lead maintainer team. While we will make an
-effort to respond to appeals filed in good faith, bandwidth contraints mean we may not
+effort to respond to appeals filed in good faith, bandwidth constraints mean we may not
 be able to respond to every appeal. We will only review one appeal per enforcement action,
 so please be thorough when submitting your appeal.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -118,10 +118,13 @@ When submitting an appeal, please include:
 
 - The account or username affected by the action
 - The action you are appealing (for example, a temporary or permanent ban)
-- Why you believe the action should be reconsidered
+- Why you believe the action should be reconsidered, with thorough evidence supporting
+  any surrounding context
 
-Appeals are reviewed by the moderation and lead maintainer team. We will consider your
-request and respond as promptly and fairly as we can.
+Appeals are reviewed by the moderation and lead maintainer team. While we will make an
+effort to respond to appeals filed in good faith, bandwidth contraints mean we may not
+be able to respond to every appeal. We will only review one appeal per enforcement action,
+so please be thorough when submitting your appeal.
 
 ## Attribution
 


### PR DESCRIPTION
## Summary

Adds an **Appeals** section to `CODE_OF_CONDUCT.md` introducing `appeals@modelcontextprotocol.io` as the official out-of-band channel for appealing Code of Conduct enforcement actions, including organization-level GitHub bans.

### Why

When someone is blocked at the GitHub org level they lose access to all repos, issues, and PRs — so an appeals channel can't live on GitHub. The `appeals@modelcontextprotocol.io` Google Group accepts mail from anyone (including banned/external users) and delivers to the current moderation + lead-maintainer team. This makes moderation decisions reversible: moderators can act decisively knowing an incorrectly-banned person has a documented way to request reinstatement.

The group was stood up in [modelcontextprotocol/access#123](https://github.com/modelcontextprotocol/access/pull/123) (merged). That PR's description named this follow-up: *"After this inbox is confirmed working, we can add it in a section in the Code of Conduct and provide guidelines for how to submit an appeal."* This PR is that follow-up.

### What changed

A new `## Appeals` section, slotted immediately after the **Enforcement Guidelines** ladder (which defines the temporary/permanent bans being appealed) and before **Attribution**. It names the channel, explains why email/out-of-band matters, and gives concise guidelines for what to include — matching the document's existing Contributor Covenant voice without over-engineering a formal process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

