### PR TITLE
Correct several claims in the SDK betas blog post

### DIFF
--- a/blog/content/posts/2026-06-29-sdk-betas-for-2026-07-28.md
+++ b/blog/content/posts/2026-06-29-sdk-betas-for-2026-07-28.md
@@ -1,7 +1,7 @@
 ---
 title: "Beta SDKs for the 2026-07-28 MCP Spec Release Candidate Are Here"
-date: "2026-06-29T09:00:00+00:00"
-publishDate: "2026-06-29T09:00:00+00:00"
+date: "2026-07-01T09:00:00+00:00"
+publishDate: "2026-07-01T09:00:00+00:00"
 slug: sdk-betas-2026-07-28
 description: "Beta releases of the Python, TypeScript, Go, and C# SDKs are now available with support for the 2026-07-28 MCP specification release candidate. Here is what changes for your server, how to migrate, and how to test before the spec goes final on July 28."
 author:
@@ -23,7 +23,7 @@ session, and completing the plan we laid out in
 [The Future of MCP Transports](/posts/2025-12-19-mcp-transport-future/). If you're building MCP
 servers, you can now scale them using a simple round-robin load balancer, removing the need to
 manage sticky sessions and to store shared sessions. For client developers, new patterns, like
-[Multi Round-Trip Requests (MRTR)](http://modelcontextprotocol.io/specification/draft/basic/patterns/mrtr)
+[Multi Round-Trip Requests (MRTR)](https://modelcontextprotocol.io/specification/draft/basic/patterns/mrtr)
 enable a whole new range of possibilities for server-to-client interactions. You can check out
 the [full changelog](https://modelcontextprotocol.io/specification/draft/changelog) to see
 what's coming.
@@ -51,16 +51,22 @@ before the new specification is locked. For any critical workloads, the stable S
 remain the recommended versions.
 
 You might've seen that some of the SDKs, like Python and TypeScript, have also switched to v2.
+Those are new major versions, so moving your own code onto them is a breaking change, and one
+you can take on your own schedule; it is separate from anything that happens on July 28.
 Once v2 ships, the TypeScript SDK will continue shipping v1.x bug fixes and security updates
 for at least six months, and the Python v1.x branch continues to receive critical bug fixes and
 security patches.
 
-Trying a beta is safe because it is opt-in at every step. Installing any of
-the four aforementioned SDKs without explicitly requesting a pre-release still resolves to
-a stable version. The opt-in extends to the wire: in the TypeScript and Go
-SDKs, upgrading does not by itself change what your server speaks over
+Trying a beta is safe because it is opt-in at every step. Installing the
+Python, Go, or C# SDK without explicitly requesting a pre-release still resolves to
+a stable version; the TypeScript v2 packages are new package names with no
+stable release yet, so installing them is itself the opt-in. In the TypeScript and Go
+SDKs, the opt-in extends to the wire: upgrading does not by itself change what your server speaks over
 HTTP. Serving `2026-07-28` is an explicit choice you make when you wire up
-the transport. And clients that speak `2026-07-28` fall back to the
+the transport. A Python or C# server picks up the new revision on upgrade
+instead: a Python v2 server answers both protocol revisions from one
+endpoint, and the C# preview's HTTP transport defaults to the new stateless
+mode. And clients that speak `2026-07-28` fall back to the
 `initialize` handshake when they reach a server on `2025-11-25` or earlier,
 so old servers and new clients keep interoperating.
 
@@ -74,8 +80,8 @@ If you want to make sure your own users are not caught out:
 
 ## What beta SDKs implement
 
-All four beta releases implement the protocol changes from the release candidate,
-with each release's notes listing exactly which SEPs are covered. The
+All four beta releases implement the core protocol changes from the release candidate,
+with each release's notes detailing which changes are covered. The
 [RC announcement](/posts/2026-07-28-release-candidate/) covers the changes
 in depth, but if you're curious about the short version:
 
@@ -91,8 +97,9 @@ in depth, but if you're curious about the short version:
   required!
 - **Routable transport headers**
   ([SEP-2243](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2243)).
-  `Mcp-Method` and `Mcp-Name` ride on every request so gateways and rate
-  limiters can route without parsing bodies.
+  `Mcp-Method` rides on every request, and `Mcp-Name` on requests that name
+  a tool, resource, or prompt, so gateways and rate limiters can route
+  without parsing bodies.
 - **Authorization hardening**, including `iss` validation per
   [RFC 9207](https://www.rfc-editor.org/rfc/rfc9207)
   ([SEP-2468](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2468)),
@@ -124,8 +131,9 @@ lists every change against `2025-11-25`.
 
 ## Python: `mcp` v2
 
-The v2 line is a rework of the package you already know, and the API got
-smaller in the process. A complete server can now be implemented like this:
+The v2 line is a rework of the package you already know: `FastMCP` becomes
+`MCPServer`, and the decorator API carries over. A complete server still
+looks like this:
 
 ```python
 from mcp.server import MCPServer
@@ -145,8 +153,8 @@ def greeting(name: str) -> str:
     return f"Hello, {name}!"
 ```
 
-No JSON Schema to write, as idiomatic Python constructs take over. Install the beta
-with an exact pin, since unpinned installs stay on v1.x:
+As in v1, there is no JSON Schema to write, as idiomatic Python constructs take over.
+Install the beta with an exact pin, since unpinned installs stay on v1.x:
 
 ```bash
 uv add "mcp[cli]==2.0.0b1"

--- a/blog/content/posts/2026-06-29-sdk-betas-for-2026-07-28.md
+++ b/blog/content/posts/2026-06-29-sdk-betas-for-2026-07-28.md
@@ -1,7 +1,7 @@
 ---
 title: "Beta SDKs for the 2026-07-28 MCP Spec Release Candidate Are Here"
-date: "2026-07-01T09:00:00+00:00"
-publishDate: "2026-07-01T09:00:00+00:00"
+date: "2026-06-29T09:00:00+00:00"
+publishDate: "2026-06-29T09:00:00+00:00"
 slug: sdk-betas-2026-07-28
 description: "Beta releases of the Python, TypeScript, Go, and C# SDKs are now available with support for the 2026-07-28 MCP specification release candidate. Here is what changes for your server, how to migrate, and how to test before the spec goes final on July 28."
 author:


### PR DESCRIPTION
A few corrections to the SDK betas post now that the releases are out and the claims can be checked against them.

- **Install opt-in**: "Installing any of the four aforementioned SDKs without explicitly requesting a pre-release still resolves to a stable version" is not true for TypeScript. The v2 packages (`@modelcontextprotocol/server` and friends) are new package names whose only release is `2.0.0-beta.1`, and npm's `latest` tag points at it, so a bare `npm install @modelcontextprotocol/server` gets the beta. The paragraph now scopes the stable-resolution claim to Python, Go, and C#, and says installing the new TypeScript packages is itself the opt-in.
- **Wire behavior on upgrade**: the transport-level opt-in described in that paragraph applies to TypeScript and Go, but Python and C# take the opposite default. A Python v2 server answers both protocol revisions from one endpoint as soon as you upgrade, and the C# preview's HTTP transport defaults to stateless mode. Added a sentence saying so.
- **Major versions**: added a sentence making explicit that the v2 SDK lines are new major versions, so moving your own code onto them is a breaking change you take on your own schedule, separate from anything that happens on July 28.
- **Python framing**: the post presented the schema-free decorator server as new in v2, but the example is v1's FastMCP quickstart almost verbatim, and that API shipped in v1.2.0. Reworded to say the decorator API carries over ("FastMCP becomes MCPServer") and dropped "the API got smaller", which does not hold up against the actual v2 surface.
- **Routing headers**: `Mcp-Name` does not ride on every request, only on requests that name a tool, resource, or prompt (`tools/call`, `resources/read`, `prompts/get`) per SEP-2243. A gateway configured from the original sentence would reject conforming traffic.
- **Release notes**: not every SDK's release notes list exactly which SEPs are covered (the TypeScript notes do not mention SEPs at all), so that clause is softened.
- **Link fix**: the MRTR link was the post's only `http://` URL; now `https://`.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>