### PR TITLE
schema: fix NumberSchema numeric fields typed integer in released generated JSON (2025-06-18, 2025-11-25)

### DIFF
--- a/schema/2025-06-18/schema.json
+++ b/schema/2025-06-18/schema.json
@@ -1399,10 +1399,10 @@
                     "type": "string"
                 },
                 "maximum": {
-                    "type": "integer"
+                    "type": "number"
                 },
                 "minimum": {
-                    "type": "integer"
+                    "type": "number"
                 },
                 "title": {
                     "type": "string"

--- a/schema/2025-06-18/schema.ts
+++ b/schema/2025-06-18/schema.ts
@@ -1504,7 +1504,13 @@ export interface NumberSchema {
   type: "number" | "integer";
   title?: string;
   description?: string;
+  /**
+   * @TJS-type number
+   */
   minimum?: number;
+  /**
+   * @TJS-type number
+   */
   maximum?: number;
 }
 

--- a/schema/2025-11-25/schema.json
+++ b/schema/2025-11-25/schema.json
@@ -2107,16 +2107,16 @@
         "NumberSchema": {
             "properties": {
                 "default": {
-                    "type": "integer"
+                    "type": "number"
                 },
                 "description": {
                     "type": "string"
                 },
                 "maximum": {
-                    "type": "integer"
+                    "type": "number"
                 },
                 "minimum": {
-                    "type": "integer"
+                    "type": "number"
                 },
                 "title": {
                     "type": "string"

--- a/schema/2025-11-25/schema.ts
+++ b/schema/2025-11-25/schema.ts
@@ -2254,8 +2254,17 @@ export interface NumberSchema {
   type: "number" | "integer";
   title?: string;
   description?: string;
+  /**
+   * @TJS-type number
+   */
   minimum?: number;
+  /**
+   * @TJS-type number
+   */
   maximum?: number;
+  /**
+   * @TJS-type number
+   */
   default?: number;
 }
 


### PR DESCRIPTION
The 2025-11-25 schema.ts declares NumberSchema `minimum`/`maximum`/`default` as `number`, but the generated schema.json says `integer` (typescript-json-schema emits integer without a hint). The released JSON artifact rejects values like `default: 95.5` that its own source allows.

This applies the same `@TJS-type number` annotations that #2710 applied to the draft schema, and regenerates. #2710 originally included this dated fix and it was scoped out before merge; proposing it separately as an erratum since the generated file contradicts its schema.ts. Precedent for correcting released generated JSON: 357adac4 (Task.ttl nullability, also 2025-11-25).

Context: the conformance suite now validates wire messages against these schemas (modelcontextprotocol/conformance#399), and this generator artifact is the one place where every tier 1 SDK's elicitation fixture (fractional number default) fails validation at 2025-11-25. Conformance carries a load-time erratum patch for it; that patch gets deleted when this lands.