### PR TITLE
docs(blog): fix resultType value in 2026-07-28 RC post

### DIFF
--- a/blog/content/posts/2026-05-21-mcp-2026-07-28-rc.md
+++ b/blog/content/posts/2026-05-21-mcp-2026-07-28-rc.md
@@ -145,7 +145,7 @@ change how those prompts are delivered. Instead of holding a Server-Sent Events
 
 ```json
 {
-  "resultType": "inputRequired",
+  "resultType": "input_required",
   "inputRequests": {
     "confirm": {
       "type": "elicitation",


### PR DESCRIPTION
Corrects the `resultType` value in the MRTR example in the 2026-07-28 RC blog post from `inputRequired` to `input_required`.

## Motivation and Context
The blog post [`2026-05-21-mcp-2026-07-28-rc.md`](blog/content/posts/2026-05-21-mcp-2026-07-28-rc.md) shows the `InputRequiredResult` example with a camelCase literal.

```json
{
  "resultType": "inputRequired",
  ...
}
```

The normative value is snake_case. The definition in `schema/draft/schema.ts` reads as follows.

```ts
export type ResultType = "complete" | "input_required" | string;
```

The `docs/specification/draft` tree uses `input_required` consistently in all five files that mention it.

- `basic/index.mdx`
- `basic/patterns/mrtr.mdx`
- `server/tools.mdx`
- `server/utilities/caching.mdx`
- `changelog.mdx` (twice)

This is the only occurrence of the camelCase form anywhere in the repository. Since the post is the main narrative introduction to MRTR ahead of the 2026-07-28 revision, readers copying the example would produce a value that servers must reject.

The prose reference to the `InputRequiredResult` type name is correct and is left unchanged. Only the JSON string literal is edited.

## How Has This Been Tested?
Not applicable, since this is a single-token change in a blog post with no code paths involved. Rendered locally with `npm run serve:blog` to confirm the code block still renders correctly.

## Breaking Changes
None. Documentation only.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed