### PR TITLE
docs: repoint the SEP feature-matrix citation at the archived matrix

### DIFF
--- a/docs/seps/1577--sampling-with-tools.mdx
+++ b/docs/seps/1577--sampling-with-tools.mdx
@@ -34,7 +34,7 @@ This SEP introduces `tools` & `toolChoice` params to `sampling/createMessage` an
 
 - [Sampling](https://modelcontextprotocol.io/specification/2025-06-18/client/sampling) doesn't support tool calling, although it's a cornerstone of modern agentic behaviour. Without explicit support for it, MCP servers that use Sampling can either try and emulate tool calling w/ complex prompting / custom parsing of the outputs, or are limited to simpler, non-agentic requests. Adding support for tool calling could unlock many novel use cases in the MCP ecosystem.
 
-- Context inclusion is ambiguously defined (see [this doc](https://docs.google.com/document/d/1KUsloHpsjR4fdXdJuofb9jUuK0XWi88clbRm9sWE510/edit?tab=t.0#heading=h.edw7oyac2e87)): it makes it particularly tricky to fully implement sampling, which along with other precautions needed for sampling (unaffected by this SEP) may have contributed to [low adoption of the feature in clients](https://modelcontextprotocol.io/clients#feature-support-matrix) (feature was introduced in the MCP Nov 2024 spec).
+- Context inclusion is ambiguously defined (see [this doc](https://docs.google.com/document/d/1KUsloHpsjR4fdXdJuofb9jUuK0XWi88clbRm9sWE510/edit?tab=t.0#heading=h.edw7oyac2e87)): it makes it particularly tricky to fully implement sampling, which along with other precautions needed for sampling (unaffected by this SEP) may have contributed to [low adoption of the feature in clients](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/3ce9008e5182c0d18002da56edc9e13d8fcf2597/docs/clients.mdx#feature-support-matrix) (feature was introduced in the MCP Nov 2024 spec).
 
 Please note some related work:
 

--- a/docs/seps/2577-deprecate-roots-sampling-and-logging.mdx
+++ b/docs/seps/2577-deprecate-roots-sampling-and-logging.mdx
@@ -106,7 +106,7 @@ protocol:
   the implementation surface for all clients and servers.
 
 [discussion-2536]: https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/2536
-[feature-matrix]: https://modelcontextprotocol.io/clients#feature-support-matrix
+[feature-matrix]: https://github.com/modelcontextprotocol/modelcontextprotocol/blob/3ce9008e5182c0d18002da56edc9e13d8fcf2597/docs/clients.mdx#feature-support-matrix
 
 ## Specification
 

--- a/seps/1577--sampling-with-tools.md
+++ b/seps/1577--sampling-with-tools.md
@@ -40,7 +40,7 @@ This SEP introduces `tools` & `toolChoice` params to `sampling/createMessage` an
 
 - [Sampling](https://modelcontextprotocol.io/specification/2025-06-18/client/sampling) doesn't support tool calling, although it's a cornerstone of modern agentic behaviour. Without explicit support for it, MCP servers that use Sampling can either try and emulate tool calling w/ complex prompting / custom parsing of the outputs, or are limited to simpler, non-agentic requests. Adding support for tool calling could unlock many novel use cases in the MCP ecosystem.
 
-- Context inclusion is ambiguously defined (see [this doc](https://docs.google.com/document/d/1KUsloHpsjR4fdXdJuofb9jUuK0XWi88clbRm9sWE510/edit?tab=t.0#heading=h.edw7oyac2e87)): it makes it particularly tricky to fully implement sampling, which along with other precautions needed for sampling (unaffected by this SEP) may have contributed to [low adoption of the feature in clients](https://modelcontextprotocol.io/clients#feature-support-matrix) (feature was introduced in the MCP Nov 2024 spec).
+- Context inclusion is ambiguously defined (see [this doc](https://docs.google.com/document/d/1KUsloHpsjR4fdXdJuofb9jUuK0XWi88clbRm9sWE510/edit?tab=t.0#heading=h.edw7oyac2e87)): it makes it particularly tricky to fully implement sampling, which along with other precautions needed for sampling (unaffected by this SEP) may have contributed to [low adoption of the feature in clients](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/3ce9008e5182c0d18002da56edc9e13d8fcf2597/docs/clients.mdx#feature-support-matrix) (feature was introduced in the MCP Nov 2024 spec).
 
 Please note some related work:
 

--- a/seps/2577-deprecate-roots-sampling-and-logging.md
+++ b/seps/2577-deprecate-roots-sampling-and-logging.md
@@ -91,7 +91,7 @@ protocol:
   the implementation surface for all clients and servers.
 
 [discussion-2536]: https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/2536
-[feature-matrix]: https://modelcontextprotocol.io/clients#feature-support-matrix
+[feature-matrix]: https://github.com/modelcontextprotocol/modelcontextprotocol/blob/3ce9008e5182c0d18002da56edc9e13d8fcf2597/docs/clients.mdx#feature-support-matrix
 
 ## Specification
 


### PR DESCRIPTION
SEP-2577 and SEP-1577 both cite
`modelcontextprotocol.io/clients#feature-support-matrix` as the evidence for low client adoption. That target no longer exists: the matrix was dismantled in 187c4600 ("Move supported features from matrix to individual client sections"), and the whole clients page was deleted in 2075a21d, which redirects `/clients` to the intro page. The anchor silently resolves to a page with no matrix on it.

There is no live replacement to point at, so both citations now use a permalink to the last revision of `docs/clients.mdx` that actually contained the matrix. Pinned to a SHA, the evidence these SEPs rest on stays reachable and the link cannot rot again.

Fixes #3089

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
