### PR TITLE
fix: correct MISSING_REQUIRED_CLIENT_CAPABILITY error code in SEP-2663

### DIFF
--- a/docs/seps/2663-tasks-extension.mdx
+++ b/docs/seps/2663-tasks-extension.mdx
@@ -104,7 +104,7 @@ A server that has negotiated this extension **MAY** return `CreateTaskResult` in
 
 A server **MUST NOT** return `CreateTaskResult` to a client that did not include the extension capability on its request, regardless of prior declarations. A client that has negotiated this extension **MUST** be prepared to handle either `CallToolResult` or `CreateTaskResult` in response to any supported request it issues. A client that receives `CreateTaskResult` in response to an unsupported request type **MUST** interpret this as an invalid response to the request.
 
-If a server is unable to service a request to a client that does not declare this extension capability without returning `CreateTaskResult`, the server **MUST** return an error with the code `-32003` (Missing Required Client Capability), indicating the required extension in the error response:
+If a server is unable to service a request to a client that does not declare this extension capability without returning `CreateTaskResult`, the server **MUST** return an error with the code `-32021` (Missing Required Client Capability), indicating the required extension in the error response:
 
 ```jsonl
 {
@@ -112,7 +112,7 @@ If a server is unable to service a request to a client that does not declare thi
   "id": 1,
   "error": {
     // MISSING_REQUIRED_CLIENT_CAPABILITY
-    "code": -32003,
+    "code": -32021,
     // Message provided for example purposes only. The content of this example message is non-normative.
     "message": "Missing required client capability",
     "data": {
@@ -482,7 +482,7 @@ If a client requests task status notifications but does not declare the `io.mode
   "id": 12,
   "error": {
     // MISSING_REQUIRED_CLIENT_CAPABILITY
-    "code": -32003,
+    "code": -32021,
     // Message provided for example purposes only. The content of this example message is non-normative.
     "message": "Missing required client capability",
     "data": {
@@ -812,7 +812,7 @@ Servers **MUST** return standard JSON-RPC errors for the following protocol erro
   - Servers **MUST** return this error for `tasks/get`.
   - Servers **SHOULD** return this error for `tasks/update` and `tasks/cancel`.
 - Internal errors: `-32603` (Internal error)
-- Missing required client capabilities: `-32003` (Missing Required Client Capability)
+- Missing required client capabilities: `-32021` (Missing Required Client Capability)
   - Servers **MUST** return this error for non-declaring clients requesting task notifications on `subscriptions/listen`.
   - Servers **MUST** return this error for non-declaring clients issuing `tasks/get`, `tasks/update`, and `tasks/cancel` requests.
 

--- a/seps/2663-tasks-extension.md
+++ b/seps/2663-tasks-extension.md
@@ -86,7 +86,7 @@ A server that has negotiated this extension **MAY** return `CreateTaskResult` in
 
 A server **MUST NOT** return `CreateTaskResult` to a client that did not include the extension capability on its request, regardless of prior declarations. A client that has negotiated this extension **MUST** be prepared to handle either `CallToolResult` or `CreateTaskResult` in response to any supported request it issues. A client that receives `CreateTaskResult` in response to an unsupported request type **MUST** interpret this as an invalid response to the request.
 
-If a server is unable to service a request to a client that does not declare this extension capability without returning `CreateTaskResult`, the server **MUST** return an error with the code `-32003` (Missing Required Client Capability), indicating the required extension in the error response:
+If a server is unable to service a request to a client that does not declare this extension capability without returning `CreateTaskResult`, the server **MUST** return an error with the code `-32021` (Missing Required Client Capability), indicating the required extension in the error response:
 
 ```jsonl
 {
@@ -94,7 +94,7 @@ If a server is unable to service a request to a client that does not declare thi
   "id": 1,
   "error": {
     // MISSING_REQUIRED_CLIENT_CAPABILITY
-    "code": -32003,
+    "code": -32021,
     // Message provided for example purposes only. The content of this example message is non-normative.
     "message": "Missing required client capability",
     "data": {
@@ -464,7 +464,7 @@ If a client requests task status notifications but does not declare the `io.mode
   "id": 12,
   "error": {
     // MISSING_REQUIRED_CLIENT_CAPABILITY
-    "code": -32003,
+    "code": -32021,
     // Message provided for example purposes only. The content of this example message is non-normative.
     "message": "Missing required client capability",
     "data": {
@@ -794,7 +794,7 @@ Servers **MUST** return standard JSON-RPC errors for the following protocol erro
   - Servers **MUST** return this error for `tasks/get`.
   - Servers **SHOULD** return this error for `tasks/update` and `tasks/cancel`.
 - Internal errors: `-32603` (Internal error)
-- Missing required client capabilities: `-32003` (Missing Required Client Capability)
+- Missing required client capabilities: `-32021` (Missing Required Client Capability)
   - Servers **MUST** return this error for non-declaring clients requesting task notifications on `subscriptions/listen`.
   - Servers **MUST** return this error for non-declaring clients issuing `tasks/get`, `tasks/update`, and `tasks/cancel` requests.
 


### PR DESCRIPTION
## Motivation and Context

Similar to #3091, the MISSING_REQUIRED_CLIENT_CAPABILITY error code is
incorrect in the SEP-2663 docs.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
see https://github.com/modelcontextprotocol/modelcontextprotocol/blob/73720340e7c42ddaf4b303b86e81663e9a2796d0/docs/specification/draft/changelog.mdx#minor-changes item 12