### PR TITLE
docs: modernise the Python examples for the 2026-07-28 release

### DIFF
--- a/docs/docs/draft/develop/build-client.mdx
+++ b/docs/docs/draft/develop/build-client.mdx
@@ -95,73 +95,58 @@ Make sure you keep your `ANTHROPIC_API_KEY` secure!
 
 ## Creating the Client
 
-### Basic Client Structure
+### Imports and Setup
 
-First, let's set up our imports and create the basic client class:
+First, let's set up our imports and the pieces the rest of the file shares:
 
 ```python
 import asyncio
-from typing import Optional
-from contextlib import AsyncExitStack
+import sys
 
-from mcp import ClientSession, StdioServerParameters
+from mcp import Client, StdioServerParameters
 from mcp.client.stdio import stdio_client
+from mcp_types import TextContent
 
 from anthropic import Anthropic
 from dotenv import load_dotenv
 
 load_dotenv()  # load environment variables from .env
 
-class MCPClient:
-    def __init__(self):
-        # Initialize session and client objects
-        self.session: Optional[ClientSession] = None
-        self.exit_stack = AsyncExitStack()
-        self.anthropic = Anthropic()
-    # methods will go here
+MODEL = "claude-sonnet-4-20250514"
+anthropic = Anthropic()
 ```
+
+`Client` is the single object your program talks to the server through. Listing the tools, calling one, reading a resource: each of those is a method on it.
 
 ### Server Connection Management
 
-Next, we'll implement the method to connect to an MCP server:
+Next, we'll work out which process to launch for a given server script:
 
 ```python
-async def connect_to_server(self, server_script_path: str):
-    """Connect to an MCP server
+def server_params(server_script_path: str) -> StdioServerParameters:
+    """Describe the subprocess that runs an MCP server
 
     Args:
         server_script_path: Path to the server script (.py or .js)
     """
-    is_python = server_script_path.endswith('.py')
-    is_js = server_script_path.endswith('.js')
-    if not (is_python or is_js):
+    if server_script_path.endswith(".py"):
+        command = "python"
+    elif server_script_path.endswith(".js"):
+        command = "node"
+    else:
         raise ValueError("Server script must be a .py or .js file")
 
-    command = "python" if is_python else "node"
-    server_params = StdioServerParameters(
-        command=command,
-        args=[server_script_path],
-        env=None
-    )
-
-    stdio_transport = await self.exit_stack.enter_async_context(stdio_client(server_params))
-    self.stdio, self.write = stdio_transport
-    self.session = await self.exit_stack.enter_async_context(ClientSession(self.stdio, self.write))
-
-    await self.session.initialize()
-
-    # List available tools
-    response = await self.session.list_tools()
-    tools = response.tools
-    print("\nConnected to server with tools:", [tool.name for tool in tools])
+    return StdioServerParameters(command=command, args=[server_script_path])
 ```
+
+`StdioServerParameters` is configuration, not a connection. `stdio_client()` turns it into a stdio transport, and `Client` opens that transport when you enter its `async with` block. We'll do both in `main()`.
 
 ### Query Processing Logic
 
 Now let's add the core functionality for processing queries and handling tool calls:
 
 ```python
-async def process_query(self, query: str) -> str:
+async def process_query(client: Client, query: str) -> str:
     """Process a query using Claude and available tools"""
     messages = [
         {
@@ -170,16 +155,16 @@ async def process_query(self, query: str) -> str:
         }
     ]
 
-    response = await self.session.list_tools()
+    tool_list = await client.list_tools()
     available_tools = [{
         "name": tool.name,
         "description": tool.description,
         "input_schema": tool.input_schema
-    } for tool in response.tools]
+    } for tool in tool_list.tools]
 
     # Initial Claude API call
-    response = self.anthropic.messages.create(
-        model="claude-sonnet-4-20250514",
+    response = anthropic.messages.create(
+        model=MODEL,
         max_tokens=1000,
         messages=messages,
         tools=available_tools
@@ -187,98 +172,102 @@ async def process_query(self, query: str) -> str:
 
     # Process response and handle tool calls
     final_text = []
+    tool_results = []
 
-    assistant_message_content = []
     for content in response.content:
         if content.type == 'text':
             final_text.append(content.text)
-            assistant_message_content.append(content)
         elif content.type == 'tool_use':
             tool_name = content.name
             tool_args = content.input
 
             # Execute tool call
-            result = await self.session.call_tool(tool_name, tool_args)
+            result = await client.call_tool(tool_name, tool_args)
             final_text.append(f"[Calling tool {tool_name} with args {tool_args}]")
 
-            assistant_message_content.append(content)
-            messages.append({
-                "role": "assistant",
-                "content": assistant_message_content
-            })
-            messages.append({
-                "role": "user",
-                "content": [
-                    {
-                        "type": "tool_result",
-                        "tool_use_id": content.id,
-                        "content": result.content
-                    }
-                ]
+            tool_results.append({
+                "type": "tool_result",
+                "tool_use_id": content.id,
+                "content": "\n".join(
+                    block.text
+                    for block in result.content
+                    if isinstance(block, TextContent)
+                ),
+                "is_error": result.is_error
             })
 
-            # Get next response from Claude
-            response = self.anthropic.messages.create(
-                model="claude-sonnet-4-20250514",
-                max_tokens=1000,
-                messages=messages,
-                tools=available_tools
-            )
+    if tool_results:
+        messages.append({"role": "assistant", "content": response.content})
+        messages.append({"role": "user", "content": tool_results})
 
-            final_text.append(response.content[0].text)
+        # Get next response from Claude
+        response = anthropic.messages.create(
+            model=MODEL,
+            max_tokens=1000,
+            messages=messages,
+            tools=available_tools
+        )
+
+        for content in response.content:
+            if content.type == 'text':
+                final_text.append(content.text)
 
     return "\n".join(final_text)
 ```
 
+`call_tool` returns a `CallToolResult`. Its `content` is a list of blocks, which is why we narrow to `TextContent` before reading `.text`. A tool that raises does not raise here: it answers with `is_error` set, and passing that flag on lets Claude read the message and try something else.
+
 ### Interactive Chat Interface
 
-Now we'll add the chat loop and cleanup functionality:
+Now we'll add the chat loop:
 
 ```python
-async def chat_loop(self):
+async def chat_loop(client: Client) -> None:
     """Run an interactive chat loop"""
     print("\nMCP Client Started!")
     print("Type your queries or 'quit' to exit.")
 
     while True:
         try:
-            query = input("\nQuery: ").strip()
+            query = (await asyncio.to_thread(input, "\nQuery: ")).strip()
+        except EOFError:
+            break
 
-            if query.lower() == 'quit':
-                break
+        if query.lower() == 'quit':
+            break
 
-            response = await self.process_query(query)
+        try:
+            response = await process_query(client, query)
             print("\n" + response)
-
         except Exception as e:
-            print(f"\nError: {str(e)}")
-
-async def cleanup(self):
-    """Clean up resources"""
-    await self.exit_stack.aclose()
+            print(f"\nError: {e}")
 ```
+
+`input()` blocks, so it runs on a worker thread. That keeps the event loop free to service the connection while you type.
 
 ### Main Entry Point
 
 Finally, we'll add the main execution logic:
 
 ```python
-async def main():
+async def main() -> None:
     if len(sys.argv) < 2:
         print("Usage: python client.py <path_to_server_script>")
         sys.exit(1)
 
-    client = MCPClient()
-    try:
-        await client.connect_to_server(sys.argv[1])
-        await client.chat_loop()
-    finally:
-        await client.cleanup()
+    async with Client(stdio_client(server_params(sys.argv[1]))) as client:
+        tool_list = await client.list_tools()
+        tool_names = [tool.name for tool in tool_list.tools]
+        print("\nConnected to server with tools:", tool_names)
+
+        await chat_loop(client)
+
 
 if __name__ == "__main__":
-    import sys
     asyncio.run(main())
 ```
+
+That `async with` is the entire connection lifecycle. Entering it launches the server and agrees a protocol version with it; leaving it disconnects and shuts the subprocess down. There is nothing to close by hand.
 
 You can find the complete `client.py` file [here](https://github.com/modelcontextprotocol/quickstart-resources/blob/main/mcp-client-python/client.py).
 
@@ -286,16 +275,16 @@ You can find the complete `client.py` file [here](https://github.com/modelcontex
 
 ### 1. Client Initialization
 
-- The `MCPClient` class initializes with session management and API clients
-- Uses `AsyncExitStack` for proper resource management
+- A single `Client` carries the connection, and `async with` is its whole lifecycle
+- There is no connect/close pair to call and nothing to clean up afterwards
 - Configures the Anthropic client for Claude interactions
 
 ### 2. Server Connection
 
 - Supports both Python and Node.js servers
 - Validates server script type
-- Sets up proper communication channels
-- Initializes the session and lists available tools
+- Launches the server as a subprocess and speaks stdio to it
+- Lists the available tools once the connection is open
 
 ### 3. Query Processing
 
@@ -313,9 +302,9 @@ You can find the complete `client.py` file [here](https://github.com/modelcontex
 
 ### 5. Resource Management
 
-- Proper cleanup of resources
-- Error handling for connection issues
-- Graceful shutdown procedures
+- Leaving the `async with` block disconnects and shuts the server subprocess down
+- A failing query is reported without ending the session
+- Typing `quit`, or closing standard input, exits cleanly
 
 ## Common Customization Points
 
@@ -379,13 +368,13 @@ When you submit a query:
 ## Best practices
 
 1. **Error Handling**
-   - Always wrap tool calls in try-catch blocks
+   - Check `result.is_error` rather than expecting a failing tool to raise
    - Provide meaningful error messages
    - Gracefully handle connection issues
 
 2. **Resource Management**
-   - Use `AsyncExitStack` for proper cleanup
-   - Close connections when done
+   - Let the `async with` block own the connection
+   - Keep it open for as long as you need the server
    - Handle server disconnections
 
 3. **Security**
@@ -437,7 +426,7 @@ If you see:
 - `FileNotFoundError`: Check your server path
 - `Connection refused`: Ensure the server is running and the path is correct
 - `Tool execution failed`: Verify the tool's required environment variables are set
-- `Timeout error`: Consider increasing the timeout in your client configuration
+- `Timeout error`: Consider raising `read_timeout_seconds` on the `Client`
 
 </Tab>
 

--- a/docs/docs/draft/develop/build-client.mdx
+++ b/docs/docs/draft/develop/build-client.mdx
@@ -112,7 +112,7 @@ from dotenv import load_dotenv
 
 load_dotenv()  # load environment variables from .env
 
-MODEL = "claude-sonnet-4-20250514"
+MODEL = "claude-opus-5"
 anthropic = Anthropic()
 ```
 
@@ -638,7 +638,7 @@ async processQuery(query: string) {
   ];
 
   const response = await this.anthropic.messages.create({
-    model: "claude-sonnet-4-20250514",
+    model: "claude-opus-5",
     max_tokens: 1000,
     messages,
     tools: this.tools,
@@ -670,7 +670,7 @@ async processQuery(query: string) {
       });
 
       const response = await this.anthropic.messages.create({
-        model: "claude-sonnet-4-20250514",
+        model: "claude-opus-5",
         max_tokens: 1000,
         messages,
       });
@@ -1238,7 +1238,7 @@ suspend fun processQuery(query: String): String {
 
     val response = anthropic.messages().create(
         MessageCreateParams.builder()
-            .model("claude-sonnet-4-20250514")
+            .model("claude-opus-5")
             .maxTokens(1024)
             .messages(messages)
             .tools(tools)
@@ -1274,7 +1274,7 @@ suspend fun processQuery(query: String): String {
 
                 val aiResponse = anthropic.messages().create(
                     MessageCreateParams.builder()
-                        .model("claude-sonnet-4-20250514")
+                        .model("claude-opus-5")
                         .maxTokens(1024)
                         .messages(messages)
                         .build(),
@@ -1585,7 +1585,7 @@ using var anthropicClient = new AnthropicClient(new APIAuthentication(builder.Co
 var options = new ChatOptions
 {
     MaxOutputTokens = 1000,
-    ModelId = "claude-sonnet-4-20250514",
+    ModelId = "claude-opus-5",
     Tools = [.. tools]
 };
 
@@ -1760,7 +1760,7 @@ require "json"
 require "mcp"
 
 class MCPClient
-  ANTHROPIC_MODEL = "claude-sonnet-4-20250514"
+  ANTHROPIC_MODEL = "claude-opus-5"
 
   def initialize
     @mcp_client = nil
@@ -2170,7 +2170,7 @@ use serde_json::Value;
 use tokio::io::{self, AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
-const MODEL_ANTHROPIC: &str = "claude-sonnet-4-20250514";
+const MODEL_ANTHROPIC: &str = "claude-opus-5";
 
 struct MCPClient {
     anthropic: Client,

--- a/docs/docs/draft/develop/build-server.mdx
+++ b/docs/docs/draft/develop/build-server.mdx
@@ -45,28 +45,27 @@ This quickstart assumes you have familiarity with:
 
 When implementing MCP servers, be careful about how you handle logging:
 
-**For STDIO-based servers:** Never write to stdout. Writing to stdout will corrupt the JSON-RPC messages and break your server. The `print()` function writes to stdout by default, but can be used safely with `file=sys.stderr`.
+**For STDIO-based servers:** Never write to stdout. Writing to stdout will corrupt the JSON-RPC messages and break your server. The `print()` function writes to stdout by default, so keep it out of a STDIO server entirely.
 
 **For HTTP-based servers:** Standard output logging is fine since it doesn't interfere with HTTP responses.
 
 ### Best Practices
 
-- Use a logging library that writes to stderr or files.
+- Use the standard library `logging` module, which writes to stderr.
+- Create one logger per module with `logging.getLogger(__name__)` and call it from your tools.
 
 ### Quick Examples
 
 ```python
-import sys
 import logging
+
+logger = logging.getLogger(__name__)
 
 # ❌ Bad (STDIO)
 print("Processing request")
 
 # ✅ Good (STDIO)
-print("Processing request", file=sys.stderr)
-
-# ✅ Good (STDIO)
-logging.info("Processing request")
+logger.info("Processing request")  # writes to stderr
 ```
 
 ### System requirements
@@ -106,7 +105,7 @@ uv venv
 source .venv/bin/activate
 
 # Install dependencies
-uv add "mcp[cli]" httpx
+uv add "mcp[cli]"
 
 # Create our server file
 touch weather.py
@@ -122,7 +121,7 @@ uv venv
 .venv\Scripts\activate
 
 # Install dependencies
-uv add mcp[cli] httpx
+uv add mcp[cli]
 
 # Create our server file
 new-item weather.py
@@ -141,8 +140,8 @@ Add these to the top of your `weather.py`:
 ```python
 from typing import Any
 
-import httpx
-from mcp.server.mcpserver import MCPServer
+import httpx2
+from mcp.server import MCPServer
 
 # Initialize MCPServer
 mcp = MCPServer("weather")
@@ -151,6 +150,8 @@ mcp = MCPServer("weather")
 NWS_API_BASE = "https://api.weather.gov"
 USER_AGENT = "weather-app/1.0"
 ```
+
+`httpx2` is the HTTP client the SDK itself depends on, so installing `mcp` already brought it in.
 
 The MCPServer class uses Python type hints and docstrings to automatically generate tool definitions, making it easy to create and maintain MCP tools.
 
@@ -162,7 +163,7 @@ Next, let's add our helper functions for querying and formatting the data from t
 async def make_nws_request(url: str) -> dict[str, Any] | None:
     """Make a request to the NWS API with proper error handling."""
     headers = {"User-Agent": USER_AGENT, "Accept": "application/geo+json"}
-    async with httpx.AsyncClient() as client:
+    async with httpx2.AsyncClient() as client:
         try:
             response = await client.get(url, headers=headers, timeout=30.0)
             response.raise_for_status()
@@ -250,13 +251,8 @@ Forecast: {period["detailedForecast"]}
 Finally, let's initialize and run the server:
 
 ```python
-def main():
-    # Initialize and run the server
-    mcp.run(transport="stdio")
-
-
 if __name__ == "__main__":
-    main()
+    mcp.run(transport="stdio")
 ```
 
 Your server is complete! Run `uv run weather.py` to start the MCP server, which will listen for messages from MCP hosts.

--- a/docs/docs/draft/learn/architecture.mdx
+++ b/docs/docs/draft/learn/architecture.mdx
@@ -223,16 +223,14 @@ After successful initialization, the client sends a notification to indicate it'
 
 #### How This Works in AI Applications
 
-During initialization, the AI application's MCP client manager establishes connections to configured servers and stores their capabilities for later use. The application uses this information to determine which servers can provide specific types of functionality (tools, resources, prompts) and whether they support real-time updates.
+When the AI application starts up, its MCP client manager establishes connections to configured servers and stores their capabilities for later use. The application uses this information to determine which servers can provide specific types of functionality (tools, resources, prompts) and whether they support real-time updates.
 
 ```python Pseudo-code for AI application initialization
 # Pseudo Code
-async with stdio_client(server_config) as (read, write):
-    async with ClientSession(read, write) as session:
-        init_response = await session.initialize()
-        if init_response.capabilities.tools:
-            app.register_mcp_server(session, supports_tools=True)
-        app.set_server_ready(session)
+async with Client(stdio_client(server_config)) as client:
+    if client.server_capabilities.tools:
+        app.register_mcp_server(client, supports_tools=True)
+    app.set_server_ready(client)
 ```
 
 </Step>
@@ -318,8 +316,8 @@ The AI application fetches available tools from all connected MCP servers and co
 ```python Pseudo-code for AI application tool discovery
 # Pseudo-code using MCP Python SDK patterns
 available_tools = []
-for session in app.mcp_server_sessions():
-    tools_response = await session.list_tools()
+for client in app.mcp_clients():
+    tools_response = await client.list_tools()
     available_tools.extend(tools_response.tools)
 conversation.register_available_tools(available_tools)
 ```
@@ -395,8 +393,8 @@ When the language model decides to use a tool during a conversation, the AI appl
 ```python
 # Pseudo-code for AI application tool execution
 async def handle_tool_call(conversation, tool_name, arguments):
-    session = app.find_mcp_session_for_tool(tool_name)
-    result = await session.call_tool(tool_name, arguments)
+    client = app.find_mcp_client_for_tool(tool_name)
+    result = await client.call_tool(tool_name, arguments)
     conversation.add_tool_result(result.content)
 ```
 
@@ -449,15 +447,17 @@ This notification pattern extends beyond tools to other MCP primitives, enabling
 
 #### How This Works in AI Applications
 
-When the AI application receives a notification about changed tools, it immediately refreshes its tool registry and updates the LLM's available capabilities. This ensures that ongoing conversations always have access to the most current set of tools, and the LLM can dynamically adapt to new functionality as it becomes available.
+The AI application keeps a notification stream open for the changes it cares about. When one arrives, it immediately refreshes its tool registry and updates the LLM's available capabilities. This ensures that ongoing conversations always have access to the most current set of tools, and the LLM can dynamically adapt to new functionality as it becomes available.
 
 ```python
 # Pseudo-code for AI application notification handling
-async def handle_tools_changed_notification(session):
-    tools_response = await session.list_tools()
-    app.update_available_tools(session, tools_response.tools)
-    if app.conversation.is_active():
-        app.conversation.notify_llm_of_new_capabilities()
+async def follow_tool_changes(client):
+    async with client.listen(tools_list_changed=True) as sub:
+        async for _event in sub:
+            tools_response = await client.list_tools()
+            app.update_available_tools(client, tools_response.tools)
+            if app.conversation.is_active():
+                app.conversation.notify_llm_of_new_capabilities()
 ```
 
 </Step>

--- a/docs/docs/draft/tools/debugging.mdx
+++ b/docs/docs/draft/tools/debugging.mdx
@@ -48,19 +48,26 @@ DevTools Network panel) to inspect requests,
 [`Mcp-Session-Id` headers](/specification/latest/basic/transports#session-management),
 and SSE streams.
 
-For all [transports](/specification/latest/basic/transports), you can also
-provide logging to the client by sending a log message notification:
+For all [transports](/specification/latest/basic/transports), record what the
+server is doing as it runs:
 
 <CodeGroup>
 
 ```python Python
-@server.tool()
-async def my_tool(ctx: Context) -> str:
-    await ctx.session.send_log_message(
-        level="info",
-        data="Server started successfully",
-    )
-    return "done"
+import logging
+
+from mcp.server import MCPServer
+
+logger = logging.getLogger(__name__)
+
+mcp = MCPServer("reports")
+
+
+@mcp.tool()
+async def fetch_report(report_id: str) -> str:
+    """Fetch a report by id."""
+    logger.info("Fetching report %s", report_id)
+    return f"Report {report_id} is ready."
 ```
 
 ```typescript TypeScript

--- a/docs/docs/draft/tutorials/security/authorization.mdx
+++ b/docs/docs/draft/tutorials/security/authorization.mdx
@@ -618,7 +618,7 @@ For more details about implementing MCP servers in TypeScript, refer to the [Typ
 
 You can see the complete Python project in the [sample repository](https://github.com/modelcontextprotocol/python-sdk/tree/main/examples/servers/simple-auth).
 
-To simplify our authorization interaction, in Python scenarios we rely on [FastMCP](https://gofastmcp.com/getting-started/welcome). Many of the conventions around authorization, like the endpoints and token validation logic, are consistent across languages, but some offer simpler ways of integrating them in production scenarios.
+To simplify our authorization interaction, in Python scenarios we rely on the `MCPServer` class from the [Python SDK](https://py.sdk.modelcontextprotocol.io/v2/run/authorization/). It publishes the Protected Resource Metadata document, answers unauthenticated requests with a `401` whose `WWW-Authenticate` header points back at that document, and hands every bearer token to a verifier that we supply. Many of the conventions around authorization, like the endpoints and token validation logic, are consistent across languages, but some offer simpler ways of integrating them in production scenarios.
 
 Prior to writing the actual server, we need to set up our configuration in `config.py` - the contents are entirely based on your local server setup:
 
@@ -626,7 +626,6 @@ Prior to writing the actual server, we need to set up our configuration in `conf
 """Configuration settings for the MCP auth server."""
 
 import os
-from typing import Optional
 
 
 class Config:
@@ -643,12 +642,10 @@ class Config:
 
     # OAuth client settings
     OAUTH_CLIENT_ID: str = os.getenv("OAUTH_CLIENT_ID", "mcp-server")
-    OAUTH_CLIENT_SECRET: str = os.getenv("OAUTH_CLIENT_SECRET", "UO3rmozkFFkXr0QxPTkzZ0LMXDidIikB")
+    OAUTH_CLIENT_SECRET: str = os.getenv("OAUTH_CLIENT_SECRET", "")
 
-    # Server settings
+    # Scope required on every token
     MCP_SCOPE: str = os.getenv("MCP_SCOPE", "mcp:tools")
-    OAUTH_STRICT: bool = os.getenv("OAUTH_STRICT", "false").lower() in ("true", "1", "yes")
-    TRANSPORT: str = os.getenv("TRANSPORT", "streamable-http")
 
     @property
     def server_url(self) -> str:
@@ -660,16 +657,12 @@ class Config:
         """Build the auth server base URL."""
         return f"http://{self.AUTH_HOST}:{self.AUTH_PORT}/realms/{self.AUTH_REALM}/"
 
-    def validate(self) -> None:
-        """Validate configuration."""
-        if self.TRANSPORT != "streamable-http":
-            raise ValueError(f"Invalid transport: {self.TRANSPORT}. Must be 'streamable-http'")
-
 
 # Global configuration instance
 config = Config()
-
 ```
+
+`OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET` are associated with the MCP server client we created earlier. Set them in your environment before starting the server.
 
 The server implementation is as follows:
 
@@ -677,11 +670,12 @@ The server implementation is as follows:
 import datetime
 import logging
 from typing import Any
+from urllib.parse import urljoin
 
 from pydantic import AnyHttpUrl
 
+from mcp.server import MCPServer
 from mcp.server.auth.settings import AuthSettings
-from mcp.server.fastmcp.server import FastMCP
 
 from .config import config
 from .token_verifier import IntrospectionTokenVerifier
@@ -691,8 +685,6 @@ logger = logging.getLogger(__name__)
 
 def create_oauth_urls() -> dict[str, str]:
     """Create OAuth URLs based on configuration (Keycloak-style)."""
-    from urllib.parse import urljoin
-
     auth_base_url = config.auth_base_url
 
     return {
@@ -703,10 +695,8 @@ def create_oauth_urls() -> dict[str, str]:
     }
 
 
-def create_server() -> FastMCP:
-    """Create and configure the FastMCP server."""
-
-    config.validate()
+def create_server() -> MCPServer:
+    """Create and configure the MCP server."""
 
     oauth_urls = create_oauth_urls()
 
@@ -717,13 +707,10 @@ def create_server() -> FastMCP:
         client_secret=config.OAUTH_CLIENT_SECRET,
     )
 
-    app = FastMCP(
+    app = MCPServer(
         name="MCP Resource Server",
         instructions="Resource Server that validates tokens via Authorization Server introspection",
-        host=config.HOST,
-        port=config.PORT,
         debug=True,
-        streamable_http_path="/",
         token_verifier=token_verifier,
         auth=AuthSettings(
             issuer_url=AnyHttpUrl(oauth_urls["issuer"]),
@@ -748,7 +735,7 @@ def create_server() -> FastMCP:
             "operand_a": a,
             "operand_b": b,
             "result": result,
-            "timestamp": datetime.datetime.now().isoformat()
+            "timestamp": datetime.datetime.now().isoformat(),
         }
 
     @app.tool()
@@ -767,7 +754,7 @@ def create_server() -> FastMCP:
             "operand_x": x,
             "operand_y": y,
             "result": result,
-            "timestamp": datetime.datetime.now().isoformat()
+            "timestamp": datetime.datetime.now().isoformat(),
         }
 
     return app
@@ -786,22 +773,20 @@ def main() -> int:
     """
     logging.basicConfig(level=logging.INFO)
 
-    try:
-        config.validate()
-        oauth_urls = create_oauth_urls()
-
-    except ValueError as e:
-        logger.error("Configuration error: %s", e)
-        return 1
+    oauth_urls = create_oauth_urls()
 
     try:
         mcp_server = create_server()
 
         logger.info("Starting MCP Server on %s:%s", config.HOST, config.PORT)
         logger.info("Authorization Server: %s", oauth_urls["issuer"])
-        logger.info("Transport: %s", config.TRANSPORT)
 
-        mcp_server.run(transport=config.TRANSPORT)
+        mcp_server.run(
+            transport="streamable-http",
+            host=config.HOST,
+            port=config.PORT,
+            streamable_http_path="/",
+        )
         return 0
 
     except Exception:
@@ -821,6 +806,8 @@ Lastly, the token verification logic is delegated entirely to `token_verifier.py
 import logging
 from typing import Any
 
+import httpx2
+
 from mcp.server.auth.provider import AccessToken, TokenVerifier
 from mcp.shared.auth_utils import check_resource_allowed, resource_url_from_server_url
 
@@ -828,8 +815,7 @@ logger = logging.getLogger(__name__)
 
 
 class IntrospectionTokenVerifier(TokenVerifier):
-    """Token verifier that uses OAuth 2.0 Token Introspection (RFC 7662).
-    """
+    """Token verifier that uses OAuth 2.0 Token Introspection (RFC 7662)."""
 
     def __init__(
         self,
@@ -846,15 +832,13 @@ class IntrospectionTokenVerifier(TokenVerifier):
 
     async def verify_token(self, token: str) -> AccessToken | None:
         """Verify token via introspection endpoint."""
-        import httpx
-
         if not self.introspection_endpoint.startswith(("https://", "http://localhost", "http://127.0.0.1")):
             return None
 
-        timeout = httpx.Timeout(10.0, connect=5.0)
-        limits = httpx.Limits(max_connections=10, max_keepalive_connections=5)
+        timeout = httpx2.Timeout(10.0, connect=5.0)
+        limits = httpx2.Limits(max_connections=10, max_keepalive_connections=5)
 
-        async with httpx.AsyncClient(
+        async with httpx2.AsyncClient(
             timeout=timeout,
             limits=limits,
             verify=True,
@@ -889,9 +873,12 @@ class IntrospectionTokenVerifier(TokenVerifier):
                     scopes=data.get("scope", "").split() if data.get("scope") else [],
                     expires_at=data.get("exp"),
                     resource=data.get("aud"),  # Include resource in token
+                    subject=data.get("sub"),  # RFC 7662 subject (resource owner)
+                    claims=data,
                 )
 
-            except Exception as e:
+            except Exception:
+                logger.exception("Token introspection failed")
                 return None
 
     def _validate_resource(self, token_data: dict[str, Any]) -> bool:
@@ -914,7 +901,7 @@ class IntrospectionTokenVerifier(TokenVerifier):
 
     def _is_valid_resource(self, resource: str) -> bool:
         """Check if the given resource matches our server."""
-        return check_resource_allowed(self.resource_url, resource)
+        return check_resource_allowed(requested_resource=self.resource_url, configured_resource=resource)
 ```
 
 For more details, see the [Python SDK documentation](https://github.com/modelcontextprotocol/python-sdk).

--- a/docs/extensions/auth/oauth-client-credentials.mdx
+++ b/docs/extensions/auth/oauth-client-credentials.mdx
@@ -244,6 +244,8 @@ await transport.close();
 <Tab title="Python">
 
 ```python
+import asyncio
+
 import httpx2
 
 from mcp import Client
@@ -280,15 +282,21 @@ provider = ClientCredentialsOAuthProvider(
     scopes="read write",
 )
 
-async with httpx2.AsyncClient(auth=provider, follow_redirects=True) as http_client:
-    transport = streamable_http_client(
-        "https://mcp.example.com/mcp",
-        http_client=http_client,
-    )
-    async with Client(transport) as client:
-        # Use the client
-        tools = await client.list_tools()
-        print("Available tools:", [t.name for t in tools.tools])
+
+async def main() -> None:
+    async with httpx2.AsyncClient(auth=provider) as http_client:
+        transport = streamable_http_client(
+            "https://mcp.example.com/mcp",
+            http_client=http_client,
+        )
+        async with Client(transport) as client:
+            # Use the client
+            tools = await client.list_tools()
+            print("Available tools:", [t.name for t in tools.tools])
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 </Tab>
@@ -338,6 +346,9 @@ await transport.close();
 <Tab title="Python">
 
 ```python
+import asyncio
+from pathlib import Path
+
 import httpx2
 
 from mcp import Client
@@ -371,7 +382,7 @@ class InMemoryTokenStorage:
 jwt_params = SignedJWTParameters(
     issuer="my-service",
     subject="my-service",
-    signing_key=open("private_key.pem").read(),
+    signing_key=Path("private_key.pem").read_text(),
     signing_algorithm="RS256",
     lifetime_seconds=300,
 )
@@ -384,15 +395,21 @@ provider = PrivateKeyJWTOAuthProvider(
     scopes="read write",
 )
 
-async with httpx2.AsyncClient(auth=provider, follow_redirects=True) as http_client:
-    transport = streamable_http_client(
-        "https://mcp.example.com/mcp",
-        http_client=http_client,
-    )
-    async with Client(transport) as client:
-        # Use the client
-        tools = await client.list_tools()
-        print("Available tools:", [t.name for t in tools.tools])
+
+async def main() -> None:
+    async with httpx2.AsyncClient(auth=provider) as http_client:
+        transport = streamable_http_client(
+            "https://mcp.example.com/mcp",
+            http_client=http_client,
+        )
+        async with Client(transport) as client:
+            # Use the client
+            tools = await client.list_tools()
+            print("Available tools:", [t.name for t in tools.tools])
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 </Tab>


### PR DESCRIPTION
---

The Python SDK ships 2.0 stable alongside this spec revision, and the Python in
these six pages was written against 1.x. Some of it is merely old, and some of
it no longer imports at all. This brings all twenty Python blocks up to the v2
interfaces and the 2026-07-28 protocol shapes, and adjusts the prose wherever it
described code that is no longer there. Only the Python tabs are touched;
TypeScript, Java, Kotlin, C#, Ruby, Rust and Go are left exactly as they were.

Three things account for most of the diff. There is no `initialize` handshake at
2026-07-28, so examples that called it were negotiating the previous revision.
`mcp.server.fastmcp` no longer exists, so anything importing it raises on the
first line. And the protocol logging capability is deprecated in this revision
with no replacement, so examples may not teach it.

## What changed, page by page

### `docs/docs/draft/develop/build-client.mdx`

The largest change. The tab connected, but taught the previous era and carried
two bugs in the tool loop.

```python
# before
from mcp import ClientSession, StdioServerParameters
from contextlib import AsyncExitStack

class MCPClient:
    def __init__(self):
        self.session: Optional[ClientSession] = None
        self.exit_stack = AsyncExitStack()

    async def connect_to_server(self, server_script_path: str):
        stdio_transport = await self.exit_stack.enter_async_context(stdio_client(server_params))
        self.stdio, self.write = stdio_transport
        self.session = await self.exit_stack.enter_async_context(ClientSession(self.stdio, self.write))
        await self.session.initialize()
```

```python
# after
from mcp import Client, StdioServerParameters
from mcp.client.stdio import stdio_client

async with Client(stdio_client(server_params(sys.argv[1]))) as client:
    tool_list = await client.list_tools()
```

`await self.session.initialize()` was the handshake, so the page negotiated
2025-11-25 against a server that speaks 2026-07-28. The whole `AsyncExitStack`
and `ClientSession` scaffold existed because 1.x had no context manager owning
the connection, and `Client` is that context manager, so the class dissolves
into module-level functions and `cleanup()` goes away entirely.

Two bugs went with it. The tool loop handed raw MCP content blocks straight to
the model API, where `result.content` is a union of `TextContent`,
`ImageContent`, `ResourceLink` and more, so it now narrows with
`isinstance(block, TextContent)` before reading `.text`. And
`assistant_message_content` was appended to inside the loop and then mutated
afterwards, so any response asking for two tools built a duplicated assistant
turn with an unanswered `tool_use`. Results are now collected and appended once.
A failing tool comes back as an ordinary result with `is_error` set rather than
raising, so that flag is passed through to the model.

Separately, the chat loop called `input()` inside `except Exception`, so
pressing Ctrl-D raised `EOFError`, printed it, and looped forever. It produced
5.7 million lines in eight seconds. `input()` now runs on a worker thread with
an explicit EOF exit, which also stops it blocking the event loop.

The prose moved with the code: the sections on sessions, exit stacks,
initialization and cleanup are rewritten, and one heading changed from "Basic
Client Structure" to "Imports and Setup" since there is no client class any
more. No page links to that anchor.

### `docs/docs/draft/tutorials/security/authorization.mdx`

The server block did not import on v2:

```python
# before
from mcp.server.fastmcp.server import FastMCP

def create_server() -> FastMCP:
    app = FastMCP(
        name="MCP Resource Server",
        host=config.HOST,
        port=config.PORT,
        streamable_http_path="/",
        ...
    )
```

```python
# after
from mcp.server import MCPServer

def create_server() -> MCPServer:
    app = MCPServer(
        name="MCP Resource Server",
        ...
    )
```

Past the import, `host`, `port` and `streamable_http_path` are not constructor
arguments in v2; they belong on `run()`, which is what
`examples/servers/simple-auth` in the SDK does, so they moved there. The
verifier block imported the wrong HTTP library, `AccessToken` is now built with
the `subject` and `claims` fields that exist in v2, and a swallowed exception
that bound an unused name now goes through the module's logger.

Three lines in the config module were removed because nothing read them, and
`OAUTH_CLIENT_SECRET` now defaults to an empty string with a sentence pointing
at the step where those credentials are created, which is what the TypeScript
tab already does.

The prose above the block told Python readers to rely on a separate third-party
project to explain code that does not use it. It now names `MCPServer` and
describes what the SDK actually does for you, each claim of which is visible in
the transcript below.

### `docs/docs/draft/learn/architecture.mdx`

Four pseudo-code blocks. The first called `session.initialize()`, which does not
merely look stale: run against a stock v2 server it silently negotiates
2025-11-25. The other three used `session` vocabulary for objects that are
clients.

```python
# before
async def handle_tools_changed_notification(session):
    tools_response = await session.list_tools()
    app.update_available_tools(session, tools_response.tools)
```

```python
# after
async def follow_tool_changes(client):
    async with client.listen(tools_list_changed=True) as sub:
        async for _event in sub:
            tools_response = await client.list_tools()
            app.update_available_tools(client, tools_response.tools)
```

That last one is a shape change, not a rename. A function taking a session and
waiting to be called is a callback, and it presumes an unsolicited server push.
At 2026-07-28 notifications are opt-in on a stream the client opens, and there
is no registration point for a tools-changed callback, so renaming the parameter
would leave a function nothing ever calls. I checked this rather than assuming
it: with a message handler recording every inbound message and no `listen` call,
zero messages arrive while the tool list demonstrably changes.

### `docs/docs/draft/tools/debugging.mdx`

The one Python block taught the deprecated logging capability, in a spelling
that could not run. Pasted verbatim it raises `NameError: name 'server' is not
defined`, and its `Context` annotation had no working import.

```python
# before
@server.tool()
async def my_tool(ctx: Context) -> str:
    await ctx.session.send_log_message(level="info", data="Server started successfully")
    return "done"
```

```python
# after
import logging

from mcp.server import MCPServer

logger = logging.getLogger(__name__)

mcp = MCPServer("reports")


@mcp.tool()
async def fetch_report(report_id: str) -> str:
    """Fetch a report by id."""
    logger.info("Fetching report %s", report_id)
    return f"Report {report_id} is ready."
```

The two lines of prose introducing it changed with it, since they promised a log
message notification the code no longer sends.

### `docs/docs/draft/develop/build-server.mdx`

Nothing here was broken. The weather tutorial already ran end to end. The changes
are staleness: `httpx` to `httpx2`, the long `mcp.server.mcpserver` import to
the short `mcp.server` spelling the SDK's own first-steps page teaches, and
`httpx` dropped from both install lines because `httpx2>=2.5.0` is a hard
dependency of `mcp` and the old line installed a second HTTP stack.

The logging section moved to the `logging.getLogger(__name__)` idiom and lost
its `print(..., file=sys.stderr)` example, which was presented as a good pattern
but is the one thing the SDK's logging guidance rules out unconditionally. The
`main()` wrapper around `mcp.run(transport="stdio")` is gone, since the SDK puts
`mcp.run()` directly under the guard and `mcp run weather.py` skips the
`__main__` block entirely.

### `docs/extensions/auth/oauth-client-credentials.mdx`

Both blocks were a hard `SyntaxError`, so neither had ever run: the connect was
a top-level `async with`. The v2 API underneath was already correct. Each is now
wrapped in `async def main()` with an `asyncio.run(main())` runner, matching the
SDK's own examples and the other Python examples in this repository. One
`open(...).read()` that dropped its file handle became `Path(...).read_text()`.

## How this was validated

This repository has no automated check for documentation code in any language,
so everything below was run by hand, and the programs are kept as evidence.

The method was the same for each page: extract the fenced blocks back out of the
`.mdx` **after** editing, assemble them into the file a reader would actually
create, and execute it. Nothing was checked by reading. All twenty Python blocks
across the six pages run.

The two quickstart pages are a matched pair a reader follows in sequence, so the
client tutorial was driven against the server tutorial's server, both assembled
from the pages:

```
server_params -> command='python' args=['weather.py']
negotiated protocol version: 2026-07-28
tools: ['get_alerts', 'get_forecast']
get_forecast.input_schema keys: ['latitude', 'longitude']
--- process_query returned ---
Let me look that up.
[Calling tool get_forecast with args {'latitude': 38.58, 'longitude': -121.49}]
Here is the answer.
--- end ---
tool_result.is_error   = False
tool_result.content[:80] = '\nToday:\nTemperature: 94°F\nWind: 3 to 8 mph S\nForecast: Sunny, with a high near 9'
messages sent round two: ['user', 'assistant', 'user']
```

That is live National Weather Service data through the page's own
`make_nws_request`, and the round-two message shape is the documented one: a
single assistant turn, a single user turn carrying the results, one follow-up
call. Running `client.py weather.py` as a plain subprocess also exits 0 on
Ctrl-D and reports a failed query without ending the session.

The other pages:

| Page | Blocks | How it was driven | Result |
| --- | --- | --- | --- |
| `build-server.mdx` | 5 | stdio subprocess, live upstream API | pass |
| `build-client.mdx` | 5 | driven against the server above | pass |
| `architecture.mdx` | 4 | executed against a real stdio server | pass |
| `debugging.mdx` | 1 | stdio subprocess, v2 client | pass |
| `authorization.mdx` | 3 | live server plus an RFC 7662 introspection endpoint | pass |
| `oauth-client-credentials.mdx` | 2 | live server plus an authorization server | pass |

The architecture blocks are pseudo-code referencing the reader's own
application object, so a stand-in for that object was supplied and the block
bodies executed verbatim. Block 4 opens the stream, a tool change is published,
and the refetch observes the new tool.

For the authorization page:

```
=== PRM discovery (no token) ===
HTTP/1.1 200 OK
{"resource":"http://localhost:3222/","authorization_servers":[...],"scopes_supported":["mcp:tools"]}

=== tools/list with NO Authorization header ===
HTTP/1.1 401 Unauthorized
www-authenticate: Bearer error="invalid_token", resource_metadata=".../.well-known/oauth-protected-resource"

=== real MCP client, four token cases ===
no token         -> refused
inactive token   -> refused
wrong audience   -> refused
valid token      -> tools: ['add_numbers', 'multiply_numbers']
valid token      -> add_numbers(2,3) = {'operation': 'addition', ..., 'result': 5.0}
```

For the client credentials page, both blocks reached a server through a real
token exchange, one with `client_secret_basic` and one with a
`private_key_jwt` assertion whose RS256 signature was verified:

```
[AS] client_secret_basic ACCEPTED: my-service:s3cr3t
[AS] private_key_jwt ACCEPTED (RS256 signature verified): iss=my-service alg=RS256
[WIRE] POST /mcp method='server/discover'
[WIRE] POST /mcp method='tools/list'
```

That wire log is worth noting on its own: `server/discover` followed by
`tools/list`, with no `initialize` anywhere, so the examples are provably on the
current revision rather than merely free of the old call in their text.

Blast radius was checked mechanically rather than by eye. Every fenced block on
all six pages was parsed before and after and compared as a (tab, language,
body) tuple: every non-Python fence is byte-identical to `HEAD`, TypeScript
included. The two exceptions are the install lines on build-server, which are
shell fences inside the Python tab. Heading sets are unchanged except for the
one noted above, and the only fragment link into any of these pages in the
whole repository is `/docs/learn/architecture#example`, whose anchor is intact.
`npm run check:docs` passes: prettier, the MDX comment check, and the broken
link check.

## Left alone on purpose

- **The lessons themselves.** These are tutorials with a narrative, and the aim
  was to modernise the code, not to redesign the teaching. The weather tools
  still return formatted strings rather than models, the architecture blocks are
  still pseudo-code at the same altitude, and the authorization page still
  teaches introspection rather than local signature checks even though the SDK's
  own guide leads with the latter.
- **Every non-Python tab**, including the ones that are also out of date. The
  `debugging.mdx` TypeScript tab still uses the deprecated logging capability,
  and after this change the severity-level prose beneath the group describes
  only that tab. Somebody should make the same call for TypeScript, but not from
  a Python change.
- **`architecture.mdx` step 4's JSON narrative**, which still describes the
  server proactively notifying clients and ties notifications to `listChanged`
  at initialization. Those are framings of the wire rather than of the Python,
  and `#3068` rewrites them along with the JSON. Changing the prose without the
  JSON would swap one mismatch for a worse one.
- **The model identifier in build-client**, which is shared verbatim with the
  seven other language tabs. Refreshing it is a page-wide change, not a
  Python-only one, and it should be done separately. More on this below.
- **The two overview bullets and the severity-level paragraph in
  `debugging.mdx`**, both of which remain accurate for the TypeScript tab.

## Things you may want to reconcile

- `#3069` rewrites all four Python blocks in `architecture.mdx` and touches
  `debugging.mdx`. Its `architecture.mdx` replacement does not run on v2: it
  lands `Client(read, write)` and `await client.discover()`, where
  `Client.__init__` takes one positional argument and `Client.discover` does not
  exist. If both land, the Python from this branch is the one that works.
  `#3067` and `#3069` also already conflict with each other on `debugging.mdx`,
  independently of this branch.
- `#3067` overlaps our `debugging.mdx` hunk. Take its Streamable HTTP paragraph
  and its warning wholesale and keep the lead-in sentence here.
- `#3070` reworked this authorization tutorial and solved the Python problem by
  removing the Python tab, but it merged into `#3062`'s branch and `#3062` was
  closed, so that work never reached the release branch. This change assumes the
  Python tab should exist and makes it correct. If you would rather it went
  away, say so and the authorization page can come out of this branch.
- The model identifier `build-client.mdx` passes to the API is past the
  end-of-life date its own client library warns about, and that deprecation
  warning fires on every run. The same string sits in all eight language tabs,
  so refreshing it is a page-wide change rather than a Python-only one, but it
  is worth doing before release.
- The linked complete-code repositories are now behind these pages.
  `quickstart-resources/weather-server-python/weather.py` still imports
  `mcp.server.fastmcp`, which does not exist in v2, and
  `mcp-client-python/client.py` still holds the `ClientSession` version. Both
  were already stale; this widens the gap. Every language tab links to the same
  repository, so it needs its own change regardless.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
