### PR TITLE
docs: inline style to proportionally render icons

### DIFF
--- a/docs/docs/develop/build-server.mdx
+++ b/docs/docs/develop/build-server.mdx
@@ -2966,7 +2966,7 @@ Save the file, and restart **Claude for Desktop**.
 
 ### Test with commands
 
-Let's make sure Claude for Desktop is picking up the two tools we've exposed in our `weather` server. You can do this by looking for the "Add files, connectors, and more /" <img src="/images/claude-add-files-connectors-and-more.png" style={{display: 'inline', margin: 0, height: '1.3em'}} /> icon:
+Let's make sure Claude for Desktop is picking up the two tools we've exposed in our `weather` server. You can do this by looking for the "Add files, connectors, and more /" <img src="/images/claude-add-files-connectors-and-more.png" style={{display: 'inline', margin: 0, height: '1.3em', width: 'auto'}} /> icon:
 
 <Frame>
   <img src="/images/visual-indicator-mcp-tools.png" />

--- a/docs/docs/develop/connect-local-servers.mdx
+++ b/docs/docs/develop/connect-local-servers.mdx
@@ -149,7 +149,7 @@ Only grant access to directories you're comfortable with Claude reading and modi
 <Step title="Restart Claude Desktop">
 After saving the configuration file, completely quit Claude Desktop and restart it. The application needs to restart to load the new configuration and start the MCP server.
 
-Upon successful restart, click the "Add files, connectors, and more /" indicator <img src="/images/claude-add-files-connectors-and-more.png" style={{display: 'inline', margin: 0, height: '1.3em'}} /> in the bottom-left corner of the conversation input box:
+Upon successful restart, click the "Add files, connectors, and more /" indicator <img src="/images/claude-add-files-connectors-and-more.png" style={{display: 'inline', margin: 0, height: '1.3em', width: 'auto'}} /> in the bottom-left corner of the conversation input box:
 
 <Frame>
   <img

--- a/docs/docs/develop/connect-remote-servers.mdx
+++ b/docs/docs/develop/connect-remote-servers.mdx
@@ -30,7 +30,7 @@ The process of connecting Claude to a remote MCP server involves adding a Custom
 <Step title="Navigate to Connector Settings">
 Open Claude Desktop or Claude in your browser, then navigate to the settings page:
 
-- **Desktop**: Either use the keyboard shortcut `Ctrl+Comma` or click the top-left menu icon <img src="/images/claude-desktop-hamburger-menu-icon.png" style={{display: 'inline', margin: 0, height: '1.3em'}} />, hover over "File", and select "Settings"
+- **Desktop**: Either use the keyboard shortcut `Ctrl+Comma` or click the top-left menu icon <img src="/images/claude-desktop-hamburger-menu-icon.png" style={{display: 'inline', margin: 0, height: '1.3em', width: 'auto'}} />, hover over "File", and select "Settings"
 - **Browser**: Either use the keyboard shortcut `⌘⇧,` (_macOS_) or click on your profile icon, and select "Settings" from the menu
 
 Once you're in the settings page, click "Connectors" in the sidebar. This displays your currently configured connectors and provides options for adding new ones.
@@ -79,7 +79,7 @@ Follow the authentication prompts provided by the server. This may redirect you 
 </Step>
 
 <Step title="Access Resources and Prompts">
-After successful connection, the remote server’s resources and prompts become available in your Claude conversations. You can access these by clicking the "Add files, connectors, and more /" indicator <img src="/images/claude-add-files-connectors-and-more.png" style={{display: 'inline', margin: 0, height: '1.3em'}} /> in the bottom-left corner of the message input area. Then hover over "Connectors", move the cursor over "Add to Example Remote Server", where hovering displays the attachment menu.
+After successful connection, the remote server’s resources and prompts become available in your Claude conversations. You can access these by clicking the "Add files, connectors, and more /" indicator <img src="/images/claude-add-files-connectors-and-more.png" style={{display: 'inline', margin: 0, height: '1.3em', width: 'auto'}} /> in the bottom-left corner of the message input area. Then hover over "Connectors", move the cursor over "Add to Example Remote Server", where hovering displays the attachment menu.
 
 <Frame>
   <img


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Live site and local site render icons differently. Changes applied:

- Added inline style of `width: 'auto'` to all instances of icons:
  - `claude-desktop-hamburger-menu-icon.png`
  - `claude-add-files-connectors-and-more.png`

Pages changed:

- `connect-local-servers.mdx`: 1 instance of inline style added
- `connect-remote-servers.mdx`: 2 instances of inline style added
- `build-server.mdx`: 1 instance of inline style added

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Prior review of [PR #3073](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/3073) using `npm run serve:docs` rendered the icons correctly (_like this PR_). On the live site the icons are rendered unproportionally wider.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Tested icon rendering with browser DevTools (_F12_) on the live website, applying `width: auto` to elements.

My "Goldilocks-esque" verdict is:

- Removing height: Renders icon too large
- Width only: Renders icon too small on responsive screen (_iphone_)
- Height only (_current_): Renders icon too unproportionally wide
- Using both: Renders icon just right

Ran `npm run serve:docs` to ensure no parsing error.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
  - Failing jobs are not from files changed in this PR
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
I looked for the other icons from the `docs/image` folder to see if they needed updating, but is seems they are not being used. Icons checked are:

- `claude-desktop-mcp-plug-icon.svg`
- `claude-desktop-mcp-slider.svg`
