### PR TITLE
docs: add a consolidated table of reserved `_meta` keys

### DIFF
--- a/docs/specification/draft/basic/index.mdx
+++ b/docs/specification/draft/basic/index.mdx
@@ -349,6 +349,7 @@ The following `_meta` keys are currently reserved by this specification:
 
 | Key                                          | Description                                                 | Defined in                                                         |
 | -------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------ |
+| `progressToken`                              | Opts the request into progress notifications                | [Progress](/specification/draft/basic/patterns/progress)           |
 | `io.modelcontextprotocol/protocolVersion`    | Protocol version for a request                              | Per-request protocol fields (below)                                |
 | `io.modelcontextprotocol/clientInfo`         | Client name and version                                     | Per-request protocol fields (below)                                |
 | `io.modelcontextprotocol/clientCapabilities` | Client capabilities relevant to a request                   | Per-request protocol fields (below)                                |

--- a/docs/specification/draft/basic/index.mdx
+++ b/docs/specification/draft/basic/index.mdx
@@ -345,7 +345,7 @@ implementations **MUST NOT** make assumptions about values at these keys.
 
 **Reserved keys:**
 
-The following `_meta` keys are currently reserved by this specification:
+The following `_meta` keys are reserved by this specification:
 
 | Key                                          | Description                                                 | Defined in                                                         |
 | -------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------ |

--- a/docs/specification/draft/basic/index.mdx
+++ b/docs/specification/draft/basic/index.mdx
@@ -359,7 +359,8 @@ The following `_meta` keys are reserved by this specification:
 
 Official [extensions](/specification/draft/basic/versioning#extension-negotiation)
 define additional `_meta` keys under the `io.modelcontextprotocol/` prefix, and
-each extension's documentation.
+third-party extensions use their own vendor prefix.
+In both cases the keys are specified in the extension's documentation.
 
 **Per-request protocol fields:**
 

--- a/docs/specification/draft/basic/index.mdx
+++ b/docs/specification/draft/basic/index.mdx
@@ -343,6 +343,23 @@ implementations **MUST NOT** make assumptions about values at these keys.
 - Unless empty, MUST begin and end with an alphanumeric character (`[a-z0-9A-Z]`).
 - MAY contain hyphens (`-`), underscores (`_`), dots (`.`), and alphanumerics in between.
 
+**Reserved keys:**
+
+The following `_meta` keys are currently reserved by this specification:
+
+| Key                                          | Description                                                 | Defined in                                                         |
+| -------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------ |
+| `io.modelcontextprotocol/protocolVersion`    | Protocol version for a request                              | Per-request protocol fields (below)                                |
+| `io.modelcontextprotocol/clientInfo`         | Client name and version                                     | Per-request protocol fields (below)                                |
+| `io.modelcontextprotocol/clientCapabilities` | Client capabilities relevant to a request                   | Per-request protocol fields (below)                                |
+| `io.modelcontextprotocol/logLevel`           | Minimum log level the server should emit for a request      | [Logging](/specification/draft/server/utilities/logging)           |
+| `io.modelcontextprotocol/subscriptionId`     | Correlates a notification with its originating subscription | [Subscriptions](/specification/draft/basic/patterns/subscriptions) |
+| `traceparent`, `tracestate`, `baggage`       | OpenTelemetry trace context propagation                     | OpenTelemetry trace context (below)                                |
+
+[Extensions](/specification/draft/basic/versioning#extension-negotiation) may
+define additional `_meta` keys under the reserved prefix; these are specified in
+each extension's documentation.
+
 **Per-request protocol fields:**
 
 Every client request **MUST** include the following `io.modelcontextprotocol/*` fields

--- a/docs/specification/draft/basic/index.mdx
+++ b/docs/specification/draft/basic/index.mdx
@@ -358,7 +358,7 @@ The following `_meta` keys are currently reserved by this specification:
 | `traceparent`, `tracestate`, `baggage`       | OpenTelemetry trace context propagation                     | OpenTelemetry trace context (below)                                |
 
 [Extensions](/specification/draft/basic/versioning#extension-negotiation) may
-define additional `_meta` keys under the reserved prefix; these are specified in
+define additional `_meta` keys under the `io.modelcontextprotocol/` prefix, and
 each extension's documentation.
 
 **Per-request protocol fields:**

--- a/docs/specification/draft/basic/index.mdx
+++ b/docs/specification/draft/basic/index.mdx
@@ -357,7 +357,7 @@ The following `_meta` keys are reserved by this specification:
 | `io.modelcontextprotocol/subscriptionId`     | Correlates a notification with its originating subscription | [Subscriptions](/specification/draft/basic/patterns/subscriptions) |
 | `traceparent`, `tracestate`, `baggage`       | OpenTelemetry trace context propagation                     | OpenTelemetry trace context (below)                                |
 
-[Extensions](/specification/draft/basic/versioning#extension-negotiation) may
+Official [extensions](/specification/draft/basic/versioning#extension-negotiation)
 define additional `_meta` keys under the `io.modelcontextprotocol/` prefix, and
 each extension's documentation.
 


### PR DESCRIPTION
The keys reserved by the spec were scattered across prose in several pages (per-request fields, logging, subscriptions, OpenTelemetry), making it easy to miss one. List them in a single table in the General fields section, pointing to where each key is normatively defined. Extension-defined keys stay in each extension's own documentation.
