### PR TITLE
Add blog post announcing Ruby SDK 1.0

### DIFF
--- a/blog/content/posts/2026-07-27-ruby-sdk-1-0.md
+++ b/blog/content/posts/2026-07-27-ruby-sdk-1-0.md
@@ -1,0 +1,86 @@
+---
+title: The Official Ruby SDK for MCP Reaches 1.0
+date: "2026-07-27T09:00:00+00:00"
+publishDate: "2026-07-27T09:00:00+00:00"
+slug: ruby-sdk-1-0
+description: The official Ruby SDK for the Model Context Protocol has reached version 1.0 with a stable public API and a 100% conformance pass rate. The SDK now meets every Tier 2 requirement of the MCP SDK tiering system, and development toward Tier 1 continues.
+author:
+  - Koichi Ito (Ruby SDK Maintainer)
+tags:
+  - mcp
+  - sdk
+  - release
+  - announcement
+  - ruby
+---
+
+[Version 1.0.0](https://github.com/modelcontextprotocol/ruby-sdk/releases/tag/v1.0.0) of the official [Ruby SDK](https://github.com/modelcontextprotocol/ruby-sdk) for the Model Context Protocol is now available. This is the first stable release of the [`mcp` gem](https://rubygems.org/gems/mcp): the public API is now stable, and breaking changes ship only in major releases, following the Semantic Versioning policy documented in [VERSIONING.md](https://github.com/modelcontextprotocol/ruby-sdk/blob/main/VERSIONING.md).
+
+Alongside the release, the Ruby SDK now meets every Tier 2 requirement of the [SDK tiering system](https://modelcontextprotocol.io/community/sdk-tiers), as recorded in the [Tier 2 assessment](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/3127), and development toward Tier 1 is ongoing.
+
+## What is in 1.0
+
+The 1.0 release implements the 2025-06-18 and 2025-11-25 specification revisions and passes 100% of the server and client conformance scenarios. It includes:
+
+- MCP servers with tools, prompts, resources (including templates and subscriptions), completions, logging, pagination, progress, and cancellation, plus server-to-client requests for sampling, elicitation (form and URL mode), and roots
+- An MCP client with a complete OAuth flow, including dynamic client registration, PKCE, and scope handling
+- stdio and Streamable HTTP transports; the HTTP transport is a standard Rack app, so it can be mounted directly in Rails routes or any Rack-compatible framework
+
+## From Tier 3 to Tier 2
+
+The Ruby SDK was assessed at [Tier 3](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2340) in March 2026. Since then:
+
+- Server conformance moved from 83.3% to 100%, with no baselined failures
+- A conformance client was implemented and passes 100% of client scenarios
+- Sampling, elicitation, and progress notifications were implemented on both the server and client sides
+- [ROADMAP.md](https://github.com/modelcontextprotocol/ruby-sdk/blob/main/ROADMAP.md) and [VERSIONING.md](https://github.com/modelcontextprotocol/ruby-sdk/blob/main/VERSIONING.md) were published
+
+Work is also under way to support the upcoming [2026-07-28 specification release](/posts/sdk-betas-2026-07-28/).
+
+## Get started
+
+Install the gem:
+
+```console
+$ gem install mcp
+```
+
+A minimal stdio server looks like this:
+
+```ruby
+require "mcp"
+
+class ExampleTool < MCP::Tool
+  description "A simple example tool that echoes back its arguments"
+  input_schema(
+    properties: {
+      message: { type: "string" },
+    },
+    required: ["message"]
+  )
+
+  class << self
+    def call(message:, server_context:)
+      MCP::Tool::Response.new([{
+        type: "text",
+        text: "Hello from example tool! Message: #{message}",
+      }])
+    end
+  end
+end
+
+server = MCP::Server.new(
+  name: "example_server",
+  tools: [ExampleTool],
+)
+
+MCP::Server::Transports::StdioTransport.new(server).open
+```
+
+See the [Ruby SDK documentation](https://ruby.sdk.modelcontextprotocol.io) for guides on building servers and clients, including Rails integration.
+
+## Give us your feedback
+
+If you run into problems or unexpected behavior while using the SDK, please report them on the [issue tracker](https://github.com/modelcontextprotocol/ruby-sdk/issues). Reports from real-world usage are especially valuable.
+
+The Ruby SDK began at [Shopify](https://www.shopify.com/) and is maintained by [Topher Bullock](https://github.com/topherbullock), [Koichi Ito](https://github.com/koic), [Ateş Göral](https://github.com/atesgoral), and [Jonathan Hefner](https://github.com/jonathanhefner) together with the wider Ruby community. Thank you to everyone for the feedback and contributions on the road to 1.0.


### PR DESCRIPTION
Announce the first stable release of the MCP Ruby SDK: a stable public API under the Semantic Versioning policy, a 100% server and client conformance pass rate, and the Tier 2 assessment (#3127).

If accepted, this post is intended to be published after #3128, which moves the Ruby SDK to Tier 2 in the official SDK listing, is merged.
