### PR TITLE
docs: redirect old draft basic/utilities paths to basic/patterns

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -590,6 +590,22 @@
       "destination": "/specification/draft/basic/versioning"
     },
     {
+      "source": "/specification/draft/basic/utilities/cancellation",
+      "destination": "/specification/draft/basic/patterns/cancellation"
+    },
+    {
+      "source": "/specification/draft/basic/utilities/mrtr",
+      "destination": "/specification/draft/basic/patterns/mrtr"
+    },
+    {
+      "source": "/specification/draft/basic/utilities/progress",
+      "destination": "/specification/draft/basic/patterns/progress"
+    },
+    {
+      "source": "/specification/draft/basic/utilities/subscriptions",
+      "destination": "/specification/draft/basic/patterns/subscriptions"
+    },
+    {
       "source": "/specification/versioning",
       "destination": "/docs/learn/versioning"
     },


### PR DESCRIPTION
ea7c32ad moved cancellation, mrtr, progress, and subscriptions from
`draft/basic/utilities/` to `draft/basic/patterns/` without adding redirects, so
the old URLs 404 today. This adds the four redirects. #2892 covered the same gap
but was closed unmerged with a stale branch.