### PR TITLE
docs: note HTTP+SSE transport deprecation

### DIFF
--- a/docs/docs/develop/build-client.mdx
+++ b/docs/docs/develop/build-client.mdx
@@ -1032,7 +1032,7 @@ For WebFlux-based applications, you can use the WebFlux starter instead:
 </dependency>
 ```
 
-This provides similar functionality but uses a WebFlux-based SSE transport implementation, recommended for production deployments.
+This provides similar functionality but uses a WebFlux-based SSE transport implementation. SSE is [Deprecated](/specification/draft/deprecated); for new production deployments, use [Streamable HTTP](/specification/draft/basic/transports/streamable-http) instead.
 
 </Tab>
 

--- a/docs/docs/develop/build-server.mdx
+++ b/docs/docs/develop/build-server.mdx
@@ -1117,7 +1117,7 @@ For more information, see the [MCP Client Boot Starters](https://docs.spring.io/
 
 ## More Java MCP Server examples
 
-The [starter-webflux-server](https://github.com/spring-projects/spring-ai-examples/tree/main/model-context-protocol/weather/starter-webflux-server) demonstrates how to create an MCP server using SSE transport.
+The [starter-webflux-server](https://github.com/spring-projects/spring-ai-examples/tree/main/model-context-protocol/weather/starter-webflux-server) demonstrates how to create an MCP server using SSE transport. SSE is [Deprecated](/specification/draft/deprecated); for new servers, use [Streamable HTTP](/specification/draft/basic/transports/streamable-http) instead.
 It showcases how to define and register MCP Tools, Resources, and Prompts, using the Spring Boot's auto-configuration capabilities.
 
 </Tab>

--- a/docs/registry/remote-servers.mdx
+++ b/docs/registry/remote-servers.mdx
@@ -29,7 +29,7 @@ A remote server **MUST** be publicly accessible at its specified URL.
 
 ## Transport Type
 
-Remote servers can use the Streamable HTTP transport (recommended) or the SSE transport. Remote servers can also support both transports simultaneously at different URLs.
+Remote servers can use the Streamable HTTP transport (recommended) or the SSE transport. The SSE transport is [Deprecated](/specification/draft/deprecated); new remote servers **SHOULD** use Streamable HTTP. Remote servers can also support both transports simultaneously at different URLs.
 
 Specify the transport by setting the `type` property of the `remotes` entry to either `"streamable-http"` or `"sse"`:
 


### PR DESCRIPTION
## Motivation and Context

Closes #3045. This updates the three pages identified in the release-tracking issue so they no longer recommend HTTP+SSE for new deployments without its deprecation status and Streamable HTTP alternative.

## Changes

- Mark the Registry `sse` transport option as Deprecated and recommend Streamable HTTP for new remote servers.
- Replace the WebFlux SSE production recommendation in the Java client guide with a deprecation caveat and Streamable HTTP link.
- Add the same caveat to the WebFlux server example.

## Validation

- `npm run check:docs`

## Breaking Changes

No.

## Types of changes

- [x] Documentation update

## Checklist

- [x] I have read the MCP Documentation
- [x] My changes follow the repository style guidelines
- [x] Documentation validation passes locally
- [x] I have updated documentation as needed