### PR TITLE
docs: Fix broken anchor to _meta

### DIFF
--- a/docs/specification/draft/basic/index.mdx
+++ b/docs/specification/draft/basic/index.mdx
@@ -190,7 +190,7 @@ Specifically:
 
 - Servers **MUST NOT** rely on prior requests over the same connection to
   establish context (e.g., capabilities, protocol version, client identity).
-  Every request supplies this metadata in its [`_meta`](#meta) field.
+  Every request supplies this metadata in its [`_meta`](#_meta) field.
 - Servers **SHOULD** be prepared to handle requests associated with multiple
   tasks, threads, or conversations.
 - Servers **SHOULD NOT** require that a client reuse the same connection or process to


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Broken anchor link in the /draft/basic doc page

## How Has This Been Tested?
Manually!

## Breaking Changes
Nope

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed


