### PR TITLE
docs: align SEP-2575 error codes

### DIFF
--- a/docs/seps/2575-stateless-mcp.mdx
+++ b/docs/seps/2575-stateless-mcp.mdx
@@ -189,7 +189,7 @@ return a JSON-RPC error response. For HTTP, the response status code MUST be
 `400 Bad Request`. The error MUST conform to the following structure:
 
 ```ts
-export const UNSUPPORTED_PROTOCOL_VERSION = -32004;
+export const UNSUPPORTED_PROTOCOL_VERSION = -32022;
 
 export interface UnsupportedProtocolVersionError extends Omit<
   JSONRPCErrorResponse,
@@ -395,7 +395,7 @@ the missing capabilities. For HTTP, the response status code MUST be
 `400 Bad Request`.
 
 ```ts
-export const MISSING_REQUIRED_CLIENT_CAPABILITY = -32003;
+export const MISSING_REQUIRED_CLIENT_CAPABILITY = -32021;
 
 export interface MissingRequiredClientCapabilityError extends Omit<
   JSONRPCErrorResponse,

--- a/seps/2575-stateless-mcp.md
+++ b/seps/2575-stateless-mcp.md
@@ -171,7 +171,7 @@ return a JSON-RPC error response. For HTTP, the response status code MUST be
 `400 Bad Request`. The error MUST conform to the following structure:
 
 ```ts
-export const UNSUPPORTED_PROTOCOL_VERSION = -32004;
+export const UNSUPPORTED_PROTOCOL_VERSION = -32022;
 
 export interface UnsupportedProtocolVersionError extends Omit<
   JSONRPCErrorResponse,
@@ -377,7 +377,7 @@ the missing capabilities. For HTTP, the response status code MUST be
 `400 Bad Request`.
 
 ```ts
-export const MISSING_REQUIRED_CLIENT_CAPABILITY = -32003;
+export const MISSING_REQUIRED_CLIENT_CAPABILITY = -32021;
 
 export interface MissingRequiredClientCapabilityError extends Omit<
   JSONRPCErrorResponse,


### PR DESCRIPTION
Fixes https://github.com/modelcontextprotocol/modelcontextprotocol/issues/3091

## Motivation and Context

SEP-2575 still documented the original error codes for unsupported protocol versions and missing required client capabilities. This aligns the accepted SEP with the renumbered draft schema and conformance suite, preventing SDK implementations from following contradictory guidance.

https://modelcontextprotocol.io/seps/2575-stateless-mcp#unsupported-protocol-versions

<img width="1550" height="1470" alt="Image" src="https://github.com/user-attachments/assets/534d9166-c902-45d3-973d-c549e6e2193d" />

https://modelcontextprotocol.io/seps/2575-stateless-mcp#missing-required-capabilities

<img width="1502" height="1270" alt="Image" src="https://github.com/user-attachments/assets/a29aa84b-0aab-4fb2-8f6a-17e5d870ee40" />

https://modelcontextprotocol.io/specification/draft/schema#unsupported_protocol_version

<img width="1542" height="364" alt="Image" src="https://github.com/user-attachments/assets/124580aa-9893-423a-8004-be4f7b2b710e" />

https://modelcontextprotocol.io/specification/draft/schema#missing_required_client_capability

<img width="1512" height="456" alt="Image" src="https://github.com/user-attachments/assets/78bb174f-09f6-4e23-b8a1-7301967867f3" />


## How Has This Been Tested?

Documentation-only change.

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed