### PR TITLE
docs: clarify structuredContent is not LLM "structured outputs"

### DIFF
--- a/docs/specification/2025-06-18/server/tools.mdx
+++ b/docs/specification/2025-06-18/server/tools.mdx
@@ -300,6 +300,13 @@ Embedded resources support the same [Resource annotations](/specification/2025-0
 
 For backwards compatibility, a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block.
 
+<Note>
+
+`structuredContent` is server-produced result data and is unrelated to LLM
+"structured outputs" (schema-constrained model generation).
+
+</Note>
+
 #### Output Schema
 
 Tools may also provide an output schema for validation of structured results.

--- a/docs/specification/2025-11-25/server/tools.mdx
+++ b/docs/specification/2025-11-25/server/tools.mdx
@@ -325,6 +325,13 @@ Embedded resources support the same [Resource annotations](/specification/2025-1
 
 For backwards compatibility, a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block.
 
+<Note>
+
+`structuredContent` is server-produced result data and is unrelated to LLM
+"structured outputs" (schema-constrained model generation).
+
+</Note>
+
 #### Output Schema
 
 Tools may also provide an output schema for validation of structured results.

--- a/docs/specification/draft/server/tools.mdx
+++ b/docs/specification/draft/server/tools.mdx
@@ -499,6 +499,13 @@ Embedded resources support the same [Resource annotations](/specification/draft/
 
 For backwards compatibility, a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block.
 
+<Note>
+
+`structuredContent` is server-produced result data and is unrelated to LLM
+"structured outputs" (schema-constrained model generation).
+
+</Note>
+
 #### Output Schema
 
 Tools may also provide an output schema for validation of structured results.


### PR DESCRIPTION
Add a note to the Structured Content section of the server tools spec clarifying that `structuredContent` is server-produced result data, unrelated to LLM provider "structured outputs" (schema-constrained model generation).  I've seen at least one instance of the terms being used interchangeably by accident so this could be worth explicitly calling out in the spec docs.