### PR TITLE
fix issues #3114: restore wildcard schema generation

### DIFF
--- a/schema/2024-11-05/schema.json
+++ b/schema/2024-11-05/schema.json
@@ -1,91 +1,1175 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
-        "Annotated": {
-            "description": "Base for objects that include optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
+        "JSONRPCMessage": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/JSONRPCRequest"
+                },
+                {
+                    "$ref": "#/definitions/JSONRPCNotification"
+                },
+                {
+                    "$ref": "#/definitions/JSONRPCResponse"
+                },
+                {
+                    "$ref": "#/definitions/JSONRPCError"
+                }
+            ]
+        },
+        "ProgressToken": {
+            "description": "A progress token, used to associate progress notifications with the original request.",
+            "type": [
+                "string",
+                "integer"
+            ]
+        },
+        "Cursor": {
+            "description": "An opaque token used to represent a cursor for pagination.",
+            "type": "string"
+        },
+        "Notification": {
+            "type": "object",
             "properties": {
-                "annotations": {
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
                     "properties": {
-                        "audience": {
-                            "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
-                            "items": {
-                                "$ref": "#/definitions/Role"
-                            },
-                            "type": "array"
+                        "_meta": {
+                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "Result": {
+            "type": "object",
+            "additionalProperties": {},
+            "properties": {
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            }
+        },
+        "RequestId": {
+            "description": "A uniquely identifying ID for a request in JSON-RPC.",
+            "type": [
+                "string",
+                "integer"
+            ]
+        },
+        "JSONRPCRequest": {
+            "description": "A request that expects a response.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/definitions/RequestId"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "type": "object",
+                            "properties": {
+                                "progressToken": {
+                                    "$ref": "#/definitions/ProgressToken",
+                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "JSONRPCNotification": {
+            "description": "A notification which does not expect a response.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "JSONRPCResponse": {
+            "description": "A successful (non-error) response to a request.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/definitions/RequestId"
+                },
+                "result": {
+                    "$ref": "#/definitions/Result"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ]
+        },
+        "JSONRPCError": {
+            "description": "A response to a request that indicates an error occurred.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/definitions/RequestId"
+                },
+                "error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "description": "The error type that occurred.",
+                            "type": "integer"
                         },
-                        "priority": {
-                            "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
-                            "maximum": 1,
-                            "minimum": 0,
+                        "message": {
+                            "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+                            "type": "string"
+                        },
+                        "data": {
+                            "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+                        }
+                    },
+                    "required": [
+                        "code",
+                        "message"
+                    ]
+                }
+            },
+            "required": [
+                "error",
+                "id",
+                "jsonrpc"
+            ]
+        },
+        "EmptyResult": {
+            "$ref": "#/definitions/Result"
+        },
+        "CancelledNotification": {
+            "description": "This notification can be sent by either side to indicate that it is cancelling a previously-issued request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.\n\nA client MUST NOT attempt to cancel its `initialize` request.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/cancelled"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "requestId": {
+                            "$ref": "#/definitions/RequestId",
+                            "description": "The ID of the request to cancel.\n\nThis MUST correspond to the ID of a request previously issued in the same direction."
+                        },
+                        "reason": {
+                            "description": "An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "requestId"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "InitializeRequest": {
+            "description": "This request is sent from the client to the server when it first connects, asking it to begin initialization.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "initialize"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "protocolVersion": {
+                            "description": "The latest version of the Model Context Protocol that the client supports. The client MAY decide to support older versions as well.",
+                            "type": "string"
+                        },
+                        "capabilities": {
+                            "$ref": "#/definitions/ClientCapabilities"
+                        },
+                        "clientInfo": {
+                            "$ref": "#/definitions/Implementation"
+                        }
+                    },
+                    "required": [
+                        "capabilities",
+                        "clientInfo",
+                        "protocolVersion"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "InitializeResult": {
+            "description": "After receiving an initialize request from the client, the server sends this response.",
+            "type": "object",
+            "properties": {
+                "protocolVersion": {
+                    "description": "The version of the Model Context Protocol that the server wants to use. This may not match the version that the client requested. If the client cannot support this version, it MUST disconnect.",
+                    "type": "string"
+                },
+                "capabilities": {
+                    "$ref": "#/definitions/ServerCapabilities"
+                },
+                "serverInfo": {
+                    "$ref": "#/definitions/Implementation"
+                },
+                "instructions": {
+                    "description": "Instructions describing how to use the server and its features.\n\nThis can be used by clients to improve the LLM's understanding of available tools, resources, etc. It can be thought of like a \"hint\" to the model. For example, this information MAY be added to the system prompt.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "capabilities",
+                "protocolVersion",
+                "serverInfo"
+            ]
+        },
+        "InitializedNotification": {
+            "description": "This notification is sent from the client to the server after initialization has finished.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/initialized"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ClientCapabilities": {
+            "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
+            "type": "object",
+            "properties": {
+                "experimental": {
+                    "description": "Experimental, non-standard capabilities that the client supports.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": true
+                    }
+                },
+                "roots": {
+                    "description": "Present if the client supports listing roots.",
+                    "type": "object",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether the client supports notifications for changes to the roots list.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "sampling": {
+                    "description": "Present if the client supports sampling from an LLM.",
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true
+                }
+            }
+        },
+        "ServerCapabilities": {
+            "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
+            "type": "object",
+            "properties": {
+                "experimental": {
+                    "description": "Experimental, non-standard capabilities that the server supports.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": true
+                    }
+                },
+                "logging": {
+                    "description": "Present if the server supports sending log messages to the client.",
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true
+                },
+                "prompts": {
+                    "description": "Present if the server offers any prompt templates.",
+                    "type": "object",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the prompt list.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "resources": {
+                    "description": "Present if the server offers any resources to read.",
+                    "type": "object",
+                    "properties": {
+                        "subscribe": {
+                            "description": "Whether this server supports subscribing to resource updates.",
+                            "type": "boolean"
+                        },
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the resource list.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "tools": {
+                    "description": "Present if the server offers any tools to call.",
+                    "type": "object",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the tool list.",
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
+        "Implementation": {
+            "description": "Describes the name and version of an MCP implementation.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "version"
+            ]
+        },
+        "PingRequest": {
+            "description": "A ping, issued by either the server or the client, to check that the other party is still alive. The receiver must promptly respond, or else may be disconnected.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "ping"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "type": "object",
+                            "properties": {
+                                "progressToken": {
+                                    "$ref": "#/definitions/ProgressToken",
+                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ProgressNotification": {
+            "description": "An out-of-band notification used to inform the receiver of a progress update for a long-running request.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/progress"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/definitions/ProgressToken",
+                            "description": "The progress token which was given in the initial request, used to associate this notification with the request that is proceeding."
+                        },
+                        "progress": {
+                            "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
+                            "type": "number"
+                        },
+                        "total": {
+                            "description": "Total number of items to process (or total progress required), if known.",
                             "type": "number"
                         }
                     },
-                    "type": "object"
+                    "required": [
+                        "progress",
+                        "progressToken"
+                    ]
                 }
             },
-            "type": "object"
+            "required": [
+                "method",
+                "params"
+            ]
         },
-        "BlobResourceContents": {
+        "PaginatedRequest": {
+            "type": "object",
             "properties": {
-                "blob": {
-                    "description": "A base64-encoded string representing the binary data of the item.",
-                    "format": "byte",
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "cursor": {
+                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "method": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "PaginatedResult": {
+            "type": "object",
+            "properties": {
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            }
+        },
+        "ListResourcesRequest": {
+            "description": "Sent from the client to request a list of resources the server has.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/list"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "cursor": {
+                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ListResourcesResult": {
+            "description": "The server's response to a resources/list request from the client.",
+            "type": "object",
+            "properties": {
+                "resources": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Resource"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "resources"
+            ]
+        },
+        "ListResourceTemplatesRequest": {
+            "description": "Sent from the client to request a list of resource templates the server has.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/templates/list"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "cursor": {
+                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ListResourceTemplatesResult": {
+            "description": "The server's response to a resources/templates/list request from the client.",
+            "type": "object",
+            "properties": {
+                "resourceTemplates": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ResourceTemplate"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "resourceTemplates"
+            ]
+        },
+        "ReadResourceRequest": {
+            "description": "Sent from the client to the server, to read a specific resource URI.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/read"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "uri": {
+                            "description": "The URI of the resource to read. The URI can use any protocol; it is up to the server how to interpret it.",
+                            "format": "uri",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "uri"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "ReadResourceResult": {
+            "description": "The server's response to a resources/read request from the client.",
+            "type": "object",
+            "properties": {
+                "contents": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/TextResourceContents"
+                            },
+                            {
+                                "$ref": "#/definitions/BlobResourceContents"
+                            }
+                        ]
+                    }
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "contents"
+            ]
+        },
+        "ResourceListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This may be issued by servers without any previous subscription from the client.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/resources/list_changed"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "SubscribeRequest": {
+            "description": "Sent from the client to request resources/updated notifications from the server whenever a particular resource changes.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/subscribe"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "uri": {
+                            "description": "The URI of the resource to subscribe to. The URI can use any protocol; it is up to the server how to interpret it.",
+                            "format": "uri",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "uri"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "UnsubscribeRequest": {
+            "description": "Sent from the client to request cancellation of resources/updated notifications from the server. This should follow a previous resources/subscribe request.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/unsubscribe"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "uri": {
+                            "description": "The URI of the resource to unsubscribe from.",
+                            "format": "uri",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "uri"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "ResourceUpdatedNotification": {
+            "description": "A notification from the server to the client, informing it that a resource has changed and may need to be read again. This should only be sent if the client previously sent a resources/subscribe request.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/resources/updated"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "uri": {
+                            "description": "The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.",
+                            "format": "uri",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "uri"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "ResourceTemplate": {
+            "description": "A template description for resources available on the server.",
+            "type": "object",
+            "properties": {
+                "uriTemplate": {
+                    "description": "A URI template (according to RFC 6570) that can be used to construct resource URIs.",
+                    "format": "uri-template",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "A human-readable name for the type of resource this template refers to.\n\nThis can be used by clients to populate UI elements.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "type": "object",
+                    "properties": {
+                        "audience": {
+                            "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Role"
+                            }
+                        },
+                        "priority": {
+                            "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                        }
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "uriTemplate"
+            ]
+        },
+        "ResourceContents": {
+            "description": "The contents of a specific resource or sub-resource.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "mimeType": {
                     "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "uri"
+            ]
+        },
+        "TextResourceContents": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
                     "type": "string"
                 },
                 "uri": {
                     "description": "The URI of this resource.",
                     "format": "uri",
                     "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "text",
+                "uri"
+            ]
+        },
+        "BlobResourceContents": {
+            "type": "object",
+            "properties": {
+                "blob": {
+                    "description": "A base64-encoded string representing the binary data of the item.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
                 }
             },
             "required": [
                 "blob",
                 "uri"
-            ],
-            "type": "object"
+            ]
         },
-        "CallToolRequest": {
-            "description": "Used by the client to invoke a tool provided by the server.",
+        "ListPromptsRequest": {
+            "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
+            "type": "object",
             "properties": {
                 "method": {
-                    "const": "tools/call",
-                    "type": "string"
+                    "type": "string",
+                    "const": "prompts/list"
                 },
                 "params": {
+                    "type": "object",
                     "properties": {
-                        "arguments": {
-                            "additionalProperties": {},
-                            "type": "object"
-                        },
-                        "name": {
+                        "cursor": {
+                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
                             "type": "string"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ListPromptsResult": {
+            "description": "The server's response to a prompts/list request from the client.",
+            "type": "object",
+            "properties": {
+                "prompts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Prompt"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "prompts"
+            ]
+        },
+        "GetPromptRequest": {
+            "description": "Used by the client to get a prompt provided by the server.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "prompts/get"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "description": "The name of the prompt or prompt template.",
+                            "type": "string"
+                        },
+                        "arguments": {
+                            "description": "Arguments to use for templating the prompt.",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "required": [
                         "name"
-                    ],
-                    "type": "object"
+                    ]
                 }
             },
             "required": [
                 "method",
                 "params"
+            ]
+        },
+        "GetPromptResult": {
+            "description": "The server's response to a prompts/get request from the client.",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "An optional description for the prompt.",
+                    "type": "string"
+                },
+                "messages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/PromptMessage"
+                    }
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "messages"
+            ]
+        },
+        "Prompt": {
+            "description": "A prompt or prompt template that the server offers.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The name of the prompt or prompt template.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "An optional description of what this prompt provides",
+                    "type": "string"
+                },
+                "arguments": {
+                    "description": "A list of arguments to use for templating the prompt.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/PromptArgument"
+                    }
+                }
+            },
+            "required": [
+                "name"
+            ]
+        },
+        "PromptArgument": {
+            "description": "Describes an argument that a prompt can accept.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The name of the argument.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A human-readable description of the argument.",
+                    "type": "string"
+                },
+                "required": {
+                    "description": "Whether this argument must be provided.",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "name"
+            ]
+        },
+        "Role": {
+            "description": "The sender or recipient of messages and data in a conversation.",
+            "enum": [
+                "assistant",
+                "user"
             ],
-            "type": "object"
+            "type": "string"
+        },
+        "PromptMessage": {
+            "description": "Describes a message returned as part of a prompt.\n\nThis is similar to `SamplingMessage`, but also supports the embedding of\nresources from the MCP server.",
+            "type": "object",
+            "properties": {
+                "role": {
+                    "$ref": "#/definitions/Role"
+                },
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TextContent"
+                        },
+                        {
+                            "$ref": "#/definitions/ImageContent"
+                        },
+                        {
+                            "$ref": "#/definitions/EmbeddedResource"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "content",
+                "role"
+            ]
+        },
+        "EmbeddedResource": {
+            "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "resource"
+                },
+                "resource": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TextResourceContents"
+                        },
+                        {
+                            "$ref": "#/definitions/BlobResourceContents"
+                        }
+                    ]
+                },
+                "annotations": {
+                    "type": "object",
+                    "properties": {
+                        "audience": {
+                            "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Role"
+                            }
+                        },
+                        "priority": {
+                            "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                        }
+                    }
+                }
+            },
+            "required": [
+                "resource",
+                "type"
+            ]
+        },
+        "PromptListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/prompts/list_changed"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ListToolsRequest": {
+            "description": "Sent from the client to request a list of tools the server has.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "tools/list"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "cursor": {
+                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ListToolsResult": {
+            "description": "The server's response to a tools/list request from the client.",
+            "type": "object",
+            "properties": {
+                "tools": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Tool"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "tools"
+            ]
         },
         "CallToolResult": {
             "description": "The server's response to a tool call.\n\nAny errors that originate from the tool SHOULD be reported inside the result\nobject, with `isError` set to true, _not_ as an MCP protocol-level error\nresponse. Otherwise, the LLM would not be able to see that an error occurred\nand self-correct.\n\nHowever, any errors in _finding_ the tool, an error indicating that the\nserver does not support tool calls, or any other exceptional conditions,\nshould be reported as an MCP error response.",
+            "type": "object",
             "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
                 "content": {
+                    "type": "array",
                     "items": {
                         "anyOf": [
                             {
@@ -98,79 +1182,658 @@
                                 "$ref": "#/definitions/EmbeddedResource"
                             }
                         ]
-                    },
-                    "type": "array"
+                    }
                 },
                 "isError": {
                     "description": "Whether the tool call ended in an error.\n\nIf not set, this is assumed to be false (the call was successful).",
                     "type": "boolean"
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
                 }
             },
             "required": [
                 "content"
-            ],
-            "type": "object"
+            ]
         },
-        "CancelledNotification": {
-            "description": "This notification can be sent by either side to indicate that it is cancelling a previously-issued request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.\n\nA client MUST NOT attempt to cancel its `initialize` request.",
+        "CallToolRequest": {
+            "description": "Used by the client to invoke a tool provided by the server.",
+            "type": "object",
             "properties": {
                 "method": {
-                    "const": "notifications/cancelled",
-                    "type": "string"
+                    "type": "string",
+                    "const": "tools/call"
                 },
                 "params": {
+                    "type": "object",
                     "properties": {
-                        "reason": {
-                            "description": "An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.",
+                        "name": {
                             "type": "string"
                         },
-                        "requestId": {
-                            "$ref": "#/definitions/RequestId",
-                            "description": "The ID of the request to cancel.\n\nThis MUST correspond to the ID of a request previously issued in the same direction."
+                        "arguments": {
+                            "type": "object",
+                            "additionalProperties": {}
                         }
                     },
                     "required": [
-                        "requestId"
-                    ],
-                    "type": "object"
+                        "name"
+                    ]
                 }
             },
             "required": [
                 "method",
                 "params"
-            ],
-            "type": "object"
+            ]
         },
-        "ClientCapabilities": {
-            "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
+        "ToolListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of tools it offers has changed. This may be issued by servers without any previous subscription from the client.",
+            "type": "object",
             "properties": {
-                "experimental": {
-                    "additionalProperties": {
-                        "additionalProperties": true,
-                        "properties": {},
-                        "type": "object"
-                    },
-                    "description": "Experimental, non-standard capabilities that the client supports.",
-                    "type": "object"
+                "method": {
+                    "type": "string",
+                    "const": "notifications/tools/list_changed"
                 },
-                "roots": {
-                    "description": "Present if the client supports listing roots.",
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
                     "properties": {
-                        "listChanged": {
-                            "description": "Whether the client supports notifications for changes to the roots list.",
+                        "_meta": {
+                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "Tool": {
+            "description": "Definition for a tool the client can call.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The name of the tool.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A human-readable description of the tool.",
+                    "type": "string"
+                },
+                "inputSchema": {
+                    "description": "A JSON Schema object defining the expected parameters for the tool.",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "object"
+                        },
+                        "properties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": true
+                            }
+                        },
+                        "required": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ]
+                }
+            },
+            "required": [
+                "inputSchema",
+                "name"
+            ]
+        },
+        "SetLevelRequest": {
+            "description": "A request from the client to the server, to enable or adjust logging.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "logging/setLevel"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "level": {
+                            "$ref": "#/definitions/LoggingLevel",
+                            "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message."
+                        }
+                    },
+                    "required": [
+                        "level"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "LoggingMessageNotification": {
+            "description": "Notification of a log message passed from server to client. If no logging/setLevel request has been sent from the client, the server MAY decide which messages to send automatically.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/message"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "level": {
+                            "$ref": "#/definitions/LoggingLevel",
+                            "description": "The severity of this log message."
+                        },
+                        "logger": {
+                            "description": "An optional name of the logger issuing this message.",
+                            "type": "string"
+                        },
+                        "data": {
+                            "description": "The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here."
+                        }
+                    },
+                    "required": [
+                        "data",
+                        "level"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "LoggingLevel": {
+            "description": "The severity of a log message.\n\nThese map to syslog message severities, as specified in RFC-5424:\nhttps://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1",
+            "enum": [
+                "alert",
+                "critical",
+                "debug",
+                "emergency",
+                "error",
+                "info",
+                "notice",
+                "warning"
+            ],
+            "type": "string"
+        },
+        "CreateMessageRequest": {
+            "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "sampling/createMessage"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SamplingMessage"
+                            }
+                        },
+                        "modelPreferences": {
+                            "$ref": "#/definitions/ModelPreferences",
+                            "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
+                        },
+                        "systemPrompt": {
+                            "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
+                            "type": "string"
+                        },
+                        "includeContext": {
+                            "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt. The client MAY ignore this request.",
+                            "enum": [
+                                "allServers",
+                                "none",
+                                "thisServer"
+                            ],
+                            "type": "string"
+                        },
+                        "temperature": {
+                            "type": "number"
+                        },
+                        "maxTokens": {
+                            "description": "The maximum number of tokens to sample, as requested by the server. The client MAY choose to sample fewer tokens than requested.",
+                            "type": "integer"
+                        },
+                        "stopSequences": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "metadata": {
+                            "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific.",
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": true
+                        }
+                    },
+                    "required": [
+                        "maxTokens",
+                        "messages"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "CreateMessageResult": {
+            "description": "The client's response to a sampling/create_message request from the server. The client should inform the user before returning the sampled message, to allow them to inspect the response (human in the loop) and decide whether to allow the server to see it.",
+            "type": "object",
+            "properties": {
+                "model": {
+                    "description": "The name of the model that generated the message.",
+                    "type": "string"
+                },
+                "stopReason": {
+                    "description": "The reason why sampling stopped, if known.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "role": {
+                    "$ref": "#/definitions/Role"
+                },
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TextContent"
+                        },
+                        {
+                            "$ref": "#/definitions/ImageContent"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "content",
+                "model",
+                "role"
+            ]
+        },
+        "SamplingMessage": {
+            "description": "Describes a message issued to or received from an LLM API.",
+            "type": "object",
+            "properties": {
+                "role": {
+                    "$ref": "#/definitions/Role"
+                },
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TextContent"
+                        },
+                        {
+                            "$ref": "#/definitions/ImageContent"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "content",
+                "role"
+            ]
+        },
+        "Annotated": {
+            "description": "Base for objects that include optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object",
+                    "properties": {
+                        "audience": {
+                            "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Role"
+                            }
+                        },
+                        "priority": {
+                            "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                        }
+                    }
+                }
+            }
+        },
+        "TextContent": {
+            "description": "Text provided to or from an LLM.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "text"
+                },
+                "text": {
+                    "description": "The text content of the message.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "type": "object",
+                    "properties": {
+                        "audience": {
+                            "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Role"
+                            }
+                        },
+                        "priority": {
+                            "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                        }
+                    }
+                }
+            },
+            "required": [
+                "text",
+                "type"
+            ]
+        },
+        "ImageContent": {
+            "description": "An image provided to or from an LLM.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "image"
+                },
+                "data": {
+                    "description": "The base64-encoded image data.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of the image. Different providers may support different image types.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "type": "object",
+                    "properties": {
+                        "audience": {
+                            "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Role"
+                            }
+                        },
+                        "priority": {
+                            "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                        }
+                    }
+                }
+            },
+            "required": [
+                "data",
+                "mimeType",
+                "type"
+            ]
+        },
+        "ModelPreferences": {
+            "description": "The server's preferences for model selection, requested of the client during sampling.\n\nBecause LLMs can vary along multiple dimensions, choosing the \"best\" model is\nrarely straightforward.  Different models excel in different areas—some are\nfaster but less capable, others are more capable but more expensive, and so\non. This interface allows servers to express their priorities across multiple\ndimensions to help clients make an appropriate selection for their use case.\n\nThese preferences are always advisory. The client MAY ignore them. It is also\nup to the client to decide how to interpret these preferences and how to\nbalance them against other considerations.",
+            "type": "object",
+            "properties": {
+                "hints": {
+                    "description": "Optional hints to use for model selection.\n\nIf multiple hints are specified, the client MUST evaluate them in order\n(such that the first match is taken).\n\nThe client SHOULD prioritize these hints over the numeric priorities, but\nMAY still use the priorities to select from ambiguous matches.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ModelHint"
+                    }
+                },
+                "costPriority": {
+                    "description": "How much to prioritize cost when selecting a model. A value of 0 means cost\nis not important, while a value of 1 means cost is the most important\nfactor.",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "speedPriority": {
+                    "description": "How much to prioritize sampling speed (latency) when selecting a model. A\nvalue of 0 means speed is not important, while a value of 1 means speed is\nthe most important factor.",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "intelligencePriority": {
+                    "description": "How much to prioritize intelligence and capabilities when selecting a\nmodel. A value of 0 means intelligence is not important, while a value of 1\nmeans intelligence is the most important factor.",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                }
+            }
+        },
+        "ModelHint": {
+            "description": "Hints to use for model selection.\n\nKeys not declared here are currently left unspecified by the spec and are up\nto the client to interpret.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "A hint for a model name.\n\nThe client SHOULD treat this as a substring of a model name; for example:\n - `claude-3-5-sonnet` should match `claude-3-5-sonnet-20241022`\n - `sonnet` should match `claude-3-5-sonnet-20241022`, `claude-3-sonnet-20240229`, etc.\n - `claude` should match any Claude model\n\nThe client MAY also map the string to a different provider's model name or a different model family, as long as it fills a similar niche; for example:\n - `gemini-1.5-flash` could match `claude-3-haiku-20240307`",
+                    "type": "string"
+                }
+            }
+        },
+        "CompleteRequest": {
+            "description": "A request from the client to the server, to ask for completion options.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "completion/complete"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "ref": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/definitions/PromptReference"
+                                },
+                                {
+                                    "$ref": "#/definitions/ResourceReference"
+                                }
+                            ]
+                        },
+                        "argument": {
+                            "description": "The argument's information",
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "description": "The name of the argument",
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "description": "The value of the argument to use for completion matching.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "argument",
+                        "ref"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "CompleteResult": {
+            "description": "The server's response to a completion/complete request",
+            "type": "object",
+            "properties": {
+                "completion": {
+                    "type": "object",
+                    "properties": {
+                        "values": {
+                            "description": "An array of completion values. Must not exceed 100 items.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "total": {
+                            "description": "The total number of completion options available. This can exceed the number of values actually sent in the response.",
+                            "type": "integer"
+                        },
+                        "hasMore": {
+                            "description": "Indicates whether there are additional completion options beyond those provided in the current response, even if the exact total is unknown.",
                             "type": "boolean"
                         }
                     },
-                    "type": "object"
+                    "required": [
+                        "values"
+                    ]
                 },
-                "sampling": {
-                    "additionalProperties": true,
-                    "description": "Present if the client supports sampling from an LLM.",
-                    "properties": {},
-                    "type": "object"
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
                 }
             },
-            "type": "object"
+            "required": [
+                "completion"
+            ]
+        },
+        "ResourceReference": {
+            "description": "A reference to a resource or resource template definition.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "ref/resource"
+                },
+                "uri": {
+                    "description": "The URI or URI template of the resource.",
+                    "format": "uri-template",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type",
+                "uri"
+            ]
+        },
+        "PromptReference": {
+            "description": "Identifies a prompt.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "ref/prompt"
+                },
+                "name": {
+                    "description": "The name of the prompt or prompt template",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "type"
+            ]
+        },
+        "ListRootsRequest": {
+            "description": "Sent from the server to request a list of root URIs from the client. Roots allow\nservers to ask for specific directories or files to operate on. A common example\nfor roots is providing a set of repositories or directories a server should operate\non.\n\nThis request is typically used when the server needs to understand the file system\nstructure or access specific locations that the client has permission to read from.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "roots/list"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "type": "object",
+                            "properties": {
+                                "progressToken": {
+                                    "$ref": "#/definitions/ProgressToken",
+                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ListRootsResult": {
+            "description": "The client's response to a roots/list request from the server.\nThis result contains an array of Root objects, each representing a root directory\nor file that the server can operate on.",
+            "type": "object",
+            "properties": {
+                "roots": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Root"
+                    }
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "roots"
+            ]
+        },
+        "RootsListChangedNotification": {
+            "description": "A notification from the client to the server, informing it that the list of roots has changed.\nThis notification should be sent whenever the client adds, removes, or modifies any root.\nThe server should then request an updated list of roots using the ListRootsRequest.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/roots/list_changed"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
         },
         "ClientNotification": {
             "anyOf": [
@@ -186,6 +1849,184 @@
                 {
                     "$ref": "#/definitions/RootsListChangedNotification"
                 }
+            ]
+        },
+        "ClientResult": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/Result"
+                },
+                {
+                    "$ref": "#/definitions/CreateMessageResult"
+                },
+                {
+                    "$ref": "#/definitions/ListRootsResult"
+                }
+            ]
+        },
+        "ServerRequest": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/PingRequest"
+                },
+                {
+                    "$ref": "#/definitions/CreateMessageRequest"
+                },
+                {
+                    "$ref": "#/definitions/ListRootsRequest"
+                }
+            ]
+        },
+        "ServerNotification": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/CancelledNotification"
+                },
+                {
+                    "$ref": "#/definitions/ProgressNotification"
+                },
+                {
+                    "$ref": "#/definitions/ResourceListChangedNotification"
+                },
+                {
+                    "$ref": "#/definitions/ResourceUpdatedNotification"
+                },
+                {
+                    "$ref": "#/definitions/PromptListChangedNotification"
+                },
+                {
+                    "$ref": "#/definitions/ToolListChangedNotification"
+                },
+                {
+                    "$ref": "#/definitions/LoggingMessageNotification"
+                }
+            ]
+        },
+        "ServerResult": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/Result"
+                },
+                {
+                    "$ref": "#/definitions/InitializeResult"
+                },
+                {
+                    "$ref": "#/definitions/ListResourcesResult"
+                },
+                {
+                    "$ref": "#/definitions/ListResourceTemplatesResult"
+                },
+                {
+                    "$ref": "#/definitions/ReadResourceResult"
+                },
+                {
+                    "$ref": "#/definitions/ListPromptsResult"
+                },
+                {
+                    "$ref": "#/definitions/GetPromptResult"
+                },
+                {
+                    "$ref": "#/definitions/ListToolsResult"
+                },
+                {
+                    "$ref": "#/definitions/CallToolResult"
+                },
+                {
+                    "$ref": "#/definitions/CompleteResult"
+                }
+            ]
+        },
+        "Request": {
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "type": "object",
+                            "properties": {
+                                "progressToken": {
+                                    "$ref": "#/definitions/ProgressToken",
+                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "Resource": {
+            "description": "A known resource that the server is capable of reading.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "A human-readable name for this resource.\n\nThis can be used by clients to populate UI elements.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "size": {
+                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+                    "type": "integer"
+                },
+                "annotations": {
+                    "type": "object",
+                    "properties": {
+                        "audience": {
+                            "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Role"
+                            }
+                        },
+                        "priority": {
+                            "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                        }
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "uri"
+            ]
+        },
+        "Root": {
+            "description": "Represents a root directory or file that the server can operate on.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI identifying the root. This *must* start with file:// for now.\nThis restriction may be relaxed in future versions of the protocol to allow\nother URI schemes.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "uri"
             ]
         },
         "ClientRequest": {
@@ -230,1848 +2071,6 @@
                     "$ref": "#/definitions/CompleteRequest"
                 }
             ]
-        },
-        "ClientResult": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/Result"
-                },
-                {
-                    "$ref": "#/definitions/CreateMessageResult"
-                },
-                {
-                    "$ref": "#/definitions/ListRootsResult"
-                }
-            ]
-        },
-        "CompleteRequest": {
-            "description": "A request from the client to the server, to ask for completion options.",
-            "properties": {
-                "method": {
-                    "const": "completion/complete",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "argument": {
-                            "description": "The argument's information",
-                            "properties": {
-                                "name": {
-                                    "description": "The name of the argument",
-                                    "type": "string"
-                                },
-                                "value": {
-                                    "description": "The value of the argument to use for completion matching.",
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "name",
-                                "value"
-                            ],
-                            "type": "object"
-                        },
-                        "ref": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/definitions/PromptReference"
-                                },
-                                {
-                                    "$ref": "#/definitions/ResourceReference"
-                                }
-                            ]
-                        }
-                    },
-                    "required": [
-                        "argument",
-                        "ref"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "CompleteResult": {
-            "description": "The server's response to a completion/complete request",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "completion": {
-                    "properties": {
-                        "hasMore": {
-                            "description": "Indicates whether there are additional completion options beyond those provided in the current response, even if the exact total is unknown.",
-                            "type": "boolean"
-                        },
-                        "total": {
-                            "description": "The total number of completion options available. This can exceed the number of values actually sent in the response.",
-                            "type": "integer"
-                        },
-                        "values": {
-                            "description": "An array of completion values. Must not exceed 100 items.",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "required": [
-                        "values"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "completion"
-            ],
-            "type": "object"
-        },
-        "CreateMessageRequest": {
-            "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
-            "properties": {
-                "method": {
-                    "const": "sampling/createMessage",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "includeContext": {
-                            "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt. The client MAY ignore this request.",
-                            "enum": [
-                                "allServers",
-                                "none",
-                                "thisServer"
-                            ],
-                            "type": "string"
-                        },
-                        "maxTokens": {
-                            "description": "The maximum number of tokens to sample, as requested by the server. The client MAY choose to sample fewer tokens than requested.",
-                            "type": "integer"
-                        },
-                        "messages": {
-                            "items": {
-                                "$ref": "#/definitions/SamplingMessage"
-                            },
-                            "type": "array"
-                        },
-                        "metadata": {
-                            "additionalProperties": true,
-                            "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific.",
-                            "properties": {},
-                            "type": "object"
-                        },
-                        "modelPreferences": {
-                            "$ref": "#/definitions/ModelPreferences",
-                            "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
-                        },
-                        "stopSequences": {
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "systemPrompt": {
-                            "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
-                            "type": "string"
-                        },
-                        "temperature": {
-                            "type": "number"
-                        }
-                    },
-                    "required": [
-                        "maxTokens",
-                        "messages"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "CreateMessageResult": {
-            "description": "The client's response to a sampling/create_message request from the server. The client should inform the user before returning the sampled message, to allow them to inspect the response (human in the loop) and decide whether to allow the server to see it.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "content": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/TextContent"
-                        },
-                        {
-                            "$ref": "#/definitions/ImageContent"
-                        }
-                    ]
-                },
-                "model": {
-                    "description": "The name of the model that generated the message.",
-                    "type": "string"
-                },
-                "role": {
-                    "$ref": "#/definitions/Role"
-                },
-                "stopReason": {
-                    "description": "The reason why sampling stopped, if known.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "content",
-                "model",
-                "role"
-            ],
-            "type": "object"
-        },
-        "Cursor": {
-            "description": "An opaque token used to represent a cursor for pagination.",
-            "type": "string"
-        },
-        "EmbeddedResource": {
-            "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
-            "properties": {
-                "annotations": {
-                    "properties": {
-                        "audience": {
-                            "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
-                            "items": {
-                                "$ref": "#/definitions/Role"
-                            },
-                            "type": "array"
-                        },
-                        "priority": {
-                            "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
-                            "maximum": 1,
-                            "minimum": 0,
-                            "type": "number"
-                        }
-                    },
-                    "type": "object"
-                },
-                "resource": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/TextResourceContents"
-                        },
-                        {
-                            "$ref": "#/definitions/BlobResourceContents"
-                        }
-                    ]
-                },
-                "type": {
-                    "const": "resource",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "resource",
-                "type"
-            ],
-            "type": "object"
-        },
-        "EmptyResult": {
-            "$ref": "#/definitions/Result"
-        },
-        "GetPromptRequest": {
-            "description": "Used by the client to get a prompt provided by the server.",
-            "properties": {
-                "method": {
-                    "const": "prompts/get",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "arguments": {
-                            "additionalProperties": {
-                                "type": "string"
-                            },
-                            "description": "Arguments to use for templating the prompt.",
-                            "type": "object"
-                        },
-                        "name": {
-                            "description": "The name of the prompt or prompt template.",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "name"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "GetPromptResult": {
-            "description": "The server's response to a prompts/get request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "description": {
-                    "description": "An optional description for the prompt.",
-                    "type": "string"
-                },
-                "messages": {
-                    "items": {
-                        "$ref": "#/definitions/PromptMessage"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "messages"
-            ],
-            "type": "object"
-        },
-        "ImageContent": {
-            "description": "An image provided to or from an LLM.",
-            "properties": {
-                "annotations": {
-                    "properties": {
-                        "audience": {
-                            "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
-                            "items": {
-                                "$ref": "#/definitions/Role"
-                            },
-                            "type": "array"
-                        },
-                        "priority": {
-                            "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
-                            "maximum": 1,
-                            "minimum": 0,
-                            "type": "number"
-                        }
-                    },
-                    "type": "object"
-                },
-                "data": {
-                    "description": "The base64-encoded image data.",
-                    "format": "byte",
-                    "type": "string"
-                },
-                "mimeType": {
-                    "description": "The MIME type of the image. Different providers may support different image types.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "image",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "data",
-                "mimeType",
-                "type"
-            ],
-            "type": "object"
-        },
-        "Implementation": {
-            "description": "Describes the name and version of an MCP implementation.",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "version"
-            ],
-            "type": "object"
-        },
-        "InitializeRequest": {
-            "description": "This request is sent from the client to the server when it first connects, asking it to begin initialization.",
-            "properties": {
-                "method": {
-                    "const": "initialize",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "capabilities": {
-                            "$ref": "#/definitions/ClientCapabilities"
-                        },
-                        "clientInfo": {
-                            "$ref": "#/definitions/Implementation"
-                        },
-                        "protocolVersion": {
-                            "description": "The latest version of the Model Context Protocol that the client supports. The client MAY decide to support older versions as well.",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "capabilities",
-                        "clientInfo",
-                        "protocolVersion"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "InitializeResult": {
-            "description": "After receiving an initialize request from the client, the server sends this response.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "capabilities": {
-                    "$ref": "#/definitions/ServerCapabilities"
-                },
-                "instructions": {
-                    "description": "Instructions describing how to use the server and its features.\n\nThis can be used by clients to improve the LLM's understanding of available tools, resources, etc. It can be thought of like a \"hint\" to the model. For example, this information MAY be added to the system prompt.",
-                    "type": "string"
-                },
-                "protocolVersion": {
-                    "description": "The version of the Model Context Protocol that the server wants to use. This may not match the version that the client requested. If the client cannot support this version, it MUST disconnect.",
-                    "type": "string"
-                },
-                "serverInfo": {
-                    "$ref": "#/definitions/Implementation"
-                }
-            },
-            "required": [
-                "capabilities",
-                "protocolVersion",
-                "serverInfo"
-            ],
-            "type": "object"
-        },
-        "InitializedNotification": {
-            "description": "This notification is sent from the client to the server after initialization has finished.",
-            "properties": {
-                "method": {
-                    "const": "notifications/initialized",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "JSONRPCError": {
-            "description": "A response to a request that indicates an error occurred.",
-            "properties": {
-                "error": {
-                    "properties": {
-                        "code": {
-                            "description": "The error type that occurred.",
-                            "type": "integer"
-                        },
-                        "data": {
-                            "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
-                        },
-                        "message": {
-                            "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "code",
-                        "message"
-                    ],
-                    "type": "object"
-                },
-                "id": {
-                    "$ref": "#/definitions/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "error",
-                "id",
-                "jsonrpc"
-            ],
-            "type": "object"
-        },
-        "JSONRPCMessage": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/JSONRPCRequest"
-                },
-                {
-                    "$ref": "#/definitions/JSONRPCNotification"
-                },
-                {
-                    "$ref": "#/definitions/JSONRPCResponse"
-                },
-                {
-                    "$ref": "#/definitions/JSONRPCError"
-                }
-            ]
-        },
-        "JSONRPCNotification": {
-            "description": "A notification which does not expect a response.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "JSONRPCRequest": {
-            "description": "A request that expects a response.",
-            "properties": {
-                "id": {
-                    "$ref": "#/definitions/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "properties": {
-                                "progressToken": {
-                                    "$ref": "#/definitions/ProgressToken",
-                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                                }
-                            },
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "JSONRPCResponse": {
-            "description": "A successful (non-error) response to a request.",
-            "properties": {
-                "id": {
-                    "$ref": "#/definitions/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "result": {
-                    "$ref": "#/definitions/Result"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "result"
-            ],
-            "type": "object"
-        },
-        "ListPromptsRequest": {
-            "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
-            "properties": {
-                "method": {
-                    "const": "prompts/list",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "cursor": {
-                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListPromptsResult": {
-            "description": "The server's response to a prompts/list request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "prompts": {
-                    "items": {
-                        "$ref": "#/definitions/Prompt"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "prompts"
-            ],
-            "type": "object"
-        },
-        "ListResourceTemplatesRequest": {
-            "description": "Sent from the client to request a list of resource templates the server has.",
-            "properties": {
-                "method": {
-                    "const": "resources/templates/list",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "cursor": {
-                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListResourceTemplatesResult": {
-            "description": "The server's response to a resources/templates/list request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "resourceTemplates": {
-                    "items": {
-                        "$ref": "#/definitions/ResourceTemplate"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "resourceTemplates"
-            ],
-            "type": "object"
-        },
-        "ListResourcesRequest": {
-            "description": "Sent from the client to request a list of resources the server has.",
-            "properties": {
-                "method": {
-                    "const": "resources/list",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "cursor": {
-                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListResourcesResult": {
-            "description": "The server's response to a resources/list request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "resources": {
-                    "items": {
-                        "$ref": "#/definitions/Resource"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "resources"
-            ],
-            "type": "object"
-        },
-        "ListRootsRequest": {
-            "description": "Sent from the server to request a list of root URIs from the client. Roots allow\nservers to ask for specific directories or files to operate on. A common example\nfor roots is providing a set of repositories or directories a server should operate\non.\n\nThis request is typically used when the server needs to understand the file system\nstructure or access specific locations that the client has permission to read from.",
-            "properties": {
-                "method": {
-                    "const": "roots/list",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "properties": {
-                                "progressToken": {
-                                    "$ref": "#/definitions/ProgressToken",
-                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                                }
-                            },
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListRootsResult": {
-            "description": "The client's response to a roots/list request from the server.\nThis result contains an array of Root objects, each representing a root directory\nor file that the server can operate on.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "roots": {
-                    "items": {
-                        "$ref": "#/definitions/Root"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "roots"
-            ],
-            "type": "object"
-        },
-        "ListToolsRequest": {
-            "description": "Sent from the client to request a list of tools the server has.",
-            "properties": {
-                "method": {
-                    "const": "tools/list",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "cursor": {
-                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListToolsResult": {
-            "description": "The server's response to a tools/list request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "tools": {
-                    "items": {
-                        "$ref": "#/definitions/Tool"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "tools"
-            ],
-            "type": "object"
-        },
-        "LoggingLevel": {
-            "description": "The severity of a log message.\n\nThese map to syslog message severities, as specified in RFC-5424:\nhttps://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1",
-            "enum": [
-                "alert",
-                "critical",
-                "debug",
-                "emergency",
-                "error",
-                "info",
-                "notice",
-                "warning"
-            ],
-            "type": "string"
-        },
-        "LoggingMessageNotification": {
-            "description": "Notification of a log message passed from server to client. If no logging/setLevel request has been sent from the client, the server MAY decide which messages to send automatically.",
-            "properties": {
-                "method": {
-                    "const": "notifications/message",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "data": {
-                            "description": "The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here."
-                        },
-                        "level": {
-                            "$ref": "#/definitions/LoggingLevel",
-                            "description": "The severity of this log message."
-                        },
-                        "logger": {
-                            "description": "An optional name of the logger issuing this message.",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "data",
-                        "level"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ModelHint": {
-            "description": "Hints to use for model selection.\n\nKeys not declared here are currently left unspecified by the spec and are up\nto the client to interpret.",
-            "properties": {
-                "name": {
-                    "description": "A hint for a model name.\n\nThe client SHOULD treat this as a substring of a model name; for example:\n - `claude-3-5-sonnet` should match `claude-3-5-sonnet-20241022`\n - `sonnet` should match `claude-3-5-sonnet-20241022`, `claude-3-sonnet-20240229`, etc.\n - `claude` should match any Claude model\n\nThe client MAY also map the string to a different provider's model name or a different model family, as long as it fills a similar niche; for example:\n - `gemini-1.5-flash` could match `claude-3-haiku-20240307`",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "ModelPreferences": {
-            "description": "The server's preferences for model selection, requested of the client during sampling.\n\nBecause LLMs can vary along multiple dimensions, choosing the \"best\" model is\nrarely straightforward.  Different models excel in different areas—some are\nfaster but less capable, others are more capable but more expensive, and so\non. This interface allows servers to express their priorities across multiple\ndimensions to help clients make an appropriate selection for their use case.\n\nThese preferences are always advisory. The client MAY ignore them. It is also\nup to the client to decide how to interpret these preferences and how to\nbalance them against other considerations.",
-            "properties": {
-                "costPriority": {
-                    "description": "How much to prioritize cost when selecting a model. A value of 0 means cost\nis not important, while a value of 1 means cost is the most important\nfactor.",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "hints": {
-                    "description": "Optional hints to use for model selection.\n\nIf multiple hints are specified, the client MUST evaluate them in order\n(such that the first match is taken).\n\nThe client SHOULD prioritize these hints over the numeric priorities, but\nMAY still use the priorities to select from ambiguous matches.",
-                    "items": {
-                        "$ref": "#/definitions/ModelHint"
-                    },
-                    "type": "array"
-                },
-                "intelligencePriority": {
-                    "description": "How much to prioritize intelligence and capabilities when selecting a\nmodel. A value of 0 means intelligence is not important, while a value of 1\nmeans intelligence is the most important factor.",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "speedPriority": {
-                    "description": "How much to prioritize sampling speed (latency) when selecting a model. A\nvalue of 0 means speed is not important, while a value of 1 means speed is\nthe most important factor.",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
-                }
-            },
-            "type": "object"
-        },
-        "Notification": {
-            "properties": {
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "PaginatedRequest": {
-            "properties": {
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "cursor": {
-                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "PaginatedResult": {
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "PingRequest": {
-            "description": "A ping, issued by either the server or the client, to check that the other party is still alive. The receiver must promptly respond, or else may be disconnected.",
-            "properties": {
-                "method": {
-                    "const": "ping",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "properties": {
-                                "progressToken": {
-                                    "$ref": "#/definitions/ProgressToken",
-                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                                }
-                            },
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ProgressNotification": {
-            "description": "An out-of-band notification used to inform the receiver of a progress update for a long-running request.",
-            "properties": {
-                "method": {
-                    "const": "notifications/progress",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "progress": {
-                            "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
-                            "type": "number"
-                        },
-                        "progressToken": {
-                            "$ref": "#/definitions/ProgressToken",
-                            "description": "The progress token which was given in the initial request, used to associate this notification with the request that is proceeding."
-                        },
-                        "total": {
-                            "description": "Total number of items to process (or total progress required), if known.",
-                            "type": "number"
-                        }
-                    },
-                    "required": [
-                        "progress",
-                        "progressToken"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ProgressToken": {
-            "description": "A progress token, used to associate progress notifications with the original request.",
-            "type": [
-                "string",
-                "integer"
-            ]
-        },
-        "Prompt": {
-            "description": "A prompt or prompt template that the server offers.",
-            "properties": {
-                "arguments": {
-                    "description": "A list of arguments to use for templating the prompt.",
-                    "items": {
-                        "$ref": "#/definitions/PromptArgument"
-                    },
-                    "type": "array"
-                },
-                "description": {
-                    "description": "An optional description of what this prompt provides",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "The name of the prompt or prompt template.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "type": "object"
-        },
-        "PromptArgument": {
-            "description": "Describes an argument that a prompt can accept.",
-            "properties": {
-                "description": {
-                    "description": "A human-readable description of the argument.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "The name of the argument.",
-                    "type": "string"
-                },
-                "required": {
-                    "description": "Whether this argument must be provided.",
-                    "type": "boolean"
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "type": "object"
-        },
-        "PromptListChangedNotification": {
-            "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.",
-            "properties": {
-                "method": {
-                    "const": "notifications/prompts/list_changed",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "PromptMessage": {
-            "description": "Describes a message returned as part of a prompt.\n\nThis is similar to `SamplingMessage`, but also supports the embedding of\nresources from the MCP server.",
-            "properties": {
-                "content": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/TextContent"
-                        },
-                        {
-                            "$ref": "#/definitions/ImageContent"
-                        },
-                        {
-                            "$ref": "#/definitions/EmbeddedResource"
-                        }
-                    ]
-                },
-                "role": {
-                    "$ref": "#/definitions/Role"
-                }
-            },
-            "required": [
-                "content",
-                "role"
-            ],
-            "type": "object"
-        },
-        "PromptReference": {
-            "description": "Identifies a prompt.",
-            "properties": {
-                "name": {
-                    "description": "The name of the prompt or prompt template",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "ref/prompt",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "type"
-            ],
-            "type": "object"
-        },
-        "ReadResourceRequest": {
-            "description": "Sent from the client to the server, to read a specific resource URI.",
-            "properties": {
-                "method": {
-                    "const": "resources/read",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "uri": {
-                            "description": "The URI of the resource to read. The URI can use any protocol; it is up to the server how to interpret it.",
-                            "format": "uri",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "uri"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ReadResourceResult": {
-            "description": "The server's response to a resources/read request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "contents": {
-                    "items": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/definitions/TextResourceContents"
-                            },
-                            {
-                                "$ref": "#/definitions/BlobResourceContents"
-                            }
-                        ]
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "contents"
-            ],
-            "type": "object"
-        },
-        "Request": {
-            "properties": {
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "properties": {
-                                "progressToken": {
-                                    "$ref": "#/definitions/ProgressToken",
-                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                                }
-                            },
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "RequestId": {
-            "description": "A uniquely identifying ID for a request in JSON-RPC.",
-            "type": [
-                "string",
-                "integer"
-            ]
-        },
-        "Resource": {
-            "description": "A known resource that the server is capable of reading.",
-            "properties": {
-                "annotations": {
-                    "properties": {
-                        "audience": {
-                            "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
-                            "items": {
-                                "$ref": "#/definitions/Role"
-                            },
-                            "type": "array"
-                        },
-                        "priority": {
-                            "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
-                            "maximum": 1,
-                            "minimum": 0,
-                            "type": "number"
-                        }
-                    },
-                    "type": "object"
-                },
-                "description": {
-                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
-                    "type": "string"
-                },
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "A human-readable name for this resource.\n\nThis can be used by clients to populate UI elements.",
-                    "type": "string"
-                },
-                "size": {
-                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
-                    "type": "integer"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ResourceContents": {
-            "description": "The contents of a specific resource or sub-resource.",
-            "properties": {
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ResourceListChangedNotification": {
-            "description": "An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This may be issued by servers without any previous subscription from the client.",
-            "properties": {
-                "method": {
-                    "const": "notifications/resources/list_changed",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ResourceReference": {
-            "description": "A reference to a resource or resource template definition.",
-            "properties": {
-                "type": {
-                    "const": "ref/resource",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI or URI template of the resource.",
-                    "format": "uri-template",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "type",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ResourceTemplate": {
-            "description": "A template description for resources available on the server.",
-            "properties": {
-                "annotations": {
-                    "properties": {
-                        "audience": {
-                            "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
-                            "items": {
-                                "$ref": "#/definitions/Role"
-                            },
-                            "type": "array"
-                        },
-                        "priority": {
-                            "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
-                            "maximum": 1,
-                            "minimum": 0,
-                            "type": "number"
-                        }
-                    },
-                    "type": "object"
-                },
-                "description": {
-                    "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
-                    "type": "string"
-                },
-                "mimeType": {
-                    "description": "The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "A human-readable name for the type of resource this template refers to.\n\nThis can be used by clients to populate UI elements.",
-                    "type": "string"
-                },
-                "uriTemplate": {
-                    "description": "A URI template (according to RFC 6570) that can be used to construct resource URIs.",
-                    "format": "uri-template",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "uriTemplate"
-            ],
-            "type": "object"
-        },
-        "ResourceUpdatedNotification": {
-            "description": "A notification from the server to the client, informing it that a resource has changed and may need to be read again. This should only be sent if the client previously sent a resources/subscribe request.",
-            "properties": {
-                "method": {
-                    "const": "notifications/resources/updated",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "uri": {
-                            "description": "The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.",
-                            "format": "uri",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "uri"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "Result": {
-            "additionalProperties": {},
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "Role": {
-            "description": "The sender or recipient of messages and data in a conversation.",
-            "enum": [
-                "assistant",
-                "user"
-            ],
-            "type": "string"
-        },
-        "Root": {
-            "description": "Represents a root directory or file that the server can operate on.",
-            "properties": {
-                "name": {
-                    "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI identifying the root. This *must* start with file:// for now.\nThis restriction may be relaxed in future versions of the protocol to allow\nother URI schemes.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "uri"
-            ],
-            "type": "object"
-        },
-        "RootsListChangedNotification": {
-            "description": "A notification from the client to the server, informing it that the list of roots has changed.\nThis notification should be sent whenever the client adds, removes, or modifies any root.\nThe server should then request an updated list of roots using the ListRootsRequest.",
-            "properties": {
-                "method": {
-                    "const": "notifications/roots/list_changed",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "SamplingMessage": {
-            "description": "Describes a message issued to or received from an LLM API.",
-            "properties": {
-                "content": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/TextContent"
-                        },
-                        {
-                            "$ref": "#/definitions/ImageContent"
-                        }
-                    ]
-                },
-                "role": {
-                    "$ref": "#/definitions/Role"
-                }
-            },
-            "required": [
-                "content",
-                "role"
-            ],
-            "type": "object"
-        },
-        "ServerCapabilities": {
-            "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
-            "properties": {
-                "experimental": {
-                    "additionalProperties": {
-                        "additionalProperties": true,
-                        "properties": {},
-                        "type": "object"
-                    },
-                    "description": "Experimental, non-standard capabilities that the server supports.",
-                    "type": "object"
-                },
-                "logging": {
-                    "additionalProperties": true,
-                    "description": "Present if the server supports sending log messages to the client.",
-                    "properties": {},
-                    "type": "object"
-                },
-                "prompts": {
-                    "description": "Present if the server offers any prompt templates.",
-                    "properties": {
-                        "listChanged": {
-                            "description": "Whether this server supports notifications for changes to the prompt list.",
-                            "type": "boolean"
-                        }
-                    },
-                    "type": "object"
-                },
-                "resources": {
-                    "description": "Present if the server offers any resources to read.",
-                    "properties": {
-                        "listChanged": {
-                            "description": "Whether this server supports notifications for changes to the resource list.",
-                            "type": "boolean"
-                        },
-                        "subscribe": {
-                            "description": "Whether this server supports subscribing to resource updates.",
-                            "type": "boolean"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": {
-                    "description": "Present if the server offers any tools to call.",
-                    "properties": {
-                        "listChanged": {
-                            "description": "Whether this server supports notifications for changes to the tool list.",
-                            "type": "boolean"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "ServerNotification": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/CancelledNotification"
-                },
-                {
-                    "$ref": "#/definitions/ProgressNotification"
-                },
-                {
-                    "$ref": "#/definitions/ResourceListChangedNotification"
-                },
-                {
-                    "$ref": "#/definitions/ResourceUpdatedNotification"
-                },
-                {
-                    "$ref": "#/definitions/PromptListChangedNotification"
-                },
-                {
-                    "$ref": "#/definitions/ToolListChangedNotification"
-                },
-                {
-                    "$ref": "#/definitions/LoggingMessageNotification"
-                }
-            ]
-        },
-        "ServerRequest": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/PingRequest"
-                },
-                {
-                    "$ref": "#/definitions/CreateMessageRequest"
-                },
-                {
-                    "$ref": "#/definitions/ListRootsRequest"
-                }
-            ]
-        },
-        "ServerResult": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/Result"
-                },
-                {
-                    "$ref": "#/definitions/InitializeResult"
-                },
-                {
-                    "$ref": "#/definitions/ListResourcesResult"
-                },
-                {
-                    "$ref": "#/definitions/ListResourceTemplatesResult"
-                },
-                {
-                    "$ref": "#/definitions/ReadResourceResult"
-                },
-                {
-                    "$ref": "#/definitions/ListPromptsResult"
-                },
-                {
-                    "$ref": "#/definitions/GetPromptResult"
-                },
-                {
-                    "$ref": "#/definitions/ListToolsResult"
-                },
-                {
-                    "$ref": "#/definitions/CallToolResult"
-                },
-                {
-                    "$ref": "#/definitions/CompleteResult"
-                }
-            ]
-        },
-        "SetLevelRequest": {
-            "description": "A request from the client to the server, to enable or adjust logging.",
-            "properties": {
-                "method": {
-                    "const": "logging/setLevel",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "level": {
-                            "$ref": "#/definitions/LoggingLevel",
-                            "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message."
-                        }
-                    },
-                    "required": [
-                        "level"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "SubscribeRequest": {
-            "description": "Sent from the client to request resources/updated notifications from the server whenever a particular resource changes.",
-            "properties": {
-                "method": {
-                    "const": "resources/subscribe",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "uri": {
-                            "description": "The URI of the resource to subscribe to. The URI can use any protocol; it is up to the server how to interpret it.",
-                            "format": "uri",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "uri"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "TextContent": {
-            "description": "Text provided to or from an LLM.",
-            "properties": {
-                "annotations": {
-                    "properties": {
-                        "audience": {
-                            "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
-                            "items": {
-                                "$ref": "#/definitions/Role"
-                            },
-                            "type": "array"
-                        },
-                        "priority": {
-                            "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
-                            "maximum": 1,
-                            "minimum": 0,
-                            "type": "number"
-                        }
-                    },
-                    "type": "object"
-                },
-                "text": {
-                    "description": "The text content of the message.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "text",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "text",
-                "type"
-            ],
-            "type": "object"
-        },
-        "TextResourceContents": {
-            "properties": {
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "text": {
-                    "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "text",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "Tool": {
-            "description": "Definition for a tool the client can call.",
-            "properties": {
-                "description": {
-                    "description": "A human-readable description of the tool.",
-                    "type": "string"
-                },
-                "inputSchema": {
-                    "description": "A JSON Schema object defining the expected parameters for the tool.",
-                    "properties": {
-                        "properties": {
-                            "additionalProperties": {
-                                "additionalProperties": true,
-                                "properties": {},
-                                "type": "object"
-                            },
-                            "type": "object"
-                        },
-                        "required": {
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "type": {
-                            "const": "object",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "type"
-                    ],
-                    "type": "object"
-                },
-                "name": {
-                    "description": "The name of the tool.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "inputSchema",
-                "name"
-            ],
-            "type": "object"
-        },
-        "ToolListChangedNotification": {
-            "description": "An optional notification from the server to the client, informing it that the list of tools it offers has changed. This may be issued by servers without any previous subscription from the client.",
-            "properties": {
-                "method": {
-                    "const": "notifications/tools/list_changed",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "UnsubscribeRequest": {
-            "description": "Sent from the client to request cancellation of resources/updated notifications from the server. This should follow a previous resources/subscribe request.",
-            "properties": {
-                "method": {
-                    "const": "resources/unsubscribe",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "uri": {
-                            "description": "The URI of the resource to unsubscribe from.",
-                            "format": "uri",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "uri"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
         }
     }
 }
-

--- a/schema/2025-03-26/schema.json
+++ b/schema/2025-03-26/schema.json
@@ -1,114 +1,1217 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
-        "Annotations": {
-            "description": "Optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
-            "properties": {
-                "audience": {
-                    "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
-                    "items": {
-                        "$ref": "#/definitions/Role"
-                    },
-                    "type": "array"
+        "JSONRPCMessage": {
+            "description": "Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent.",
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/JSONRPCRequest"
                 },
-                "priority": {
-                    "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
+                {
+                    "$ref": "#/definitions/JSONRPCNotification"
+                },
+                {
+                    "description": "A JSON-RPC batch request, as described in https://www.jsonrpc.org/specification#batch.",
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/JSONRPCRequest"
+                            },
+                            {
+                                "$ref": "#/definitions/JSONRPCNotification"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "$ref": "#/definitions/JSONRPCResponse"
+                },
+                {
+                    "$ref": "#/definitions/JSONRPCError"
+                },
+                {
+                    "description": "A JSON-RPC batch response, as described in https://www.jsonrpc.org/specification#batch.",
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/JSONRPCResponse"
+                            },
+                            {
+                                "$ref": "#/definitions/JSONRPCError"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "JSONRPCBatchRequest": {
+            "description": "A JSON-RPC batch request, as described in https://www.jsonrpc.org/specification#batch.",
+            "type": "array",
+            "items": {
+                "anyOf": [
+                    {
+                        "$ref": "#/definitions/JSONRPCRequest"
+                    },
+                    {
+                        "$ref": "#/definitions/JSONRPCNotification"
+                    }
+                ]
+            }
+        },
+        "JSONRPCBatchResponse": {
+            "description": "A JSON-RPC batch response, as described in https://www.jsonrpc.org/specification#batch.",
+            "type": "array",
+            "items": {
+                "anyOf": [
+                    {
+                        "$ref": "#/definitions/JSONRPCResponse"
+                    },
+                    {
+                        "$ref": "#/definitions/JSONRPCError"
+                    }
+                ]
+            }
+        },
+        "ProgressToken": {
+            "description": "A progress token, used to associate progress notifications with the original request.",
+            "type": [
+                "string",
+                "integer"
+            ]
+        },
+        "Cursor": {
+            "description": "An opaque token used to represent a cursor for pagination.",
+            "type": "string"
+        },
+        "Notification": {
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "required": [
+                "method"
+            ]
         },
-        "AudioContent": {
-            "description": "Audio provided to or from an LLM.",
+        "Result": {
+            "type": "object",
+            "additionalProperties": {},
             "properties": {
-                "annotations": {
-                    "$ref": "#/definitions/Annotations",
-                    "description": "Optional annotations for the client."
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            }
+        },
+        "RequestId": {
+            "description": "A uniquely identifying ID for a request in JSON-RPC.",
+            "type": [
+                "string",
+                "integer"
+            ]
+        },
+        "JSONRPCRequest": {
+            "description": "A request that expects a response.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
                 },
-                "data": {
-                    "description": "The base64-encoded audio data.",
-                    "format": "byte",
+                "id": {
+                    "$ref": "#/definitions/RequestId"
+                },
+                "method": {
                     "type": "string"
                 },
-                "mimeType": {
-                    "description": "The MIME type of the audio. Different providers may support different audio types.",
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "type": "object",
+                            "properties": {
+                                "progressToken": {
+                                    "$ref": "#/definitions/ProgressToken",
+                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "JSONRPCNotification": {
+            "description": "A notification which does not expect a response.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "method": {
                     "type": "string"
                 },
-                "type": {
-                    "const": "audio",
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "JSONRPCResponse": {
+            "description": "A successful (non-error) response to a request.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/definitions/RequestId"
+                },
+                "result": {
+                    "$ref": "#/definitions/Result"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ]
+        },
+        "JSONRPCError": {
+            "description": "A response to a request that indicates an error occurred.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/definitions/RequestId"
+                },
+                "error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "description": "The error type that occurred.",
+                            "type": "integer"
+                        },
+                        "message": {
+                            "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+                            "type": "string"
+                        },
+                        "data": {
+                            "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+                        }
+                    },
+                    "required": [
+                        "code",
+                        "message"
+                    ]
+                }
+            },
+            "required": [
+                "error",
+                "id",
+                "jsonrpc"
+            ]
+        },
+        "EmptyResult": {
+            "$ref": "#/definitions/Result"
+        },
+        "CancelledNotification": {
+            "description": "This notification can be sent by either side to indicate that it is cancelling a previously-issued request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.\n\nA client MUST NOT attempt to cancel its `initialize` request.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/cancelled"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "requestId": {
+                            "$ref": "#/definitions/RequestId",
+                            "description": "The ID of the request to cancel.\n\nThis MUST correspond to the ID of a request previously issued in the same direction."
+                        },
+                        "reason": {
+                            "description": "An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "requestId"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "InitializeRequest": {
+            "description": "This request is sent from the client to the server when it first connects, asking it to begin initialization.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "initialize"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "protocolVersion": {
+                            "description": "The latest version of the Model Context Protocol that the client supports. The client MAY decide to support older versions as well.",
+                            "type": "string"
+                        },
+                        "capabilities": {
+                            "$ref": "#/definitions/ClientCapabilities"
+                        },
+                        "clientInfo": {
+                            "$ref": "#/definitions/Implementation"
+                        }
+                    },
+                    "required": [
+                        "capabilities",
+                        "clientInfo",
+                        "protocolVersion"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "InitializeResult": {
+            "description": "After receiving an initialize request from the client, the server sends this response.",
+            "type": "object",
+            "properties": {
+                "protocolVersion": {
+                    "description": "The version of the Model Context Protocol that the server wants to use. This may not match the version that the client requested. If the client cannot support this version, it MUST disconnect.",
+                    "type": "string"
+                },
+                "capabilities": {
+                    "$ref": "#/definitions/ServerCapabilities"
+                },
+                "serverInfo": {
+                    "$ref": "#/definitions/Implementation"
+                },
+                "instructions": {
+                    "description": "Instructions describing how to use the server and its features.\n\nThis can be used by clients to improve the LLM's understanding of available tools, resources, etc. It can be thought of like a \"hint\" to the model. For example, this information MAY be added to the system prompt.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "capabilities",
+                "protocolVersion",
+                "serverInfo"
+            ]
+        },
+        "InitializedNotification": {
+            "description": "This notification is sent from the client to the server after initialization has finished.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/initialized"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ClientCapabilities": {
+            "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
+            "type": "object",
+            "properties": {
+                "experimental": {
+                    "description": "Experimental, non-standard capabilities that the client supports.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": true
+                    }
+                },
+                "roots": {
+                    "description": "Present if the client supports listing roots.",
+                    "type": "object",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether the client supports notifications for changes to the roots list.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "sampling": {
+                    "description": "Present if the client supports sampling from an LLM.",
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true
+                }
+            }
+        },
+        "ServerCapabilities": {
+            "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
+            "type": "object",
+            "properties": {
+                "experimental": {
+                    "description": "Experimental, non-standard capabilities that the server supports.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": true
+                    }
+                },
+                "logging": {
+                    "description": "Present if the server supports sending log messages to the client.",
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true
+                },
+                "completions": {
+                    "description": "Present if the server supports argument autocompletion suggestions.",
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true
+                },
+                "prompts": {
+                    "description": "Present if the server offers any prompt templates.",
+                    "type": "object",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the prompt list.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "resources": {
+                    "description": "Present if the server offers any resources to read.",
+                    "type": "object",
+                    "properties": {
+                        "subscribe": {
+                            "description": "Whether this server supports subscribing to resource updates.",
+                            "type": "boolean"
+                        },
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the resource list.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "tools": {
+                    "description": "Present if the server offers any tools to call.",
+                    "type": "object",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the tool list.",
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
+        "Implementation": {
+            "description": "Describes the name and version of an MCP implementation.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "version": {
                     "type": "string"
                 }
             },
             "required": [
-                "data",
-                "mimeType",
-                "type"
-            ],
-            "type": "object"
+                "name",
+                "version"
+            ]
         },
-        "BlobResourceContents": {
+        "PingRequest": {
+            "description": "A ping, issued by either the server or the client, to check that the other party is still alive. The receiver must promptly respond, or else may be disconnected.",
+            "type": "object",
             "properties": {
-                "blob": {
-                    "description": "A base64-encoded string representing the binary data of the item.",
-                    "format": "byte",
+                "method": {
+                    "type": "string",
+                    "const": "ping"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "type": "object",
+                            "properties": {
+                                "progressToken": {
+                                    "$ref": "#/definitions/ProgressToken",
+                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ProgressNotification": {
+            "description": "An out-of-band notification used to inform the receiver of a progress update for a long-running request.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/progress"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/definitions/ProgressToken",
+                            "description": "The progress token which was given in the initial request, used to associate this notification with the request that is proceeding."
+                        },
+                        "progress": {
+                            "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
+                            "type": "number"
+                        },
+                        "total": {
+                            "description": "Total number of items to process (or total progress required), if known.",
+                            "type": "number"
+                        },
+                        "message": {
+                            "description": "An optional message describing the current progress.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "progress",
+                        "progressToken"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "PaginatedRequest": {
+            "type": "object",
+            "properties": {
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "cursor": {
+                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "method": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "PaginatedResult": {
+            "type": "object",
+            "properties": {
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            }
+        },
+        "ListResourcesRequest": {
+            "description": "Sent from the client to request a list of resources the server has.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/list"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "cursor": {
+                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ListResourcesResult": {
+            "description": "The server's response to a resources/list request from the client.",
+            "type": "object",
+            "properties": {
+                "resources": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Resource"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "resources"
+            ]
+        },
+        "ListResourceTemplatesRequest": {
+            "description": "Sent from the client to request a list of resource templates the server has.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/templates/list"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "cursor": {
+                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ListResourceTemplatesResult": {
+            "description": "The server's response to a resources/templates/list request from the client.",
+            "type": "object",
+            "properties": {
+                "resourceTemplates": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ResourceTemplate"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "resourceTemplates"
+            ]
+        },
+        "ReadResourceRequest": {
+            "description": "Sent from the client to the server, to read a specific resource URI.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/read"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "uri": {
+                            "description": "The URI of the resource to read. The URI can use any protocol; it is up to the server how to interpret it.",
+                            "format": "uri",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "uri"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "ReadResourceResult": {
+            "description": "The server's response to a resources/read request from the client.",
+            "type": "object",
+            "properties": {
+                "contents": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/TextResourceContents"
+                            },
+                            {
+                                "$ref": "#/definitions/BlobResourceContents"
+                            }
+                        ]
+                    }
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "contents"
+            ]
+        },
+        "ResourceListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This may be issued by servers without any previous subscription from the client.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/resources/list_changed"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "SubscribeRequest": {
+            "description": "Sent from the client to request resources/updated notifications from the server whenever a particular resource changes.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/subscribe"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "uri": {
+                            "description": "The URI of the resource to subscribe to. The URI can use any protocol; it is up to the server how to interpret it.",
+                            "format": "uri",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "uri"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "UnsubscribeRequest": {
+            "description": "Sent from the client to request cancellation of resources/updated notifications from the server. This should follow a previous resources/subscribe request.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/unsubscribe"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "uri": {
+                            "description": "The URI of the resource to unsubscribe from.",
+                            "format": "uri",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "uri"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "ResourceUpdatedNotification": {
+            "description": "A notification from the server to the client, informing it that a resource has changed and may need to be read again. This should only be sent if the client previously sent a resources/subscribe request.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/resources/updated"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "uri": {
+                            "description": "The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.",
+                            "format": "uri",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "uri"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "ResourceTemplate": {
+            "description": "A template description for resources available on the server.",
+            "type": "object",
+            "properties": {
+                "uriTemplate": {
+                    "description": "A URI template (according to RFC 6570) that can be used to construct resource URIs.",
+                    "format": "uri-template",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "A human-readable name for the type of resource this template refers to.\n\nThis can be used by clients to populate UI elements.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
+                }
+            },
+            "required": [
+                "name",
+                "uriTemplate"
+            ]
+        },
+        "ResourceContents": {
+            "description": "The contents of a specific resource or sub-resource.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "mimeType": {
                     "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "uri"
+            ]
+        },
+        "TextResourceContents": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
                     "type": "string"
                 },
                 "uri": {
                     "description": "The URI of this resource.",
                     "format": "uri",
                     "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "text",
+                "uri"
+            ]
+        },
+        "BlobResourceContents": {
+            "type": "object",
+            "properties": {
+                "blob": {
+                    "description": "A base64-encoded string representing the binary data of the item.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
                 }
             },
             "required": [
                 "blob",
                 "uri"
-            ],
-            "type": "object"
+            ]
         },
-        "CallToolRequest": {
-            "description": "Used by the client to invoke a tool provided by the server.",
+        "ListPromptsRequest": {
+            "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
+            "type": "object",
             "properties": {
                 "method": {
-                    "const": "tools/call",
-                    "type": "string"
+                    "type": "string",
+                    "const": "prompts/list"
                 },
                 "params": {
+                    "type": "object",
                     "properties": {
-                        "arguments": {
-                            "additionalProperties": {},
-                            "type": "object"
-                        },
-                        "name": {
+                        "cursor": {
+                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
                             "type": "string"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ListPromptsResult": {
+            "description": "The server's response to a prompts/list request from the client.",
+            "type": "object",
+            "properties": {
+                "prompts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Prompt"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "prompts"
+            ]
+        },
+        "GetPromptRequest": {
+            "description": "Used by the client to get a prompt provided by the server.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "prompts/get"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "description": "The name of the prompt or prompt template.",
+                            "type": "string"
+                        },
+                        "arguments": {
+                            "description": "Arguments to use for templating the prompt.",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "required": [
                         "name"
-                    ],
-                    "type": "object"
+                    ]
                 }
             },
             "required": [
                 "method",
                 "params"
+            ]
+        },
+        "GetPromptResult": {
+            "description": "The server's response to a prompts/get request from the client.",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "An optional description for the prompt.",
+                    "type": "string"
+                },
+                "messages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/PromptMessage"
+                    }
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "messages"
+            ]
+        },
+        "Prompt": {
+            "description": "A prompt or prompt template that the server offers.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The name of the prompt or prompt template.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "An optional description of what this prompt provides",
+                    "type": "string"
+                },
+                "arguments": {
+                    "description": "A list of arguments to use for templating the prompt.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/PromptArgument"
+                    }
+                }
+            },
+            "required": [
+                "name"
+            ]
+        },
+        "PromptArgument": {
+            "description": "Describes an argument that a prompt can accept.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The name of the argument.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A human-readable description of the argument.",
+                    "type": "string"
+                },
+                "required": {
+                    "description": "Whether this argument must be provided.",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "name"
+            ]
+        },
+        "Role": {
+            "description": "The sender or recipient of messages and data in a conversation.",
+            "enum": [
+                "assistant",
+                "user"
             ],
-            "type": "object"
+            "type": "string"
+        },
+        "PromptMessage": {
+            "description": "Describes a message returned as part of a prompt.\n\nThis is similar to `SamplingMessage`, but also supports the embedding of\nresources from the MCP server.",
+            "type": "object",
+            "properties": {
+                "role": {
+                    "$ref": "#/definitions/Role"
+                },
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TextContent"
+                        },
+                        {
+                            "$ref": "#/definitions/ImageContent"
+                        },
+                        {
+                            "$ref": "#/definitions/AudioContent"
+                        },
+                        {
+                            "$ref": "#/definitions/EmbeddedResource"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "content",
+                "role"
+            ]
+        },
+        "EmbeddedResource": {
+            "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "resource"
+                },
+                "resource": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TextResourceContents"
+                        },
+                        {
+                            "$ref": "#/definitions/BlobResourceContents"
+                        }
+                    ]
+                },
+                "annotations": {
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
+                }
+            },
+            "required": [
+                "resource",
+                "type"
+            ]
+        },
+        "PromptListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/prompts/list_changed"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ListToolsRequest": {
+            "description": "Sent from the client to request a list of tools the server has.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "tools/list"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "cursor": {
+                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ListToolsResult": {
+            "description": "The server's response to a tools/list request from the client.",
+            "type": "object",
+            "properties": {
+                "tools": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Tool"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "tools"
+            ]
         },
         "CallToolResult": {
             "description": "The server's response to a tool call.\n\nAny errors that originate from the tool SHOULD be reported inside the result\nobject, with `isError` set to true, _not_ as an MCP protocol-level error\nresponse. Otherwise, the LLM would not be able to see that an error occurred\nand self-correct.\n\nHowever, any errors in _finding_ the tool, an error indicating that the\nserver does not support tool calls, or any other exceptional conditions,\nshould be reported as an MCP error response.",
+            "type": "object",
             "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
                 "content": {
+                    "type": "array",
                     "items": {
                         "anyOf": [
                             {
@@ -124,79 +1227,689 @@
                                 "$ref": "#/definitions/EmbeddedResource"
                             }
                         ]
-                    },
-                    "type": "array"
+                    }
                 },
                 "isError": {
                     "description": "Whether the tool call ended in an error.\n\nIf not set, this is assumed to be false (the call was successful).",
                     "type": "boolean"
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
                 }
             },
             "required": [
                 "content"
-            ],
-            "type": "object"
+            ]
         },
-        "CancelledNotification": {
-            "description": "This notification can be sent by either side to indicate that it is cancelling a previously-issued request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.\n\nA client MUST NOT attempt to cancel its `initialize` request.",
+        "CallToolRequest": {
+            "description": "Used by the client to invoke a tool provided by the server.",
+            "type": "object",
             "properties": {
                 "method": {
-                    "const": "notifications/cancelled",
-                    "type": "string"
+                    "type": "string",
+                    "const": "tools/call"
                 },
                 "params": {
+                    "type": "object",
                     "properties": {
-                        "reason": {
-                            "description": "An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.",
+                        "name": {
                             "type": "string"
                         },
-                        "requestId": {
-                            "$ref": "#/definitions/RequestId",
-                            "description": "The ID of the request to cancel.\n\nThis MUST correspond to the ID of a request previously issued in the same direction."
+                        "arguments": {
+                            "type": "object",
+                            "additionalProperties": {}
                         }
                     },
                     "required": [
-                        "requestId"
-                    ],
-                    "type": "object"
+                        "name"
+                    ]
                 }
             },
             "required": [
                 "method",
                 "params"
-            ],
-            "type": "object"
+            ]
         },
-        "ClientCapabilities": {
-            "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
+        "ToolListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of tools it offers has changed. This may be issued by servers without any previous subscription from the client.",
+            "type": "object",
             "properties": {
-                "experimental": {
-                    "additionalProperties": {
-                        "additionalProperties": true,
-                        "properties": {},
-                        "type": "object"
-                    },
-                    "description": "Experimental, non-standard capabilities that the client supports.",
-                    "type": "object"
+                "method": {
+                    "type": "string",
+                    "const": "notifications/tools/list_changed"
                 },
-                "roots": {
-                    "description": "Present if the client supports listing roots.",
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
                     "properties": {
-                        "listChanged": {
-                            "description": "Whether the client supports notifications for changes to the roots list.",
+                        "_meta": {
+                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ToolAnnotations": {
+            "description": "Additional properties describing a Tool to clients.\n\nNOTE: all properties in ToolAnnotations are **hints**.\nThey are not guaranteed to provide a faithful description of\ntool behavior (including descriptive properties like `title`).\n\nClients should never make tool use decisions based on ToolAnnotations\nreceived from untrusted servers.",
+            "type": "object",
+            "properties": {
+                "title": {
+                    "description": "A human-readable title for the tool.",
+                    "type": "string"
+                },
+                "readOnlyHint": {
+                    "description": "If true, the tool does not modify its environment.\n\nDefault: false",
+                    "type": "boolean"
+                },
+                "destructiveHint": {
+                    "description": "If true, the tool may perform destructive updates to its environment.\nIf false, the tool performs only additive updates.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: true",
+                    "type": "boolean"
+                },
+                "idempotentHint": {
+                    "description": "If true, calling the tool repeatedly with the same arguments\nwill have no additional effect on the its environment.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: false",
+                    "type": "boolean"
+                },
+                "openWorldHint": {
+                    "description": "If true, this tool may interact with an \"open world\" of external\nentities. If false, the tool's domain of interaction is closed.\nFor example, the world of a web search tool is open, whereas that\nof a memory tool is not.\n\nDefault: true",
+                    "type": "boolean"
+                }
+            }
+        },
+        "Tool": {
+            "description": "Definition for a tool the client can call.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The name of the tool.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "inputSchema": {
+                    "description": "A JSON Schema object defining the expected parameters for the tool.",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "object"
+                        },
+                        "properties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": true
+                            }
+                        },
+                        "required": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ]
+                },
+                "annotations": {
+                    "$ref": "#/definitions/ToolAnnotations",
+                    "description": "Optional additional tool information."
+                }
+            },
+            "required": [
+                "inputSchema",
+                "name"
+            ]
+        },
+        "SetLevelRequest": {
+            "description": "A request from the client to the server, to enable or adjust logging.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "logging/setLevel"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "level": {
+                            "$ref": "#/definitions/LoggingLevel",
+                            "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message."
+                        }
+                    },
+                    "required": [
+                        "level"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "LoggingMessageNotification": {
+            "description": "Notification of a log message passed from server to client. If no logging/setLevel request has been sent from the client, the server MAY decide which messages to send automatically.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/message"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "level": {
+                            "$ref": "#/definitions/LoggingLevel",
+                            "description": "The severity of this log message."
+                        },
+                        "logger": {
+                            "description": "An optional name of the logger issuing this message.",
+                            "type": "string"
+                        },
+                        "data": {
+                            "description": "The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here."
+                        }
+                    },
+                    "required": [
+                        "data",
+                        "level"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "LoggingLevel": {
+            "description": "The severity of a log message.\n\nThese map to syslog message severities, as specified in RFC-5424:\nhttps://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1",
+            "enum": [
+                "alert",
+                "critical",
+                "debug",
+                "emergency",
+                "error",
+                "info",
+                "notice",
+                "warning"
+            ],
+            "type": "string"
+        },
+        "CreateMessageRequest": {
+            "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "sampling/createMessage"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SamplingMessage"
+                            }
+                        },
+                        "modelPreferences": {
+                            "$ref": "#/definitions/ModelPreferences",
+                            "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
+                        },
+                        "systemPrompt": {
+                            "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
+                            "type": "string"
+                        },
+                        "includeContext": {
+                            "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt. The client MAY ignore this request.",
+                            "enum": [
+                                "allServers",
+                                "none",
+                                "thisServer"
+                            ],
+                            "type": "string"
+                        },
+                        "temperature": {
+                            "type": "number"
+                        },
+                        "maxTokens": {
+                            "description": "The maximum number of tokens to sample, as requested by the server. The client MAY choose to sample fewer tokens than requested.",
+                            "type": "integer"
+                        },
+                        "stopSequences": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "metadata": {
+                            "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific.",
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": true
+                        }
+                    },
+                    "required": [
+                        "maxTokens",
+                        "messages"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "CreateMessageResult": {
+            "description": "The client's response to a sampling/create_message request from the server. The client should inform the user before returning the sampled message, to allow them to inspect the response (human in the loop) and decide whether to allow the server to see it.",
+            "type": "object",
+            "properties": {
+                "model": {
+                    "description": "The name of the model that generated the message.",
+                    "type": "string"
+                },
+                "stopReason": {
+                    "description": "The reason why sampling stopped, if known.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "role": {
+                    "$ref": "#/definitions/Role"
+                },
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TextContent"
+                        },
+                        {
+                            "$ref": "#/definitions/ImageContent"
+                        },
+                        {
+                            "$ref": "#/definitions/AudioContent"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "content",
+                "model",
+                "role"
+            ]
+        },
+        "SamplingMessage": {
+            "description": "Describes a message issued to or received from an LLM API.",
+            "type": "object",
+            "properties": {
+                "role": {
+                    "$ref": "#/definitions/Role"
+                },
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TextContent"
+                        },
+                        {
+                            "$ref": "#/definitions/ImageContent"
+                        },
+                        {
+                            "$ref": "#/definitions/AudioContent"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "content",
+                "role"
+            ]
+        },
+        "Annotations": {
+            "description": "Optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
+            "type": "object",
+            "properties": {
+                "audience": {
+                    "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Role"
+                    }
+                },
+                "priority": {
+                    "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                }
+            }
+        },
+        "TextContent": {
+            "description": "Text provided to or from an LLM.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "text"
+                },
+                "text": {
+                    "description": "The text content of the message.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
+                }
+            },
+            "required": [
+                "text",
+                "type"
+            ]
+        },
+        "ImageContent": {
+            "description": "An image provided to or from an LLM.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "image"
+                },
+                "data": {
+                    "description": "The base64-encoded image data.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of the image. Different providers may support different image types.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
+                }
+            },
+            "required": [
+                "data",
+                "mimeType",
+                "type"
+            ]
+        },
+        "AudioContent": {
+            "description": "Audio provided to or from an LLM.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "audio"
+                },
+                "data": {
+                    "description": "The base64-encoded audio data.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of the audio. Different providers may support different audio types.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
+                }
+            },
+            "required": [
+                "data",
+                "mimeType",
+                "type"
+            ]
+        },
+        "ModelPreferences": {
+            "description": "The server's preferences for model selection, requested of the client during sampling.\n\nBecause LLMs can vary along multiple dimensions, choosing the \"best\" model is\nrarely straightforward.  Different models excel in different areas—some are\nfaster but less capable, others are more capable but more expensive, and so\non. This interface allows servers to express their priorities across multiple\ndimensions to help clients make an appropriate selection for their use case.\n\nThese preferences are always advisory. The client MAY ignore them. It is also\nup to the client to decide how to interpret these preferences and how to\nbalance them against other considerations.",
+            "type": "object",
+            "properties": {
+                "hints": {
+                    "description": "Optional hints to use for model selection.\n\nIf multiple hints are specified, the client MUST evaluate them in order\n(such that the first match is taken).\n\nThe client SHOULD prioritize these hints over the numeric priorities, but\nMAY still use the priorities to select from ambiguous matches.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ModelHint"
+                    }
+                },
+                "costPriority": {
+                    "description": "How much to prioritize cost when selecting a model. A value of 0 means cost\nis not important, while a value of 1 means cost is the most important\nfactor.",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "speedPriority": {
+                    "description": "How much to prioritize sampling speed (latency) when selecting a model. A\nvalue of 0 means speed is not important, while a value of 1 means speed is\nthe most important factor.",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "intelligencePriority": {
+                    "description": "How much to prioritize intelligence and capabilities when selecting a\nmodel. A value of 0 means intelligence is not important, while a value of 1\nmeans intelligence is the most important factor.",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                }
+            }
+        },
+        "ModelHint": {
+            "description": "Hints to use for model selection.\n\nKeys not declared here are currently left unspecified by the spec and are up\nto the client to interpret.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "A hint for a model name.\n\nThe client SHOULD treat this as a substring of a model name; for example:\n - `claude-3-5-sonnet` should match `claude-3-5-sonnet-20241022`\n - `sonnet` should match `claude-3-5-sonnet-20241022`, `claude-3-sonnet-20240229`, etc.\n - `claude` should match any Claude model\n\nThe client MAY also map the string to a different provider's model name or a different model family, as long as it fills a similar niche; for example:\n - `gemini-1.5-flash` could match `claude-3-haiku-20240307`",
+                    "type": "string"
+                }
+            }
+        },
+        "CompleteRequest": {
+            "description": "A request from the client to the server, to ask for completion options.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "completion/complete"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "ref": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/definitions/PromptReference"
+                                },
+                                {
+                                    "$ref": "#/definitions/ResourceReference"
+                                }
+                            ]
+                        },
+                        "argument": {
+                            "description": "The argument's information",
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "description": "The name of the argument",
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "description": "The value of the argument to use for completion matching.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "argument",
+                        "ref"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "CompleteResult": {
+            "description": "The server's response to a completion/complete request",
+            "type": "object",
+            "properties": {
+                "completion": {
+                    "type": "object",
+                    "properties": {
+                        "values": {
+                            "description": "An array of completion values. Must not exceed 100 items.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "total": {
+                            "description": "The total number of completion options available. This can exceed the number of values actually sent in the response.",
+                            "type": "integer"
+                        },
+                        "hasMore": {
+                            "description": "Indicates whether there are additional completion options beyond those provided in the current response, even if the exact total is unknown.",
                             "type": "boolean"
                         }
                     },
-                    "type": "object"
+                    "required": [
+                        "values"
+                    ]
                 },
-                "sampling": {
-                    "additionalProperties": true,
-                    "description": "Present if the client supports sampling from an LLM.",
-                    "properties": {},
-                    "type": "object"
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
                 }
             },
-            "type": "object"
+            "required": [
+                "completion"
+            ]
+        },
+        "ResourceReference": {
+            "description": "A reference to a resource or resource template definition.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "ref/resource"
+                },
+                "uri": {
+                    "description": "The URI or URI template of the resource.",
+                    "format": "uri-template",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type",
+                "uri"
+            ]
+        },
+        "PromptReference": {
+            "description": "Identifies a prompt.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "ref/prompt"
+                },
+                "name": {
+                    "description": "The name of the prompt or prompt template",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "type"
+            ]
+        },
+        "ListRootsRequest": {
+            "description": "Sent from the server to request a list of root URIs from the client. Roots allow\nservers to ask for specific directories or files to operate on. A common example\nfor roots is providing a set of repositories or directories a server should operate\non.\n\nThis request is typically used when the server needs to understand the file system\nstructure or access specific locations that the client has permission to read from.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "roots/list"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "type": "object",
+                            "properties": {
+                                "progressToken": {
+                                    "$ref": "#/definitions/ProgressToken",
+                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ListRootsResult": {
+            "description": "The client's response to a roots/list request from the server.\nThis result contains an array of Root objects, each representing a root directory\nor file that the server can operate on.",
+            "type": "object",
+            "properties": {
+                "roots": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Root"
+                    }
+                },
+                "_meta": {
+                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "roots"
+            ]
+        },
+        "RootsListChangedNotification": {
+            "description": "A notification from the client to the server, informing it that the list of roots has changed.\nThis notification should be sent whenever the client adds, removes, or modifies any root.\nThe server should then request an updated list of roots using the ListRootsRequest.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/roots/list_changed"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
         },
         "ClientNotification": {
             "anyOf": [
@@ -212,6 +1925,170 @@
                 {
                     "$ref": "#/definitions/RootsListChangedNotification"
                 }
+            ]
+        },
+        "ClientResult": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/Result"
+                },
+                {
+                    "$ref": "#/definitions/CreateMessageResult"
+                },
+                {
+                    "$ref": "#/definitions/ListRootsResult"
+                }
+            ]
+        },
+        "ServerRequest": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/PingRequest"
+                },
+                {
+                    "$ref": "#/definitions/CreateMessageRequest"
+                },
+                {
+                    "$ref": "#/definitions/ListRootsRequest"
+                }
+            ]
+        },
+        "ServerNotification": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/CancelledNotification"
+                },
+                {
+                    "$ref": "#/definitions/ProgressNotification"
+                },
+                {
+                    "$ref": "#/definitions/ResourceListChangedNotification"
+                },
+                {
+                    "$ref": "#/definitions/ResourceUpdatedNotification"
+                },
+                {
+                    "$ref": "#/definitions/PromptListChangedNotification"
+                },
+                {
+                    "$ref": "#/definitions/ToolListChangedNotification"
+                },
+                {
+                    "$ref": "#/definitions/LoggingMessageNotification"
+                }
+            ]
+        },
+        "ServerResult": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/Result"
+                },
+                {
+                    "$ref": "#/definitions/InitializeResult"
+                },
+                {
+                    "$ref": "#/definitions/ListResourcesResult"
+                },
+                {
+                    "$ref": "#/definitions/ListResourceTemplatesResult"
+                },
+                {
+                    "$ref": "#/definitions/ReadResourceResult"
+                },
+                {
+                    "$ref": "#/definitions/ListPromptsResult"
+                },
+                {
+                    "$ref": "#/definitions/GetPromptResult"
+                },
+                {
+                    "$ref": "#/definitions/ListToolsResult"
+                },
+                {
+                    "$ref": "#/definitions/CallToolResult"
+                },
+                {
+                    "$ref": "#/definitions/CompleteResult"
+                }
+            ]
+        },
+        "Request": {
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "type": "object",
+                            "properties": {
+                                "progressToken": {
+                                    "$ref": "#/definitions/ProgressToken",
+                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "Resource": {
+            "description": "A known resource that the server is capable of reading.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "A human-readable name for this resource.\n\nThis can be used by clients to populate UI elements.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "size": {
+                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "name",
+                "uri"
+            ]
+        },
+        "Root": {
+            "description": "Represents a root directory or file that the server can operate on.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI identifying the root. This *must* start with file:// for now.\nThis restriction may be relaxed in future versions of the protocol to allow\nother URI schemes.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "uri"
             ]
         },
         "ClientRequest": {
@@ -256,1884 +2133,6 @@
                     "$ref": "#/definitions/CompleteRequest"
                 }
             ]
-        },
-        "ClientResult": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/Result"
-                },
-                {
-                    "$ref": "#/definitions/CreateMessageResult"
-                },
-                {
-                    "$ref": "#/definitions/ListRootsResult"
-                }
-            ]
-        },
-        "CompleteRequest": {
-            "description": "A request from the client to the server, to ask for completion options.",
-            "properties": {
-                "method": {
-                    "const": "completion/complete",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "argument": {
-                            "description": "The argument's information",
-                            "properties": {
-                                "name": {
-                                    "description": "The name of the argument",
-                                    "type": "string"
-                                },
-                                "value": {
-                                    "description": "The value of the argument to use for completion matching.",
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "name",
-                                "value"
-                            ],
-                            "type": "object"
-                        },
-                        "ref": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/definitions/PromptReference"
-                                },
-                                {
-                                    "$ref": "#/definitions/ResourceReference"
-                                }
-                            ]
-                        }
-                    },
-                    "required": [
-                        "argument",
-                        "ref"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "CompleteResult": {
-            "description": "The server's response to a completion/complete request",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "completion": {
-                    "properties": {
-                        "hasMore": {
-                            "description": "Indicates whether there are additional completion options beyond those provided in the current response, even if the exact total is unknown.",
-                            "type": "boolean"
-                        },
-                        "total": {
-                            "description": "The total number of completion options available. This can exceed the number of values actually sent in the response.",
-                            "type": "integer"
-                        },
-                        "values": {
-                            "description": "An array of completion values. Must not exceed 100 items.",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "required": [
-                        "values"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "completion"
-            ],
-            "type": "object"
-        },
-        "CreateMessageRequest": {
-            "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
-            "properties": {
-                "method": {
-                    "const": "sampling/createMessage",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "includeContext": {
-                            "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt. The client MAY ignore this request.",
-                            "enum": [
-                                "allServers",
-                                "none",
-                                "thisServer"
-                            ],
-                            "type": "string"
-                        },
-                        "maxTokens": {
-                            "description": "The maximum number of tokens to sample, as requested by the server. The client MAY choose to sample fewer tokens than requested.",
-                            "type": "integer"
-                        },
-                        "messages": {
-                            "items": {
-                                "$ref": "#/definitions/SamplingMessage"
-                            },
-                            "type": "array"
-                        },
-                        "metadata": {
-                            "additionalProperties": true,
-                            "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific.",
-                            "properties": {},
-                            "type": "object"
-                        },
-                        "modelPreferences": {
-                            "$ref": "#/definitions/ModelPreferences",
-                            "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
-                        },
-                        "stopSequences": {
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "systemPrompt": {
-                            "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
-                            "type": "string"
-                        },
-                        "temperature": {
-                            "type": "number"
-                        }
-                    },
-                    "required": [
-                        "maxTokens",
-                        "messages"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "CreateMessageResult": {
-            "description": "The client's response to a sampling/create_message request from the server. The client should inform the user before returning the sampled message, to allow them to inspect the response (human in the loop) and decide whether to allow the server to see it.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "content": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/TextContent"
-                        },
-                        {
-                            "$ref": "#/definitions/ImageContent"
-                        },
-                        {
-                            "$ref": "#/definitions/AudioContent"
-                        }
-                    ]
-                },
-                "model": {
-                    "description": "The name of the model that generated the message.",
-                    "type": "string"
-                },
-                "role": {
-                    "$ref": "#/definitions/Role"
-                },
-                "stopReason": {
-                    "description": "The reason why sampling stopped, if known.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "content",
-                "model",
-                "role"
-            ],
-            "type": "object"
-        },
-        "Cursor": {
-            "description": "An opaque token used to represent a cursor for pagination.",
-            "type": "string"
-        },
-        "EmbeddedResource": {
-            "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
-            "properties": {
-                "annotations": {
-                    "$ref": "#/definitions/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "resource": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/TextResourceContents"
-                        },
-                        {
-                            "$ref": "#/definitions/BlobResourceContents"
-                        }
-                    ]
-                },
-                "type": {
-                    "const": "resource",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "resource",
-                "type"
-            ],
-            "type": "object"
-        },
-        "EmptyResult": {
-            "$ref": "#/definitions/Result"
-        },
-        "GetPromptRequest": {
-            "description": "Used by the client to get a prompt provided by the server.",
-            "properties": {
-                "method": {
-                    "const": "prompts/get",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "arguments": {
-                            "additionalProperties": {
-                                "type": "string"
-                            },
-                            "description": "Arguments to use for templating the prompt.",
-                            "type": "object"
-                        },
-                        "name": {
-                            "description": "The name of the prompt or prompt template.",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "name"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "GetPromptResult": {
-            "description": "The server's response to a prompts/get request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "description": {
-                    "description": "An optional description for the prompt.",
-                    "type": "string"
-                },
-                "messages": {
-                    "items": {
-                        "$ref": "#/definitions/PromptMessage"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "messages"
-            ],
-            "type": "object"
-        },
-        "ImageContent": {
-            "description": "An image provided to or from an LLM.",
-            "properties": {
-                "annotations": {
-                    "$ref": "#/definitions/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "data": {
-                    "description": "The base64-encoded image data.",
-                    "format": "byte",
-                    "type": "string"
-                },
-                "mimeType": {
-                    "description": "The MIME type of the image. Different providers may support different image types.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "image",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "data",
-                "mimeType",
-                "type"
-            ],
-            "type": "object"
-        },
-        "Implementation": {
-            "description": "Describes the name and version of an MCP implementation.",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "version"
-            ],
-            "type": "object"
-        },
-        "InitializeRequest": {
-            "description": "This request is sent from the client to the server when it first connects, asking it to begin initialization.",
-            "properties": {
-                "method": {
-                    "const": "initialize",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "capabilities": {
-                            "$ref": "#/definitions/ClientCapabilities"
-                        },
-                        "clientInfo": {
-                            "$ref": "#/definitions/Implementation"
-                        },
-                        "protocolVersion": {
-                            "description": "The latest version of the Model Context Protocol that the client supports. The client MAY decide to support older versions as well.",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "capabilities",
-                        "clientInfo",
-                        "protocolVersion"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "InitializeResult": {
-            "description": "After receiving an initialize request from the client, the server sends this response.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "capabilities": {
-                    "$ref": "#/definitions/ServerCapabilities"
-                },
-                "instructions": {
-                    "description": "Instructions describing how to use the server and its features.\n\nThis can be used by clients to improve the LLM's understanding of available tools, resources, etc. It can be thought of like a \"hint\" to the model. For example, this information MAY be added to the system prompt.",
-                    "type": "string"
-                },
-                "protocolVersion": {
-                    "description": "The version of the Model Context Protocol that the server wants to use. This may not match the version that the client requested. If the client cannot support this version, it MUST disconnect.",
-                    "type": "string"
-                },
-                "serverInfo": {
-                    "$ref": "#/definitions/Implementation"
-                }
-            },
-            "required": [
-                "capabilities",
-                "protocolVersion",
-                "serverInfo"
-            ],
-            "type": "object"
-        },
-        "InitializedNotification": {
-            "description": "This notification is sent from the client to the server after initialization has finished.",
-            "properties": {
-                "method": {
-                    "const": "notifications/initialized",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "JSONRPCBatchRequest": {
-            "description": "A JSON-RPC batch request, as described in https://www.jsonrpc.org/specification#batch.",
-            "items": {
-                "anyOf": [
-                    {
-                        "$ref": "#/definitions/JSONRPCRequest"
-                    },
-                    {
-                        "$ref": "#/definitions/JSONRPCNotification"
-                    }
-                ]
-            },
-            "type": "array"
-        },
-        "JSONRPCBatchResponse": {
-            "description": "A JSON-RPC batch response, as described in https://www.jsonrpc.org/specification#batch.",
-            "items": {
-                "anyOf": [
-                    {
-                        "$ref": "#/definitions/JSONRPCResponse"
-                    },
-                    {
-                        "$ref": "#/definitions/JSONRPCError"
-                    }
-                ]
-            },
-            "type": "array"
-        },
-        "JSONRPCError": {
-            "description": "A response to a request that indicates an error occurred.",
-            "properties": {
-                "error": {
-                    "properties": {
-                        "code": {
-                            "description": "The error type that occurred.",
-                            "type": "integer"
-                        },
-                        "data": {
-                            "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
-                        },
-                        "message": {
-                            "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "code",
-                        "message"
-                    ],
-                    "type": "object"
-                },
-                "id": {
-                    "$ref": "#/definitions/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "error",
-                "id",
-                "jsonrpc"
-            ],
-            "type": "object"
-        },
-        "JSONRPCMessage": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/JSONRPCRequest"
-                },
-                {
-                    "$ref": "#/definitions/JSONRPCNotification"
-                },
-                {
-                    "description": "A JSON-RPC batch request, as described in https://www.jsonrpc.org/specification#batch.",
-                    "items": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/definitions/JSONRPCRequest"
-                            },
-                            {
-                                "$ref": "#/definitions/JSONRPCNotification"
-                            }
-                        ]
-                    },
-                    "type": "array"
-                },
-                {
-                    "$ref": "#/definitions/JSONRPCResponse"
-                },
-                {
-                    "$ref": "#/definitions/JSONRPCError"
-                },
-                {
-                    "description": "A JSON-RPC batch response, as described in https://www.jsonrpc.org/specification#batch.",
-                    "items": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/definitions/JSONRPCResponse"
-                            },
-                            {
-                                "$ref": "#/definitions/JSONRPCError"
-                            }
-                        ]
-                    },
-                    "type": "array"
-                }
-            ],
-            "description": "Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent."
-        },
-        "JSONRPCNotification": {
-            "description": "A notification which does not expect a response.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "JSONRPCRequest": {
-            "description": "A request that expects a response.",
-            "properties": {
-                "id": {
-                    "$ref": "#/definitions/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "properties": {
-                                "progressToken": {
-                                    "$ref": "#/definitions/ProgressToken",
-                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                                }
-                            },
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "JSONRPCResponse": {
-            "description": "A successful (non-error) response to a request.",
-            "properties": {
-                "id": {
-                    "$ref": "#/definitions/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "result": {
-                    "$ref": "#/definitions/Result"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "result"
-            ],
-            "type": "object"
-        },
-        "ListPromptsRequest": {
-            "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
-            "properties": {
-                "method": {
-                    "const": "prompts/list",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "cursor": {
-                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListPromptsResult": {
-            "description": "The server's response to a prompts/list request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "prompts": {
-                    "items": {
-                        "$ref": "#/definitions/Prompt"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "prompts"
-            ],
-            "type": "object"
-        },
-        "ListResourceTemplatesRequest": {
-            "description": "Sent from the client to request a list of resource templates the server has.",
-            "properties": {
-                "method": {
-                    "const": "resources/templates/list",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "cursor": {
-                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListResourceTemplatesResult": {
-            "description": "The server's response to a resources/templates/list request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "resourceTemplates": {
-                    "items": {
-                        "$ref": "#/definitions/ResourceTemplate"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "resourceTemplates"
-            ],
-            "type": "object"
-        },
-        "ListResourcesRequest": {
-            "description": "Sent from the client to request a list of resources the server has.",
-            "properties": {
-                "method": {
-                    "const": "resources/list",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "cursor": {
-                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListResourcesResult": {
-            "description": "The server's response to a resources/list request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "resources": {
-                    "items": {
-                        "$ref": "#/definitions/Resource"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "resources"
-            ],
-            "type": "object"
-        },
-        "ListRootsRequest": {
-            "description": "Sent from the server to request a list of root URIs from the client. Roots allow\nservers to ask for specific directories or files to operate on. A common example\nfor roots is providing a set of repositories or directories a server should operate\non.\n\nThis request is typically used when the server needs to understand the file system\nstructure or access specific locations that the client has permission to read from.",
-            "properties": {
-                "method": {
-                    "const": "roots/list",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "properties": {
-                                "progressToken": {
-                                    "$ref": "#/definitions/ProgressToken",
-                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                                }
-                            },
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListRootsResult": {
-            "description": "The client's response to a roots/list request from the server.\nThis result contains an array of Root objects, each representing a root directory\nor file that the server can operate on.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "roots": {
-                    "items": {
-                        "$ref": "#/definitions/Root"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "roots"
-            ],
-            "type": "object"
-        },
-        "ListToolsRequest": {
-            "description": "Sent from the client to request a list of tools the server has.",
-            "properties": {
-                "method": {
-                    "const": "tools/list",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "cursor": {
-                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListToolsResult": {
-            "description": "The server's response to a tools/list request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "tools": {
-                    "items": {
-                        "$ref": "#/definitions/Tool"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "tools"
-            ],
-            "type": "object"
-        },
-        "LoggingLevel": {
-            "description": "The severity of a log message.\n\nThese map to syslog message severities, as specified in RFC-5424:\nhttps://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1",
-            "enum": [
-                "alert",
-                "critical",
-                "debug",
-                "emergency",
-                "error",
-                "info",
-                "notice",
-                "warning"
-            ],
-            "type": "string"
-        },
-        "LoggingMessageNotification": {
-            "description": "Notification of a log message passed from server to client. If no logging/setLevel request has been sent from the client, the server MAY decide which messages to send automatically.",
-            "properties": {
-                "method": {
-                    "const": "notifications/message",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "data": {
-                            "description": "The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here."
-                        },
-                        "level": {
-                            "$ref": "#/definitions/LoggingLevel",
-                            "description": "The severity of this log message."
-                        },
-                        "logger": {
-                            "description": "An optional name of the logger issuing this message.",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "data",
-                        "level"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ModelHint": {
-            "description": "Hints to use for model selection.\n\nKeys not declared here are currently left unspecified by the spec and are up\nto the client to interpret.",
-            "properties": {
-                "name": {
-                    "description": "A hint for a model name.\n\nThe client SHOULD treat this as a substring of a model name; for example:\n - `claude-3-5-sonnet` should match `claude-3-5-sonnet-20241022`\n - `sonnet` should match `claude-3-5-sonnet-20241022`, `claude-3-sonnet-20240229`, etc.\n - `claude` should match any Claude model\n\nThe client MAY also map the string to a different provider's model name or a different model family, as long as it fills a similar niche; for example:\n - `gemini-1.5-flash` could match `claude-3-haiku-20240307`",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "ModelPreferences": {
-            "description": "The server's preferences for model selection, requested of the client during sampling.\n\nBecause LLMs can vary along multiple dimensions, choosing the \"best\" model is\nrarely straightforward.  Different models excel in different areas—some are\nfaster but less capable, others are more capable but more expensive, and so\non. This interface allows servers to express their priorities across multiple\ndimensions to help clients make an appropriate selection for their use case.\n\nThese preferences are always advisory. The client MAY ignore them. It is also\nup to the client to decide how to interpret these preferences and how to\nbalance them against other considerations.",
-            "properties": {
-                "costPriority": {
-                    "description": "How much to prioritize cost when selecting a model. A value of 0 means cost\nis not important, while a value of 1 means cost is the most important\nfactor.",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "hints": {
-                    "description": "Optional hints to use for model selection.\n\nIf multiple hints are specified, the client MUST evaluate them in order\n(such that the first match is taken).\n\nThe client SHOULD prioritize these hints over the numeric priorities, but\nMAY still use the priorities to select from ambiguous matches.",
-                    "items": {
-                        "$ref": "#/definitions/ModelHint"
-                    },
-                    "type": "array"
-                },
-                "intelligencePriority": {
-                    "description": "How much to prioritize intelligence and capabilities when selecting a\nmodel. A value of 0 means intelligence is not important, while a value of 1\nmeans intelligence is the most important factor.",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "speedPriority": {
-                    "description": "How much to prioritize sampling speed (latency) when selecting a model. A\nvalue of 0 means speed is not important, while a value of 1 means speed is\nthe most important factor.",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
-                }
-            },
-            "type": "object"
-        },
-        "Notification": {
-            "properties": {
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "PaginatedRequest": {
-            "properties": {
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "cursor": {
-                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "PaginatedResult": {
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "PingRequest": {
-            "description": "A ping, issued by either the server or the client, to check that the other party is still alive. The receiver must promptly respond, or else may be disconnected.",
-            "properties": {
-                "method": {
-                    "const": "ping",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "properties": {
-                                "progressToken": {
-                                    "$ref": "#/definitions/ProgressToken",
-                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                                }
-                            },
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ProgressNotification": {
-            "description": "An out-of-band notification used to inform the receiver of a progress update for a long-running request.",
-            "properties": {
-                "method": {
-                    "const": "notifications/progress",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "message": {
-                            "description": "An optional message describing the current progress.",
-                            "type": "string"
-                        },
-                        "progress": {
-                            "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
-                            "type": "number"
-                        },
-                        "progressToken": {
-                            "$ref": "#/definitions/ProgressToken",
-                            "description": "The progress token which was given in the initial request, used to associate this notification with the request that is proceeding."
-                        },
-                        "total": {
-                            "description": "Total number of items to process (or total progress required), if known.",
-                            "type": "number"
-                        }
-                    },
-                    "required": [
-                        "progress",
-                        "progressToken"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ProgressToken": {
-            "description": "A progress token, used to associate progress notifications with the original request.",
-            "type": [
-                "string",
-                "integer"
-            ]
-        },
-        "Prompt": {
-            "description": "A prompt or prompt template that the server offers.",
-            "properties": {
-                "arguments": {
-                    "description": "A list of arguments to use for templating the prompt.",
-                    "items": {
-                        "$ref": "#/definitions/PromptArgument"
-                    },
-                    "type": "array"
-                },
-                "description": {
-                    "description": "An optional description of what this prompt provides",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "The name of the prompt or prompt template.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "type": "object"
-        },
-        "PromptArgument": {
-            "description": "Describes an argument that a prompt can accept.",
-            "properties": {
-                "description": {
-                    "description": "A human-readable description of the argument.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "The name of the argument.",
-                    "type": "string"
-                },
-                "required": {
-                    "description": "Whether this argument must be provided.",
-                    "type": "boolean"
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "type": "object"
-        },
-        "PromptListChangedNotification": {
-            "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.",
-            "properties": {
-                "method": {
-                    "const": "notifications/prompts/list_changed",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "PromptMessage": {
-            "description": "Describes a message returned as part of a prompt.\n\nThis is similar to `SamplingMessage`, but also supports the embedding of\nresources from the MCP server.",
-            "properties": {
-                "content": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/TextContent"
-                        },
-                        {
-                            "$ref": "#/definitions/ImageContent"
-                        },
-                        {
-                            "$ref": "#/definitions/AudioContent"
-                        },
-                        {
-                            "$ref": "#/definitions/EmbeddedResource"
-                        }
-                    ]
-                },
-                "role": {
-                    "$ref": "#/definitions/Role"
-                }
-            },
-            "required": [
-                "content",
-                "role"
-            ],
-            "type": "object"
-        },
-        "PromptReference": {
-            "description": "Identifies a prompt.",
-            "properties": {
-                "name": {
-                    "description": "The name of the prompt or prompt template",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "ref/prompt",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "type"
-            ],
-            "type": "object"
-        },
-        "ReadResourceRequest": {
-            "description": "Sent from the client to the server, to read a specific resource URI.",
-            "properties": {
-                "method": {
-                    "const": "resources/read",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "uri": {
-                            "description": "The URI of the resource to read. The URI can use any protocol; it is up to the server how to interpret it.",
-                            "format": "uri",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "uri"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ReadResourceResult": {
-            "description": "The server's response to a resources/read request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                },
-                "contents": {
-                    "items": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/definitions/TextResourceContents"
-                            },
-                            {
-                                "$ref": "#/definitions/BlobResourceContents"
-                            }
-                        ]
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "contents"
-            ],
-            "type": "object"
-        },
-        "Request": {
-            "properties": {
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "properties": {
-                                "progressToken": {
-                                    "$ref": "#/definitions/ProgressToken",
-                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                                }
-                            },
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "RequestId": {
-            "description": "A uniquely identifying ID for a request in JSON-RPC.",
-            "type": [
-                "string",
-                "integer"
-            ]
-        },
-        "Resource": {
-            "description": "A known resource that the server is capable of reading.",
-            "properties": {
-                "annotations": {
-                    "$ref": "#/definitions/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "description": {
-                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
-                    "type": "string"
-                },
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "A human-readable name for this resource.\n\nThis can be used by clients to populate UI elements.",
-                    "type": "string"
-                },
-                "size": {
-                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
-                    "type": "integer"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ResourceContents": {
-            "description": "The contents of a specific resource or sub-resource.",
-            "properties": {
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ResourceListChangedNotification": {
-            "description": "An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This may be issued by servers without any previous subscription from the client.",
-            "properties": {
-                "method": {
-                    "const": "notifications/resources/list_changed",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ResourceReference": {
-            "description": "A reference to a resource or resource template definition.",
-            "properties": {
-                "type": {
-                    "const": "ref/resource",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI or URI template of the resource.",
-                    "format": "uri-template",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "type",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ResourceTemplate": {
-            "description": "A template description for resources available on the server.",
-            "properties": {
-                "annotations": {
-                    "$ref": "#/definitions/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "description": {
-                    "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
-                    "type": "string"
-                },
-                "mimeType": {
-                    "description": "The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "A human-readable name for the type of resource this template refers to.\n\nThis can be used by clients to populate UI elements.",
-                    "type": "string"
-                },
-                "uriTemplate": {
-                    "description": "A URI template (according to RFC 6570) that can be used to construct resource URIs.",
-                    "format": "uri-template",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "uriTemplate"
-            ],
-            "type": "object"
-        },
-        "ResourceUpdatedNotification": {
-            "description": "A notification from the server to the client, informing it that a resource has changed and may need to be read again. This should only be sent if the client previously sent a resources/subscribe request.",
-            "properties": {
-                "method": {
-                    "const": "notifications/resources/updated",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "uri": {
-                            "description": "The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.",
-                            "format": "uri",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "uri"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "Result": {
-            "additionalProperties": {},
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "Role": {
-            "description": "The sender or recipient of messages and data in a conversation.",
-            "enum": [
-                "assistant",
-                "user"
-            ],
-            "type": "string"
-        },
-        "Root": {
-            "description": "Represents a root directory or file that the server can operate on.",
-            "properties": {
-                "name": {
-                    "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI identifying the root. This *must* start with file:// for now.\nThis restriction may be relaxed in future versions of the protocol to allow\nother URI schemes.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "uri"
-            ],
-            "type": "object"
-        },
-        "RootsListChangedNotification": {
-            "description": "A notification from the client to the server, informing it that the list of roots has changed.\nThis notification should be sent whenever the client adds, removes, or modifies any root.\nThe server should then request an updated list of roots using the ListRootsRequest.",
-            "properties": {
-                "method": {
-                    "const": "notifications/roots/list_changed",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "SamplingMessage": {
-            "description": "Describes a message issued to or received from an LLM API.",
-            "properties": {
-                "content": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/TextContent"
-                        },
-                        {
-                            "$ref": "#/definitions/ImageContent"
-                        },
-                        {
-                            "$ref": "#/definitions/AudioContent"
-                        }
-                    ]
-                },
-                "role": {
-                    "$ref": "#/definitions/Role"
-                }
-            },
-            "required": [
-                "content",
-                "role"
-            ],
-            "type": "object"
-        },
-        "ServerCapabilities": {
-            "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
-            "properties": {
-                "completions": {
-                    "additionalProperties": true,
-                    "description": "Present if the server supports argument autocompletion suggestions.",
-                    "properties": {},
-                    "type": "object"
-                },
-                "experimental": {
-                    "additionalProperties": {
-                        "additionalProperties": true,
-                        "properties": {},
-                        "type": "object"
-                    },
-                    "description": "Experimental, non-standard capabilities that the server supports.",
-                    "type": "object"
-                },
-                "logging": {
-                    "additionalProperties": true,
-                    "description": "Present if the server supports sending log messages to the client.",
-                    "properties": {},
-                    "type": "object"
-                },
-                "prompts": {
-                    "description": "Present if the server offers any prompt templates.",
-                    "properties": {
-                        "listChanged": {
-                            "description": "Whether this server supports notifications for changes to the prompt list.",
-                            "type": "boolean"
-                        }
-                    },
-                    "type": "object"
-                },
-                "resources": {
-                    "description": "Present if the server offers any resources to read.",
-                    "properties": {
-                        "listChanged": {
-                            "description": "Whether this server supports notifications for changes to the resource list.",
-                            "type": "boolean"
-                        },
-                        "subscribe": {
-                            "description": "Whether this server supports subscribing to resource updates.",
-                            "type": "boolean"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": {
-                    "description": "Present if the server offers any tools to call.",
-                    "properties": {
-                        "listChanged": {
-                            "description": "Whether this server supports notifications for changes to the tool list.",
-                            "type": "boolean"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "ServerNotification": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/CancelledNotification"
-                },
-                {
-                    "$ref": "#/definitions/ProgressNotification"
-                },
-                {
-                    "$ref": "#/definitions/ResourceListChangedNotification"
-                },
-                {
-                    "$ref": "#/definitions/ResourceUpdatedNotification"
-                },
-                {
-                    "$ref": "#/definitions/PromptListChangedNotification"
-                },
-                {
-                    "$ref": "#/definitions/ToolListChangedNotification"
-                },
-                {
-                    "$ref": "#/definitions/LoggingMessageNotification"
-                }
-            ]
-        },
-        "ServerRequest": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/PingRequest"
-                },
-                {
-                    "$ref": "#/definitions/CreateMessageRequest"
-                },
-                {
-                    "$ref": "#/definitions/ListRootsRequest"
-                }
-            ]
-        },
-        "ServerResult": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/Result"
-                },
-                {
-                    "$ref": "#/definitions/InitializeResult"
-                },
-                {
-                    "$ref": "#/definitions/ListResourcesResult"
-                },
-                {
-                    "$ref": "#/definitions/ListResourceTemplatesResult"
-                },
-                {
-                    "$ref": "#/definitions/ReadResourceResult"
-                },
-                {
-                    "$ref": "#/definitions/ListPromptsResult"
-                },
-                {
-                    "$ref": "#/definitions/GetPromptResult"
-                },
-                {
-                    "$ref": "#/definitions/ListToolsResult"
-                },
-                {
-                    "$ref": "#/definitions/CallToolResult"
-                },
-                {
-                    "$ref": "#/definitions/CompleteResult"
-                }
-            ]
-        },
-        "SetLevelRequest": {
-            "description": "A request from the client to the server, to enable or adjust logging.",
-            "properties": {
-                "method": {
-                    "const": "logging/setLevel",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "level": {
-                            "$ref": "#/definitions/LoggingLevel",
-                            "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message."
-                        }
-                    },
-                    "required": [
-                        "level"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "SubscribeRequest": {
-            "description": "Sent from the client to request resources/updated notifications from the server whenever a particular resource changes.",
-            "properties": {
-                "method": {
-                    "const": "resources/subscribe",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "uri": {
-                            "description": "The URI of the resource to subscribe to. The URI can use any protocol; it is up to the server how to interpret it.",
-                            "format": "uri",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "uri"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "TextContent": {
-            "description": "Text provided to or from an LLM.",
-            "properties": {
-                "annotations": {
-                    "$ref": "#/definitions/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "text": {
-                    "description": "The text content of the message.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "text",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "text",
-                "type"
-            ],
-            "type": "object"
-        },
-        "TextResourceContents": {
-            "properties": {
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "text": {
-                    "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "text",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "Tool": {
-            "description": "Definition for a tool the client can call.",
-            "properties": {
-                "annotations": {
-                    "$ref": "#/definitions/ToolAnnotations",
-                    "description": "Optional additional tool information."
-                },
-                "description": {
-                    "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
-                    "type": "string"
-                },
-                "inputSchema": {
-                    "description": "A JSON Schema object defining the expected parameters for the tool.",
-                    "properties": {
-                        "properties": {
-                            "additionalProperties": {
-                                "additionalProperties": true,
-                                "properties": {},
-                                "type": "object"
-                            },
-                            "type": "object"
-                        },
-                        "required": {
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "type": {
-                            "const": "object",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "type"
-                    ],
-                    "type": "object"
-                },
-                "name": {
-                    "description": "The name of the tool.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "inputSchema",
-                "name"
-            ],
-            "type": "object"
-        },
-        "ToolAnnotations": {
-            "description": "Additional properties describing a Tool to clients.\n\nNOTE: all properties in ToolAnnotations are **hints**.\nThey are not guaranteed to provide a faithful description of\ntool behavior (including descriptive properties like `title`).\n\nClients should never make tool use decisions based on ToolAnnotations\nreceived from untrusted servers.",
-            "properties": {
-                "destructiveHint": {
-                    "description": "If true, the tool may perform destructive updates to its environment.\nIf false, the tool performs only additive updates.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: true",
-                    "type": "boolean"
-                },
-                "idempotentHint": {
-                    "description": "If true, calling the tool repeatedly with the same arguments\nwill have no additional effect on the its environment.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: false",
-                    "type": "boolean"
-                },
-                "openWorldHint": {
-                    "description": "If true, this tool may interact with an \"open world\" of external\nentities. If false, the tool's domain of interaction is closed.\nFor example, the world of a web search tool is open, whereas that\nof a memory tool is not.\n\nDefault: true",
-                    "type": "boolean"
-                },
-                "readOnlyHint": {
-                    "description": "If true, the tool does not modify its environment.\n\nDefault: false",
-                    "type": "boolean"
-                },
-                "title": {
-                    "description": "A human-readable title for the tool.",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "ToolListChangedNotification": {
-            "description": "An optional notification from the server to the client, informing it that the list of tools it offers has changed. This may be issued by servers without any previous subscription from the client.",
-            "properties": {
-                "method": {
-                    "const": "notifications/tools/list_changed",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "UnsubscribeRequest": {
-            "description": "Sent from the client to request cancellation of resources/updated notifications from the server. This should follow a previous resources/subscribe request.",
-            "properties": {
-                "method": {
-                    "const": "resources/unsubscribe",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "uri": {
-                            "description": "The URI of the resource to unsubscribe from.",
-                            "format": "uri",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "uri"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
         }
     }
 }
-

--- a/schema/2025-06-18/schema.json
+++ b/schema/2025-06-18/schema.json
@@ -1,64 +1,421 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
-        "Annotations": {
-            "description": "Optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
-            "properties": {
-                "audience": {
-                    "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
-                    "items": {
-                        "$ref": "#/definitions/Role"
-                    },
-                    "type": "array"
+        "JSONRPCMessage": {
+            "description": "Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent.",
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/JSONRPCRequest"
                 },
-                "lastModified": {
-                    "description": "The moment the resource was last modified, as an ISO 8601 formatted string.\n\nShould be an ISO 8601 formatted string (e.g., \"2025-01-12T15:00:58Z\").\n\nExamples: last activity timestamp in an open file, timestamp when the resource\nwas attached, etc.",
-                    "type": "string"
+                {
+                    "$ref": "#/definitions/JSONRPCNotification"
                 },
-                "priority": {
-                    "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
+                {
+                    "$ref": "#/definitions/JSONRPCResponse"
+                },
+                {
+                    "$ref": "#/definitions/JSONRPCError"
                 }
-            },
-            "type": "object"
+            ]
         },
-        "AudioContent": {
-            "description": "Audio provided to or from an LLM.",
+        "ProgressToken": {
+            "description": "A progress token, used to associate progress notifications with the original request.",
+            "type": [
+                "string",
+                "integer"
+            ]
+        },
+        "Cursor": {
+            "description": "An opaque token used to represent a cursor for pagination.",
+            "type": "string"
+        },
+        "Notification": {
+            "type": "object",
             "properties": {
-                "_meta": {
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "type": "object",
                     "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "annotations": {
-                    "$ref": "#/definitions/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "data": {
-                    "description": "The base64-encoded audio data.",
-                    "format": "byte",
-                    "type": "string"
-                },
-                "mimeType": {
-                    "description": "The MIME type of the audio. Different providers may support different audio types.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "audio",
-                    "type": "string"
+                    "properties": {
+                        "_meta": {
+                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
                 }
             },
             "required": [
-                "data",
-                "mimeType",
-                "type"
-            ],
-            "type": "object"
+                "method"
+            ]
+        },
+        "Result": {
+            "type": "object",
+            "additionalProperties": {},
+            "properties": {
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            }
+        },
+        "RequestId": {
+            "description": "A uniquely identifying ID for a request in JSON-RPC.",
+            "type": [
+                "string",
+                "integer"
+            ]
+        },
+        "JSONRPCRequest": {
+            "description": "A request that expects a response.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/definitions/RequestId"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                            "type": "object",
+                            "additionalProperties": {},
+                            "properties": {
+                                "progressToken": {
+                                    "$ref": "#/definitions/ProgressToken",
+                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "JSONRPCNotification": {
+            "description": "A notification which does not expect a response.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "JSONRPCResponse": {
+            "description": "A successful (non-error) response to a request.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/definitions/RequestId"
+                },
+                "result": {
+                    "$ref": "#/definitions/Result"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ]
+        },
+        "JSONRPCError": {
+            "description": "A response to a request that indicates an error occurred.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/definitions/RequestId"
+                },
+                "error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "description": "The error type that occurred.",
+                            "type": "integer"
+                        },
+                        "message": {
+                            "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+                            "type": "string"
+                        },
+                        "data": {
+                            "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+                        }
+                    },
+                    "required": [
+                        "code",
+                        "message"
+                    ]
+                }
+            },
+            "required": [
+                "error",
+                "id",
+                "jsonrpc"
+            ]
+        },
+        "EmptyResult": {
+            "$ref": "#/definitions/Result"
+        },
+        "CancelledNotification": {
+            "description": "This notification can be sent by either side to indicate that it is cancelling a previously-issued request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.\n\nA client MUST NOT attempt to cancel its `initialize` request.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/cancelled"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "requestId": {
+                            "$ref": "#/definitions/RequestId",
+                            "description": "The ID of the request to cancel.\n\nThis MUST correspond to the ID of a request previously issued in the same direction."
+                        },
+                        "reason": {
+                            "description": "An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "requestId"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "InitializeRequest": {
+            "description": "This request is sent from the client to the server when it first connects, asking it to begin initialization.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "initialize"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "protocolVersion": {
+                            "description": "The latest version of the Model Context Protocol that the client supports. The client MAY decide to support older versions as well.",
+                            "type": "string"
+                        },
+                        "capabilities": {
+                            "$ref": "#/definitions/ClientCapabilities"
+                        },
+                        "clientInfo": {
+                            "$ref": "#/definitions/Implementation"
+                        }
+                    },
+                    "required": [
+                        "capabilities",
+                        "clientInfo",
+                        "protocolVersion"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "InitializeResult": {
+            "description": "After receiving an initialize request from the client, the server sends this response.",
+            "type": "object",
+            "properties": {
+                "protocolVersion": {
+                    "description": "The version of the Model Context Protocol that the server wants to use. This may not match the version that the client requested. If the client cannot support this version, it MUST disconnect.",
+                    "type": "string"
+                },
+                "capabilities": {
+                    "$ref": "#/definitions/ServerCapabilities"
+                },
+                "serverInfo": {
+                    "$ref": "#/definitions/Implementation"
+                },
+                "instructions": {
+                    "description": "Instructions describing how to use the server and its features.\n\nThis can be used by clients to improve the LLM's understanding of available tools, resources, etc. It can be thought of like a \"hint\" to the model. For example, this information MAY be added to the system prompt.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "capabilities",
+                "protocolVersion",
+                "serverInfo"
+            ]
+        },
+        "InitializedNotification": {
+            "description": "This notification is sent from the client to the server after initialization has finished.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/initialized"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ClientCapabilities": {
+            "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
+            "type": "object",
+            "properties": {
+                "experimental": {
+                    "description": "Experimental, non-standard capabilities that the client supports.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": true
+                    }
+                },
+                "roots": {
+                    "description": "Present if the client supports listing roots.",
+                    "type": "object",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether the client supports notifications for changes to the roots list.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "sampling": {
+                    "description": "Present if the client supports sampling from an LLM.",
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true
+                },
+                "elicitation": {
+                    "description": "Present if the client supports elicitation from the server.",
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true
+                }
+            }
+        },
+        "ServerCapabilities": {
+            "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
+            "type": "object",
+            "properties": {
+                "experimental": {
+                    "description": "Experimental, non-standard capabilities that the server supports.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": true
+                    }
+                },
+                "logging": {
+                    "description": "Present if the server supports sending log messages to the client.",
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true
+                },
+                "completions": {
+                    "description": "Present if the server supports argument autocompletion suggestions.",
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true
+                },
+                "prompts": {
+                    "description": "Present if the server offers any prompt templates.",
+                    "type": "object",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the prompt list.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "resources": {
+                    "description": "Present if the server offers any resources to read.",
+                    "type": "object",
+                    "properties": {
+                        "subscribe": {
+                            "description": "Whether this server supports subscribing to resource updates.",
+                            "type": "boolean"
+                        },
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the resource list.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "tools": {
+                    "description": "Present if the server offers any tools to call.",
+                    "type": "object",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the tool list.",
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
         },
         "BaseMetadata": {
             "description": "Base interface for metadata with name (identifier) and title (display name) properties.",
+            "type": "object",
             "properties": {
                 "name": {
                     "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
@@ -71,183 +428,1844 @@
             },
             "required": [
                 "name"
-            ],
-            "type": "object"
+            ]
         },
-        "BlobResourceContents": {
+        "Implementation": {
+            "description": "Describes the name and version of an MCP implementation, with an optional title for UI representation.",
+            "type": "object",
             "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
+                "version": {
+                    "type": "string"
                 },
-                "blob": {
-                    "description": "A base64-encoded string representing the binary data of the item.",
-                    "format": "byte",
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "version"
+            ]
+        },
+        "PingRequest": {
+            "description": "A ping, issued by either the server or the client, to check that the other party is still alive. The receiver must promptly respond, or else may be disconnected.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "ping"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                            "type": "object",
+                            "additionalProperties": {},
+                            "properties": {
+                                "progressToken": {
+                                    "$ref": "#/definitions/ProgressToken",
+                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ProgressNotification": {
+            "description": "An out-of-band notification used to inform the receiver of a progress update for a long-running request.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/progress"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/definitions/ProgressToken",
+                            "description": "The progress token which was given in the initial request, used to associate this notification with the request that is proceeding."
+                        },
+                        "progress": {
+                            "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
+                            "type": "number"
+                        },
+                        "total": {
+                            "description": "Total number of items to process (or total progress required), if known.",
+                            "type": "number"
+                        },
+                        "message": {
+                            "description": "An optional message describing the current progress.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "progress",
+                        "progressToken"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "PaginatedRequest": {
+            "type": "object",
+            "properties": {
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "cursor": {
+                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "method": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "PaginatedResult": {
+            "type": "object",
+            "properties": {
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            }
+        },
+        "ListResourcesRequest": {
+            "description": "Sent from the client to request a list of resources the server has.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/list"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "cursor": {
+                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ListResourcesResult": {
+            "description": "The server's response to a resources/list request from the client.",
+            "type": "object",
+            "properties": {
+                "resources": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Resource"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "resources"
+            ]
+        },
+        "ListResourceTemplatesRequest": {
+            "description": "Sent from the client to request a list of resource templates the server has.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/templates/list"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "cursor": {
+                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ListResourceTemplatesResult": {
+            "description": "The server's response to a resources/templates/list request from the client.",
+            "type": "object",
+            "properties": {
+                "resourceTemplates": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ResourceTemplate"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "resourceTemplates"
+            ]
+        },
+        "ReadResourceRequest": {
+            "description": "Sent from the client to the server, to read a specific resource URI.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/read"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "uri": {
+                            "description": "The URI of the resource to read. The URI can use any protocol; it is up to the server how to interpret it.",
+                            "format": "uri",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "uri"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "ReadResourceResult": {
+            "description": "The server's response to a resources/read request from the client.",
+            "type": "object",
+            "properties": {
+                "contents": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/TextResourceContents"
+                            },
+                            {
+                                "$ref": "#/definitions/BlobResourceContents"
+                            }
+                        ]
+                    }
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "contents"
+            ]
+        },
+        "ResourceListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This may be issued by servers without any previous subscription from the client.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/resources/list_changed"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "SubscribeRequest": {
+            "description": "Sent from the client to request resources/updated notifications from the server whenever a particular resource changes.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/subscribe"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "uri": {
+                            "description": "The URI of the resource to subscribe to. The URI can use any protocol; it is up to the server how to interpret it.",
+                            "format": "uri",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "uri"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "UnsubscribeRequest": {
+            "description": "Sent from the client to request cancellation of resources/updated notifications from the server. This should follow a previous resources/subscribe request.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/unsubscribe"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "uri": {
+                            "description": "The URI of the resource to unsubscribe from.",
+                            "format": "uri",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "uri"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "ResourceUpdatedNotification": {
+            "description": "A notification from the server to the client, informing it that a resource has changed and may need to be read again. This should only be sent if the client previously sent a resources/subscribe request.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/resources/updated"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "uri": {
+                            "description": "The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.",
+                            "format": "uri",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "uri"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "ResourceTemplate": {
+            "description": "A template description for resources available on the server.",
+            "type": "object",
+            "properties": {
+                "uriTemplate": {
+                    "description": "A URI template (according to RFC 6570) that can be used to construct resource URIs.",
+                    "format": "uri-template",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "uriTemplate"
+            ]
+        },
+        "ResourceContents": {
+            "description": "The contents of a specific resource or sub-resource.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "mimeType": {
                     "description": "The MIME type of this resource, if known.",
                     "type": "string"
                 },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "uri"
+            ]
+        },
+        "TextResourceContents": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
+                    "type": "string"
+                },
                 "uri": {
                     "description": "The URI of this resource.",
                     "format": "uri",
                     "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "text",
+                "uri"
+            ]
+        },
+        "BlobResourceContents": {
+            "type": "object",
+            "properties": {
+                "blob": {
+                    "description": "A base64-encoded string representing the binary data of the item.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
                 }
             },
             "required": [
                 "blob",
                 "uri"
-            ],
-            "type": "object"
+            ]
         },
-        "BooleanSchema": {
+        "ListPromptsRequest": {
+            "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
+            "type": "object",
             "properties": {
-                "default": {
-                    "type": "boolean"
+                "method": {
+                    "type": "string",
+                    "const": "prompts/list"
                 },
-                "description": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "type": {
-                    "const": "boolean",
-                    "type": "string"
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "cursor": {
+                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                            "type": "string"
+                        }
+                    }
                 }
             },
             "required": [
-                "type"
-            ],
-            "type": "object"
+                "method"
+            ]
         },
-        "CallToolRequest": {
-            "description": "Used by the client to invoke a tool provided by the server.",
+        "ListPromptsResult": {
+            "description": "The server's response to a prompts/list request from the client.",
+            "type": "object",
             "properties": {
-                "method": {
-                    "const": "tools/call",
+                "prompts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Prompt"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
                     "type": "string"
                 },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "prompts"
+            ]
+        },
+        "GetPromptRequest": {
+            "description": "Used by the client to get a prompt provided by the server.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "prompts/get"
+                },
                 "params": {
+                    "type": "object",
                     "properties": {
-                        "arguments": {
-                            "additionalProperties": {},
-                            "type": "object"
-                        },
                         "name": {
+                            "description": "The name of the prompt or prompt template.",
                             "type": "string"
+                        },
+                        "arguments": {
+                            "description": "Arguments to use for templating the prompt.",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "required": [
                         "name"
-                    ],
-                    "type": "object"
+                    ]
                 }
             },
             "required": [
                 "method",
                 "params"
+            ]
+        },
+        "GetPromptResult": {
+            "description": "The server's response to a prompts/get request from the client.",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "An optional description for the prompt.",
+                    "type": "string"
+                },
+                "messages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/PromptMessage"
+                    }
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "messages"
+            ]
+        },
+        "Prompt": {
+            "description": "A prompt or prompt template that the server offers.",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "An optional description of what this prompt provides",
+                    "type": "string"
+                },
+                "arguments": {
+                    "description": "A list of arguments to use for templating the prompt.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/PromptArgument"
+                    }
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ]
+        },
+        "PromptArgument": {
+            "description": "Describes an argument that a prompt can accept.",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "A human-readable description of the argument.",
+                    "type": "string"
+                },
+                "required": {
+                    "description": "Whether this argument must be provided.",
+                    "type": "boolean"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ]
+        },
+        "Role": {
+            "description": "The sender or recipient of messages and data in a conversation.",
+            "enum": [
+                "assistant",
+                "user"
             ],
-            "type": "object"
+            "type": "string"
+        },
+        "PromptMessage": {
+            "description": "Describes a message returned as part of a prompt.\n\nThis is similar to `SamplingMessage`, but also supports the embedding of\nresources from the MCP server.",
+            "type": "object",
+            "properties": {
+                "role": {
+                    "$ref": "#/definitions/Role"
+                },
+                "content": {
+                    "$ref": "#/definitions/ContentBlock"
+                }
+            },
+            "required": [
+                "content",
+                "role"
+            ]
+        },
+        "ResourceLink": {
+            "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of `resources/list` requests.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "resource_link"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "size": {
+                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+                    "type": "integer"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "type",
+                "uri"
+            ]
+        },
+        "EmbeddedResource": {
+            "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "resource"
+                },
+                "resource": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TextResourceContents"
+                        },
+                        {
+                            "$ref": "#/definitions/BlobResourceContents"
+                        }
+                    ]
+                },
+                "annotations": {
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "resource",
+                "type"
+            ]
+        },
+        "PromptListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/prompts/list_changed"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ListToolsRequest": {
+            "description": "Sent from the client to request a list of tools the server has.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "tools/list"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "cursor": {
+                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ListToolsResult": {
+            "description": "The server's response to a tools/list request from the client.",
+            "type": "object",
+            "properties": {
+                "tools": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Tool"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "tools"
+            ]
         },
         "CallToolResult": {
             "description": "The server's response to a tool call.",
+            "type": "object",
             "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
                 "content": {
                     "description": "A list of content objects that represent the unstructured result of the tool call.",
+                    "type": "array",
                     "items": {
                         "$ref": "#/definitions/ContentBlock"
-                    },
-                    "type": "array"
+                    }
+                },
+                "structuredContent": {
+                    "description": "An optional JSON object that represents the structured result of the tool call.",
+                    "type": "object",
+                    "additionalProperties": {}
                 },
                 "isError": {
                     "description": "Whether the tool call ended in an error.\n\nIf not set, this is assumed to be false (the call was successful).\n\nAny errors that originate from the tool SHOULD be reported inside the result\nobject, with `isError` set to true, _not_ as an MCP protocol-level error\nresponse. Otherwise, the LLM would not be able to see that an error occurred\nand self-correct.\n\nHowever, any errors in _finding_ the tool, an error indicating that the\nserver does not support tool calls, or any other exceptional conditions,\nshould be reported as an MCP error response.",
                     "type": "boolean"
                 },
-                "structuredContent": {
-                    "additionalProperties": {},
-                    "description": "An optional JSON object that represents the structured result of the tool call.",
-                    "type": "object"
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
                 }
             },
             "required": [
                 "content"
-            ],
-            "type": "object"
+            ]
         },
-        "CancelledNotification": {
-            "description": "This notification can be sent by either side to indicate that it is cancelling a previously-issued request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.\n\nA client MUST NOT attempt to cancel its `initialize` request.",
+        "CallToolRequest": {
+            "description": "Used by the client to invoke a tool provided by the server.",
+            "type": "object",
             "properties": {
                 "method": {
-                    "const": "notifications/cancelled",
-                    "type": "string"
+                    "type": "string",
+                    "const": "tools/call"
                 },
                 "params": {
+                    "type": "object",
                     "properties": {
-                        "reason": {
-                            "description": "An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.",
+                        "name": {
                             "type": "string"
                         },
-                        "requestId": {
-                            "$ref": "#/definitions/RequestId",
-                            "description": "The ID of the request to cancel.\n\nThis MUST correspond to the ID of a request previously issued in the same direction."
+                        "arguments": {
+                            "type": "object",
+                            "additionalProperties": {}
                         }
                     },
                     "required": [
-                        "requestId"
-                    ],
-                    "type": "object"
+                        "name"
+                    ]
                 }
             },
             "required": [
                 "method",
                 "params"
-            ],
-            "type": "object"
+            ]
         },
-        "ClientCapabilities": {
-            "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
+        "ToolListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of tools it offers has changed. This may be issued by servers without any previous subscription from the client.",
+            "type": "object",
             "properties": {
-                "elicitation": {
-                    "additionalProperties": true,
-                    "description": "Present if the client supports elicitation from the server.",
-                    "properties": {},
-                    "type": "object"
+                "method": {
+                    "type": "string",
+                    "const": "notifications/tools/list_changed"
                 },
-                "experimental": {
-                    "additionalProperties": {
-                        "additionalProperties": true,
-                        "properties": {},
-                        "type": "object"
-                    },
-                    "description": "Experimental, non-standard capabilities that the client supports.",
-                    "type": "object"
-                },
-                "roots": {
-                    "description": "Present if the client supports listing roots.",
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
                     "properties": {
-                        "listChanged": {
-                            "description": "Whether the client supports notifications for changes to the roots list.",
+                        "_meta": {
+                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ToolAnnotations": {
+            "description": "Additional properties describing a Tool to clients.\n\nNOTE: all properties in ToolAnnotations are **hints**.\nThey are not guaranteed to provide a faithful description of\ntool behavior (including descriptive properties like `title`).\n\nClients should never make tool use decisions based on ToolAnnotations\nreceived from untrusted servers.",
+            "type": "object",
+            "properties": {
+                "title": {
+                    "description": "A human-readable title for the tool.",
+                    "type": "string"
+                },
+                "readOnlyHint": {
+                    "description": "If true, the tool does not modify its environment.\n\nDefault: false",
+                    "type": "boolean"
+                },
+                "destructiveHint": {
+                    "description": "If true, the tool may perform destructive updates to its environment.\nIf false, the tool performs only additive updates.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: true",
+                    "type": "boolean"
+                },
+                "idempotentHint": {
+                    "description": "If true, calling the tool repeatedly with the same arguments\nwill have no additional effect on the its environment.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: false",
+                    "type": "boolean"
+                },
+                "openWorldHint": {
+                    "description": "If true, this tool may interact with an \"open world\" of external\nentities. If false, the tool's domain of interaction is closed.\nFor example, the world of a web search tool is open, whereas that\nof a memory tool is not.\n\nDefault: true",
+                    "type": "boolean"
+                }
+            }
+        },
+        "Tool": {
+            "description": "Definition for a tool the client can call.",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "inputSchema": {
+                    "description": "A JSON Schema object defining the expected parameters for the tool.",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "object"
+                        },
+                        "properties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": true
+                            }
+                        },
+                        "required": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ]
+                },
+                "outputSchema": {
+                    "description": "An optional JSON Schema object defining the structure of the tool's output returned in\nthe structuredContent field of a CallToolResult.",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "object"
+                        },
+                        "properties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": true
+                            }
+                        },
+                        "required": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ]
+                },
+                "annotations": {
+                    "$ref": "#/definitions/ToolAnnotations",
+                    "description": "Optional additional tool information.\n\nDisplay name precedence order is: title, annotations.title, then name."
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "inputSchema",
+                "name"
+            ]
+        },
+        "SetLevelRequest": {
+            "description": "A request from the client to the server, to enable or adjust logging.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "logging/setLevel"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "level": {
+                            "$ref": "#/definitions/LoggingLevel",
+                            "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message."
+                        }
+                    },
+                    "required": [
+                        "level"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "LoggingMessageNotification": {
+            "description": "Notification of a log message passed from server to client. If no logging/setLevel request has been sent from the client, the server MAY decide which messages to send automatically.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/message"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "level": {
+                            "$ref": "#/definitions/LoggingLevel",
+                            "description": "The severity of this log message."
+                        },
+                        "logger": {
+                            "description": "An optional name of the logger issuing this message.",
+                            "type": "string"
+                        },
+                        "data": {
+                            "description": "The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here."
+                        }
+                    },
+                    "required": [
+                        "data",
+                        "level"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "LoggingLevel": {
+            "description": "The severity of a log message.\n\nThese map to syslog message severities, as specified in RFC-5424:\nhttps://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1",
+            "enum": [
+                "alert",
+                "critical",
+                "debug",
+                "emergency",
+                "error",
+                "info",
+                "notice",
+                "warning"
+            ],
+            "type": "string"
+        },
+        "CreateMessageRequest": {
+            "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "sampling/createMessage"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SamplingMessage"
+                            }
+                        },
+                        "modelPreferences": {
+                            "$ref": "#/definitions/ModelPreferences",
+                            "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
+                        },
+                        "systemPrompt": {
+                            "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
+                            "type": "string"
+                        },
+                        "includeContext": {
+                            "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt. The client MAY ignore this request.",
+                            "enum": [
+                                "allServers",
+                                "none",
+                                "thisServer"
+                            ],
+                            "type": "string"
+                        },
+                        "temperature": {
+                            "type": "number"
+                        },
+                        "maxTokens": {
+                            "description": "The requested maximum number of tokens to sample (to prevent runaway completions).\n\nThe client MAY choose to sample fewer tokens than the requested maximum.",
+                            "type": "integer"
+                        },
+                        "stopSequences": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "metadata": {
+                            "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific.",
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": true
+                        }
+                    },
+                    "required": [
+                        "maxTokens",
+                        "messages"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "CreateMessageResult": {
+            "description": "The client's response to a sampling/create_message request from the server. The client should inform the user before returning the sampled message, to allow them to inspect the response (human in the loop) and decide whether to allow the server to see it.",
+            "type": "object",
+            "properties": {
+                "model": {
+                    "description": "The name of the model that generated the message.",
+                    "type": "string"
+                },
+                "stopReason": {
+                    "description": "The reason why sampling stopped, if known.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "role": {
+                    "$ref": "#/definitions/Role"
+                },
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TextContent"
+                        },
+                        {
+                            "$ref": "#/definitions/ImageContent"
+                        },
+                        {
+                            "$ref": "#/definitions/AudioContent"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "content",
+                "model",
+                "role"
+            ]
+        },
+        "SamplingMessage": {
+            "description": "Describes a message issued to or received from an LLM API.",
+            "type": "object",
+            "properties": {
+                "role": {
+                    "$ref": "#/definitions/Role"
+                },
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TextContent"
+                        },
+                        {
+                            "$ref": "#/definitions/ImageContent"
+                        },
+                        {
+                            "$ref": "#/definitions/AudioContent"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "content",
+                "role"
+            ]
+        },
+        "Annotations": {
+            "description": "Optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
+            "type": "object",
+            "properties": {
+                "audience": {
+                    "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Role"
+                    }
+                },
+                "priority": {
+                    "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "lastModified": {
+                    "description": "The moment the resource was last modified, as an ISO 8601 formatted string.\n\nShould be an ISO 8601 formatted string (e.g., \"2025-01-12T15:00:58Z\").\n\nExamples: last activity timestamp in an open file, timestamp when the resource\nwas attached, etc.",
+                    "type": "string"
+                }
+            }
+        },
+        "ContentBlock": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/TextContent"
+                },
+                {
+                    "$ref": "#/definitions/ImageContent"
+                },
+                {
+                    "$ref": "#/definitions/AudioContent"
+                },
+                {
+                    "$ref": "#/definitions/ResourceLink"
+                },
+                {
+                    "$ref": "#/definitions/EmbeddedResource"
+                }
+            ]
+        },
+        "TextContent": {
+            "description": "Text provided to or from an LLM.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "text"
+                },
+                "text": {
+                    "description": "The text content of the message.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "text",
+                "type"
+            ]
+        },
+        "ImageContent": {
+            "description": "An image provided to or from an LLM.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "image"
+                },
+                "data": {
+                    "description": "The base64-encoded image data.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of the image. Different providers may support different image types.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "data",
+                "mimeType",
+                "type"
+            ]
+        },
+        "AudioContent": {
+            "description": "Audio provided to or from an LLM.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "audio"
+                },
+                "data": {
+                    "description": "The base64-encoded audio data.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of the audio. Different providers may support different audio types.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "data",
+                "mimeType",
+                "type"
+            ]
+        },
+        "ModelPreferences": {
+            "description": "The server's preferences for model selection, requested of the client during sampling.\n\nBecause LLMs can vary along multiple dimensions, choosing the \"best\" model is\nrarely straightforward.  Different models excel in different areas—some are\nfaster but less capable, others are more capable but more expensive, and so\non. This interface allows servers to express their priorities across multiple\ndimensions to help clients make an appropriate selection for their use case.\n\nThese preferences are always advisory. The client MAY ignore them. It is also\nup to the client to decide how to interpret these preferences and how to\nbalance them against other considerations.",
+            "type": "object",
+            "properties": {
+                "hints": {
+                    "description": "Optional hints to use for model selection.\n\nIf multiple hints are specified, the client MUST evaluate them in order\n(such that the first match is taken).\n\nThe client SHOULD prioritize these hints over the numeric priorities, but\nMAY still use the priorities to select from ambiguous matches.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ModelHint"
+                    }
+                },
+                "costPriority": {
+                    "description": "How much to prioritize cost when selecting a model. A value of 0 means cost\nis not important, while a value of 1 means cost is the most important\nfactor.",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "speedPriority": {
+                    "description": "How much to prioritize sampling speed (latency) when selecting a model. A\nvalue of 0 means speed is not important, while a value of 1 means speed is\nthe most important factor.",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "intelligencePriority": {
+                    "description": "How much to prioritize intelligence and capabilities when selecting a\nmodel. A value of 0 means intelligence is not important, while a value of 1\nmeans intelligence is the most important factor.",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                }
+            }
+        },
+        "ModelHint": {
+            "description": "Hints to use for model selection.\n\nKeys not declared here are currently left unspecified by the spec and are up\nto the client to interpret.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "A hint for a model name.\n\nThe client SHOULD treat this as a substring of a model name; for example:\n - `claude-3-5-sonnet` should match `claude-3-5-sonnet-20241022`\n - `sonnet` should match `claude-3-5-sonnet-20241022`, `claude-3-sonnet-20240229`, etc.\n - `claude` should match any Claude model\n\nThe client MAY also map the string to a different provider's model name or a different model family, as long as it fills a similar niche; for example:\n - `gemini-1.5-flash` could match `claude-3-haiku-20240307`",
+                    "type": "string"
+                }
+            }
+        },
+        "CompleteRequest": {
+            "description": "A request from the client to the server, to ask for completion options.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "completion/complete"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "ref": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/definitions/PromptReference"
+                                },
+                                {
+                                    "$ref": "#/definitions/ResourceTemplateReference"
+                                }
+                            ]
+                        },
+                        "argument": {
+                            "description": "The argument's information",
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "description": "The name of the argument",
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "description": "The value of the argument to use for completion matching.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "name",
+                                "value"
+                            ]
+                        },
+                        "context": {
+                            "description": "Additional, optional context for completions",
+                            "type": "object",
+                            "properties": {
+                                "arguments": {
+                                    "description": "Previously-resolved variables in a URI template or prompt.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": [
+                        "argument",
+                        "ref"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "CompleteResult": {
+            "description": "The server's response to a completion/complete request",
+            "type": "object",
+            "properties": {
+                "completion": {
+                    "type": "object",
+                    "properties": {
+                        "values": {
+                            "description": "An array of completion values. Must not exceed 100 items.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "total": {
+                            "description": "The total number of completion options available. This can exceed the number of values actually sent in the response.",
+                            "type": "integer"
+                        },
+                        "hasMore": {
+                            "description": "Indicates whether there are additional completion options beyond those provided in the current response, even if the exact total is unknown.",
                             "type": "boolean"
                         }
                     },
-                    "type": "object"
+                    "required": [
+                        "values"
+                    ]
                 },
-                "sampling": {
-                    "additionalProperties": true,
-                    "description": "Present if the client supports sampling from an LLM.",
-                    "properties": {},
-                    "type": "object"
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
                 }
             },
-            "type": "object"
+            "required": [
+                "completion"
+            ]
+        },
+        "ResourceTemplateReference": {
+            "description": "A reference to a resource or resource template definition.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "ref/resource"
+                },
+                "uri": {
+                    "description": "The URI or URI template of the resource.",
+                    "format": "uri-template",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type",
+                "uri"
+            ]
+        },
+        "PromptReference": {
+            "description": "Identifies a prompt.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "ref/prompt"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "type"
+            ]
+        },
+        "ListRootsRequest": {
+            "description": "Sent from the server to request a list of root URIs from the client. Roots allow\nservers to ask for specific directories or files to operate on. A common example\nfor roots is providing a set of repositories or directories a server should operate\non.\n\nThis request is typically used when the server needs to understand the file system\nstructure or access specific locations that the client has permission to read from.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "roots/list"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                            "type": "object",
+                            "additionalProperties": {},
+                            "properties": {
+                                "progressToken": {
+                                    "$ref": "#/definitions/ProgressToken",
+                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ListRootsResult": {
+            "description": "The client's response to a roots/list request from the server.\nThis result contains an array of Root objects, each representing a root directory\nor file that the server can operate on.",
+            "type": "object",
+            "properties": {
+                "roots": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Root"
+                    }
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "roots"
+            ]
+        },
+        "RootsListChangedNotification": {
+            "description": "A notification from the client to the server, informing it that the list of roots has changed.\nThis notification should be sent whenever the client adds, removes, or modifies any root.\nThe server should then request an updated list of roots using the ListRootsRequest.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/roots/list_changed"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                            "type": "object",
+                            "additionalProperties": {}
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ElicitRequest": {
+            "description": "A request from the server to elicit additional information from the user via the client.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "elicitation/create"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "message": {
+                            "description": "The message to present to the user.",
+                            "type": "string"
+                        },
+                        "requestedSchema": {
+                            "description": "A restricted subset of JSON Schema.\nOnly top-level properties are allowed, without nesting.",
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "const": "object"
+                                },
+                                "properties": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "$ref": "#/definitions/PrimitiveSchemaDefinition"
+                                    }
+                                },
+                                "required": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "required": [
+                                "properties",
+                                "type"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "message",
+                        "requestedSchema"
+                    ]
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "PrimitiveSchemaDefinition": {
+            "description": "Restricted schema definitions that only allow primitive types\nwithout nested objects or arrays.",
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/StringSchema"
+                },
+                {
+                    "$ref": "#/definitions/NumberSchema"
+                },
+                {
+                    "$ref": "#/definitions/BooleanSchema"
+                },
+                {
+                    "$ref": "#/definitions/EnumSchema"
+                }
+            ]
+        },
+        "StringSchema": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "minLength": {
+                    "type": "integer"
+                },
+                "maxLength": {
+                    "type": "integer"
+                },
+                "format": {
+                    "enum": [
+                        "date",
+                        "date-time",
+                        "email",
+                        "uri"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
+            ]
+        },
+        "NumberSchema": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "enum": [
+                        "integer",
+                        "number"
+                    ],
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "minimum": {
+                    "type": "integer"
+                },
+                "maximum": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "type"
+            ]
+        },
+        "BooleanSchema": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "boolean"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "default": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "type"
+            ]
+        },
+        "EnumSchema": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "enum": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "enumNames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "enum",
+                "type"
+            ]
+        },
+        "ElicitResult": {
+            "description": "The client's response to an elicitation request.",
+            "type": "object",
+            "properties": {
+                "action": {
+                    "description": "The user action in response to the elicitation.\n- \"accept\": User submitted the form/confirmed the action\n- \"decline\": User explicitly declined the action\n- \"cancel\": User dismissed without making an explicit choice",
+                    "enum": [
+                        "accept",
+                        "cancel",
+                        "decline"
+                    ],
+                    "type": "string"
+                },
+                "content": {
+                    "description": "The submitted form data, only present when action is \"accept\".\nContains values matching the requested schema.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "integer",
+                            "boolean"
+                        ]
+                    }
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "action"
+            ]
         },
         "ClientNotification": {
             "anyOf": [
@@ -263,6 +2281,192 @@
                 {
                     "$ref": "#/definitions/RootsListChangedNotification"
                 }
+            ]
+        },
+        "ClientResult": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/Result"
+                },
+                {
+                    "$ref": "#/definitions/CreateMessageResult"
+                },
+                {
+                    "$ref": "#/definitions/ListRootsResult"
+                },
+                {
+                    "$ref": "#/definitions/ElicitResult"
+                }
+            ]
+        },
+        "ServerRequest": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/PingRequest"
+                },
+                {
+                    "$ref": "#/definitions/CreateMessageRequest"
+                },
+                {
+                    "$ref": "#/definitions/ListRootsRequest"
+                },
+                {
+                    "$ref": "#/definitions/ElicitRequest"
+                }
+            ]
+        },
+        "ServerNotification": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/CancelledNotification"
+                },
+                {
+                    "$ref": "#/definitions/ProgressNotification"
+                },
+                {
+                    "$ref": "#/definitions/ResourceListChangedNotification"
+                },
+                {
+                    "$ref": "#/definitions/ResourceUpdatedNotification"
+                },
+                {
+                    "$ref": "#/definitions/PromptListChangedNotification"
+                },
+                {
+                    "$ref": "#/definitions/ToolListChangedNotification"
+                },
+                {
+                    "$ref": "#/definitions/LoggingMessageNotification"
+                }
+            ]
+        },
+        "ServerResult": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/Result"
+                },
+                {
+                    "$ref": "#/definitions/InitializeResult"
+                },
+                {
+                    "$ref": "#/definitions/ListResourcesResult"
+                },
+                {
+                    "$ref": "#/definitions/ListResourceTemplatesResult"
+                },
+                {
+                    "$ref": "#/definitions/ReadResourceResult"
+                },
+                {
+                    "$ref": "#/definitions/ListPromptsResult"
+                },
+                {
+                    "$ref": "#/definitions/GetPromptResult"
+                },
+                {
+                    "$ref": "#/definitions/ListToolsResult"
+                },
+                {
+                    "$ref": "#/definitions/CallToolResult"
+                },
+                {
+                    "$ref": "#/definitions/CompleteResult"
+                }
+            ]
+        },
+        "Request": {
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "_meta": {
+                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                            "type": "object",
+                            "additionalProperties": {},
+                            "properties": {
+                                "progressToken": {
+                                    "$ref": "#/definitions/ProgressToken",
+                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "Resource": {
+            "description": "A known resource that the server is capable of reading.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/definitions/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "size": {
+                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+                    "type": "integer"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "uri"
+            ]
+        },
+        "Root": {
+            "description": "Represents a root directory or file that the server can operate on.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI identifying the root. This *must* start with file:// for now.\nThis restriction may be relaxed in future versions of the protocol to allow\nother URI schemes.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "uri"
             ]
         },
         "ClientRequest": {
@@ -307,2211 +2511,6 @@
                     "$ref": "#/definitions/CompleteRequest"
                 }
             ]
-        },
-        "ClientResult": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/Result"
-                },
-                {
-                    "$ref": "#/definitions/CreateMessageResult"
-                },
-                {
-                    "$ref": "#/definitions/ListRootsResult"
-                },
-                {
-                    "$ref": "#/definitions/ElicitResult"
-                }
-            ]
-        },
-        "CompleteRequest": {
-            "description": "A request from the client to the server, to ask for completion options.",
-            "properties": {
-                "method": {
-                    "const": "completion/complete",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "argument": {
-                            "description": "The argument's information",
-                            "properties": {
-                                "name": {
-                                    "description": "The name of the argument",
-                                    "type": "string"
-                                },
-                                "value": {
-                                    "description": "The value of the argument to use for completion matching.",
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "name",
-                                "value"
-                            ],
-                            "type": "object"
-                        },
-                        "context": {
-                            "description": "Additional, optional context for completions",
-                            "properties": {
-                                "arguments": {
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    },
-                                    "description": "Previously-resolved variables in a URI template or prompt.",
-                                    "type": "object"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        "ref": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/definitions/PromptReference"
-                                },
-                                {
-                                    "$ref": "#/definitions/ResourceTemplateReference"
-                                }
-                            ]
-                        }
-                    },
-                    "required": [
-                        "argument",
-                        "ref"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "CompleteResult": {
-            "description": "The server's response to a completion/complete request",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "completion": {
-                    "properties": {
-                        "hasMore": {
-                            "description": "Indicates whether there are additional completion options beyond those provided in the current response, even if the exact total is unknown.",
-                            "type": "boolean"
-                        },
-                        "total": {
-                            "description": "The total number of completion options available. This can exceed the number of values actually sent in the response.",
-                            "type": "integer"
-                        },
-                        "values": {
-                            "description": "An array of completion values. Must not exceed 100 items.",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "required": [
-                        "values"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "completion"
-            ],
-            "type": "object"
-        },
-        "ContentBlock": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/TextContent"
-                },
-                {
-                    "$ref": "#/definitions/ImageContent"
-                },
-                {
-                    "$ref": "#/definitions/AudioContent"
-                },
-                {
-                    "$ref": "#/definitions/ResourceLink"
-                },
-                {
-                    "$ref": "#/definitions/EmbeddedResource"
-                }
-            ]
-        },
-        "CreateMessageRequest": {
-            "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
-            "properties": {
-                "method": {
-                    "const": "sampling/createMessage",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "includeContext": {
-                            "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt. The client MAY ignore this request.",
-                            "enum": [
-                                "allServers",
-                                "none",
-                                "thisServer"
-                            ],
-                            "type": "string"
-                        },
-                        "maxTokens": {
-                            "description": "The requested maximum number of tokens to sample (to prevent runaway completions).\n\nThe client MAY choose to sample fewer tokens than the requested maximum.",
-                            "type": "integer"
-                        },
-                        "messages": {
-                            "items": {
-                                "$ref": "#/definitions/SamplingMessage"
-                            },
-                            "type": "array"
-                        },
-                        "metadata": {
-                            "additionalProperties": true,
-                            "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific.",
-                            "properties": {},
-                            "type": "object"
-                        },
-                        "modelPreferences": {
-                            "$ref": "#/definitions/ModelPreferences",
-                            "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
-                        },
-                        "stopSequences": {
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "systemPrompt": {
-                            "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
-                            "type": "string"
-                        },
-                        "temperature": {
-                            "type": "number"
-                        }
-                    },
-                    "required": [
-                        "maxTokens",
-                        "messages"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "CreateMessageResult": {
-            "description": "The client's response to a sampling/create_message request from the server. The client should inform the user before returning the sampled message, to allow them to inspect the response (human in the loop) and decide whether to allow the server to see it.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "content": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/TextContent"
-                        },
-                        {
-                            "$ref": "#/definitions/ImageContent"
-                        },
-                        {
-                            "$ref": "#/definitions/AudioContent"
-                        }
-                    ]
-                },
-                "model": {
-                    "description": "The name of the model that generated the message.",
-                    "type": "string"
-                },
-                "role": {
-                    "$ref": "#/definitions/Role"
-                },
-                "stopReason": {
-                    "description": "The reason why sampling stopped, if known.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "content",
-                "model",
-                "role"
-            ],
-            "type": "object"
-        },
-        "Cursor": {
-            "description": "An opaque token used to represent a cursor for pagination.",
-            "type": "string"
-        },
-        "ElicitRequest": {
-            "description": "A request from the server to elicit additional information from the user via the client.",
-            "properties": {
-                "method": {
-                    "const": "elicitation/create",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "message": {
-                            "description": "The message to present to the user.",
-                            "type": "string"
-                        },
-                        "requestedSchema": {
-                            "description": "A restricted subset of JSON Schema.\nOnly top-level properties are allowed, without nesting.",
-                            "properties": {
-                                "properties": {
-                                    "additionalProperties": {
-                                        "$ref": "#/definitions/PrimitiveSchemaDefinition"
-                                    },
-                                    "type": "object"
-                                },
-                                "required": {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                "type": {
-                                    "const": "object",
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "properties",
-                                "type"
-                            ],
-                            "type": "object"
-                        }
-                    },
-                    "required": [
-                        "message",
-                        "requestedSchema"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ElicitResult": {
-            "description": "The client's response to an elicitation request.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "action": {
-                    "description": "The user action in response to the elicitation.\n- \"accept\": User submitted the form/confirmed the action\n- \"decline\": User explicitly declined the action\n- \"cancel\": User dismissed without making an explicit choice",
-                    "enum": [
-                        "accept",
-                        "cancel",
-                        "decline"
-                    ],
-                    "type": "string"
-                },
-                "content": {
-                    "additionalProperties": {
-                        "type": [
-                            "string",
-                            "integer",
-                            "boolean"
-                        ]
-                    },
-                    "description": "The submitted form data, only present when action is \"accept\".\nContains values matching the requested schema.",
-                    "type": "object"
-                }
-            },
-            "required": [
-                "action"
-            ],
-            "type": "object"
-        },
-        "EmbeddedResource": {
-            "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "annotations": {
-                    "$ref": "#/definitions/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "resource": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/TextResourceContents"
-                        },
-                        {
-                            "$ref": "#/definitions/BlobResourceContents"
-                        }
-                    ]
-                },
-                "type": {
-                    "const": "resource",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "resource",
-                "type"
-            ],
-            "type": "object"
-        },
-        "EmptyResult": {
-            "$ref": "#/definitions/Result"
-        },
-        "EnumSchema": {
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "enum": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "enumNames": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "type": {
-                    "const": "string",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "enum",
-                "type"
-            ],
-            "type": "object"
-        },
-        "GetPromptRequest": {
-            "description": "Used by the client to get a prompt provided by the server.",
-            "properties": {
-                "method": {
-                    "const": "prompts/get",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "arguments": {
-                            "additionalProperties": {
-                                "type": "string"
-                            },
-                            "description": "Arguments to use for templating the prompt.",
-                            "type": "object"
-                        },
-                        "name": {
-                            "description": "The name of the prompt or prompt template.",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "name"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "GetPromptResult": {
-            "description": "The server's response to a prompts/get request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "description": {
-                    "description": "An optional description for the prompt.",
-                    "type": "string"
-                },
-                "messages": {
-                    "items": {
-                        "$ref": "#/definitions/PromptMessage"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "messages"
-            ],
-            "type": "object"
-        },
-        "ImageContent": {
-            "description": "An image provided to or from an LLM.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "annotations": {
-                    "$ref": "#/definitions/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "data": {
-                    "description": "The base64-encoded image data.",
-                    "format": "byte",
-                    "type": "string"
-                },
-                "mimeType": {
-                    "description": "The MIME type of the image. Different providers may support different image types.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "image",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "data",
-                "mimeType",
-                "type"
-            ],
-            "type": "object"
-        },
-        "Implementation": {
-            "description": "Describes the name and version of an MCP implementation, with an optional title for UI representation.",
-            "properties": {
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                },
-                "version": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "version"
-            ],
-            "type": "object"
-        },
-        "InitializeRequest": {
-            "description": "This request is sent from the client to the server when it first connects, asking it to begin initialization.",
-            "properties": {
-                "method": {
-                    "const": "initialize",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "capabilities": {
-                            "$ref": "#/definitions/ClientCapabilities"
-                        },
-                        "clientInfo": {
-                            "$ref": "#/definitions/Implementation"
-                        },
-                        "protocolVersion": {
-                            "description": "The latest version of the Model Context Protocol that the client supports. The client MAY decide to support older versions as well.",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "capabilities",
-                        "clientInfo",
-                        "protocolVersion"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "InitializeResult": {
-            "description": "After receiving an initialize request from the client, the server sends this response.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "capabilities": {
-                    "$ref": "#/definitions/ServerCapabilities"
-                },
-                "instructions": {
-                    "description": "Instructions describing how to use the server and its features.\n\nThis can be used by clients to improve the LLM's understanding of available tools, resources, etc. It can be thought of like a \"hint\" to the model. For example, this information MAY be added to the system prompt.",
-                    "type": "string"
-                },
-                "protocolVersion": {
-                    "description": "The version of the Model Context Protocol that the server wants to use. This may not match the version that the client requested. If the client cannot support this version, it MUST disconnect.",
-                    "type": "string"
-                },
-                "serverInfo": {
-                    "$ref": "#/definitions/Implementation"
-                }
-            },
-            "required": [
-                "capabilities",
-                "protocolVersion",
-                "serverInfo"
-            ],
-            "type": "object"
-        },
-        "InitializedNotification": {
-            "description": "This notification is sent from the client to the server after initialization has finished.",
-            "properties": {
-                "method": {
-                    "const": "notifications/initialized",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "JSONRPCError": {
-            "description": "A response to a request that indicates an error occurred.",
-            "properties": {
-                "error": {
-                    "properties": {
-                        "code": {
-                            "description": "The error type that occurred.",
-                            "type": "integer"
-                        },
-                        "data": {
-                            "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
-                        },
-                        "message": {
-                            "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "code",
-                        "message"
-                    ],
-                    "type": "object"
-                },
-                "id": {
-                    "$ref": "#/definitions/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "error",
-                "id",
-                "jsonrpc"
-            ],
-            "type": "object"
-        },
-        "JSONRPCMessage": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/JSONRPCRequest"
-                },
-                {
-                    "$ref": "#/definitions/JSONRPCNotification"
-                },
-                {
-                    "$ref": "#/definitions/JSONRPCResponse"
-                },
-                {
-                    "$ref": "#/definitions/JSONRPCError"
-                }
-            ],
-            "description": "Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent."
-        },
-        "JSONRPCNotification": {
-            "description": "A notification which does not expect a response.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "JSONRPCRequest": {
-            "description": "A request that expects a response.",
-            "properties": {
-                "id": {
-                    "$ref": "#/definitions/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                            "properties": {
-                                "progressToken": {
-                                    "$ref": "#/definitions/ProgressToken",
-                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                                }
-                            },
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "JSONRPCResponse": {
-            "description": "A successful (non-error) response to a request.",
-            "properties": {
-                "id": {
-                    "$ref": "#/definitions/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "result": {
-                    "$ref": "#/definitions/Result"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "result"
-            ],
-            "type": "object"
-        },
-        "ListPromptsRequest": {
-            "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
-            "properties": {
-                "method": {
-                    "const": "prompts/list",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "cursor": {
-                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListPromptsResult": {
-            "description": "The server's response to a prompts/list request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "prompts": {
-                    "items": {
-                        "$ref": "#/definitions/Prompt"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "prompts"
-            ],
-            "type": "object"
-        },
-        "ListResourceTemplatesRequest": {
-            "description": "Sent from the client to request a list of resource templates the server has.",
-            "properties": {
-                "method": {
-                    "const": "resources/templates/list",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "cursor": {
-                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListResourceTemplatesResult": {
-            "description": "The server's response to a resources/templates/list request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "resourceTemplates": {
-                    "items": {
-                        "$ref": "#/definitions/ResourceTemplate"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "resourceTemplates"
-            ],
-            "type": "object"
-        },
-        "ListResourcesRequest": {
-            "description": "Sent from the client to request a list of resources the server has.",
-            "properties": {
-                "method": {
-                    "const": "resources/list",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "cursor": {
-                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListResourcesResult": {
-            "description": "The server's response to a resources/list request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "resources": {
-                    "items": {
-                        "$ref": "#/definitions/Resource"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "resources"
-            ],
-            "type": "object"
-        },
-        "ListRootsRequest": {
-            "description": "Sent from the server to request a list of root URIs from the client. Roots allow\nservers to ask for specific directories or files to operate on. A common example\nfor roots is providing a set of repositories or directories a server should operate\non.\n\nThis request is typically used when the server needs to understand the file system\nstructure or access specific locations that the client has permission to read from.",
-            "properties": {
-                "method": {
-                    "const": "roots/list",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                            "properties": {
-                                "progressToken": {
-                                    "$ref": "#/definitions/ProgressToken",
-                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                                }
-                            },
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListRootsResult": {
-            "description": "The client's response to a roots/list request from the server.\nThis result contains an array of Root objects, each representing a root directory\nor file that the server can operate on.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "roots": {
-                    "items": {
-                        "$ref": "#/definitions/Root"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "roots"
-            ],
-            "type": "object"
-        },
-        "ListToolsRequest": {
-            "description": "Sent from the client to request a list of tools the server has.",
-            "properties": {
-                "method": {
-                    "const": "tools/list",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "cursor": {
-                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListToolsResult": {
-            "description": "The server's response to a tools/list request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "tools": {
-                    "items": {
-                        "$ref": "#/definitions/Tool"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "tools"
-            ],
-            "type": "object"
-        },
-        "LoggingLevel": {
-            "description": "The severity of a log message.\n\nThese map to syslog message severities, as specified in RFC-5424:\nhttps://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1",
-            "enum": [
-                "alert",
-                "critical",
-                "debug",
-                "emergency",
-                "error",
-                "info",
-                "notice",
-                "warning"
-            ],
-            "type": "string"
-        },
-        "LoggingMessageNotification": {
-            "description": "Notification of a log message passed from server to client. If no logging/setLevel request has been sent from the client, the server MAY decide which messages to send automatically.",
-            "properties": {
-                "method": {
-                    "const": "notifications/message",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "data": {
-                            "description": "The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here."
-                        },
-                        "level": {
-                            "$ref": "#/definitions/LoggingLevel",
-                            "description": "The severity of this log message."
-                        },
-                        "logger": {
-                            "description": "An optional name of the logger issuing this message.",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "data",
-                        "level"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ModelHint": {
-            "description": "Hints to use for model selection.\n\nKeys not declared here are currently left unspecified by the spec and are up\nto the client to interpret.",
-            "properties": {
-                "name": {
-                    "description": "A hint for a model name.\n\nThe client SHOULD treat this as a substring of a model name; for example:\n - `claude-3-5-sonnet` should match `claude-3-5-sonnet-20241022`\n - `sonnet` should match `claude-3-5-sonnet-20241022`, `claude-3-sonnet-20240229`, etc.\n - `claude` should match any Claude model\n\nThe client MAY also map the string to a different provider's model name or a different model family, as long as it fills a similar niche; for example:\n - `gemini-1.5-flash` could match `claude-3-haiku-20240307`",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "ModelPreferences": {
-            "description": "The server's preferences for model selection, requested of the client during sampling.\n\nBecause LLMs can vary along multiple dimensions, choosing the \"best\" model is\nrarely straightforward.  Different models excel in different areas—some are\nfaster but less capable, others are more capable but more expensive, and so\non. This interface allows servers to express their priorities across multiple\ndimensions to help clients make an appropriate selection for their use case.\n\nThese preferences are always advisory. The client MAY ignore them. It is also\nup to the client to decide how to interpret these preferences and how to\nbalance them against other considerations.",
-            "properties": {
-                "costPriority": {
-                    "description": "How much to prioritize cost when selecting a model. A value of 0 means cost\nis not important, while a value of 1 means cost is the most important\nfactor.",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "hints": {
-                    "description": "Optional hints to use for model selection.\n\nIf multiple hints are specified, the client MUST evaluate them in order\n(such that the first match is taken).\n\nThe client SHOULD prioritize these hints over the numeric priorities, but\nMAY still use the priorities to select from ambiguous matches.",
-                    "items": {
-                        "$ref": "#/definitions/ModelHint"
-                    },
-                    "type": "array"
-                },
-                "intelligencePriority": {
-                    "description": "How much to prioritize intelligence and capabilities when selecting a\nmodel. A value of 0 means intelligence is not important, while a value of 1\nmeans intelligence is the most important factor.",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "speedPriority": {
-                    "description": "How much to prioritize sampling speed (latency) when selecting a model. A\nvalue of 0 means speed is not important, while a value of 1 means speed is\nthe most important factor.",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
-                }
-            },
-            "type": "object"
-        },
-        "Notification": {
-            "properties": {
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "NumberSchema": {
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "maximum": {
-                    "type": "integer"
-                },
-                "minimum": {
-                    "type": "integer"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "type": {
-                    "enum": [
-                        "integer",
-                        "number"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "type"
-            ],
-            "type": "object"
-        },
-        "PaginatedRequest": {
-            "properties": {
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "cursor": {
-                            "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "PaginatedResult": {
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "PingRequest": {
-            "description": "A ping, issued by either the server or the client, to check that the other party is still alive. The receiver must promptly respond, or else may be disconnected.",
-            "properties": {
-                "method": {
-                    "const": "ping",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                            "properties": {
-                                "progressToken": {
-                                    "$ref": "#/definitions/ProgressToken",
-                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                                }
-                            },
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "PrimitiveSchemaDefinition": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/StringSchema"
-                },
-                {
-                    "$ref": "#/definitions/NumberSchema"
-                },
-                {
-                    "$ref": "#/definitions/BooleanSchema"
-                },
-                {
-                    "$ref": "#/definitions/EnumSchema"
-                }
-            ],
-            "description": "Restricted schema definitions that only allow primitive types\nwithout nested objects or arrays."
-        },
-        "ProgressNotification": {
-            "description": "An out-of-band notification used to inform the receiver of a progress update for a long-running request.",
-            "properties": {
-                "method": {
-                    "const": "notifications/progress",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "message": {
-                            "description": "An optional message describing the current progress.",
-                            "type": "string"
-                        },
-                        "progress": {
-                            "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
-                            "type": "number"
-                        },
-                        "progressToken": {
-                            "$ref": "#/definitions/ProgressToken",
-                            "description": "The progress token which was given in the initial request, used to associate this notification with the request that is proceeding."
-                        },
-                        "total": {
-                            "description": "Total number of items to process (or total progress required), if known.",
-                            "type": "number"
-                        }
-                    },
-                    "required": [
-                        "progress",
-                        "progressToken"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ProgressToken": {
-            "description": "A progress token, used to associate progress notifications with the original request.",
-            "type": [
-                "string",
-                "integer"
-            ]
-        },
-        "Prompt": {
-            "description": "A prompt or prompt template that the server offers.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "arguments": {
-                    "description": "A list of arguments to use for templating the prompt.",
-                    "items": {
-                        "$ref": "#/definitions/PromptArgument"
-                    },
-                    "type": "array"
-                },
-                "description": {
-                    "description": "An optional description of what this prompt provides",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "type": "object"
-        },
-        "PromptArgument": {
-            "description": "Describes an argument that a prompt can accept.",
-            "properties": {
-                "description": {
-                    "description": "A human-readable description of the argument.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "required": {
-                    "description": "Whether this argument must be provided.",
-                    "type": "boolean"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "type": "object"
-        },
-        "PromptListChangedNotification": {
-            "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.",
-            "properties": {
-                "method": {
-                    "const": "notifications/prompts/list_changed",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "PromptMessage": {
-            "description": "Describes a message returned as part of a prompt.\n\nThis is similar to `SamplingMessage`, but also supports the embedding of\nresources from the MCP server.",
-            "properties": {
-                "content": {
-                    "$ref": "#/definitions/ContentBlock"
-                },
-                "role": {
-                    "$ref": "#/definitions/Role"
-                }
-            },
-            "required": [
-                "content",
-                "role"
-            ],
-            "type": "object"
-        },
-        "PromptReference": {
-            "description": "Identifies a prompt.",
-            "properties": {
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "ref/prompt",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "type"
-            ],
-            "type": "object"
-        },
-        "ReadResourceRequest": {
-            "description": "Sent from the client to the server, to read a specific resource URI.",
-            "properties": {
-                "method": {
-                    "const": "resources/read",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "uri": {
-                            "description": "The URI of the resource to read. The URI can use any protocol; it is up to the server how to interpret it.",
-                            "format": "uri",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "uri"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ReadResourceResult": {
-            "description": "The server's response to a resources/read request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "contents": {
-                    "items": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/definitions/TextResourceContents"
-                            },
-                            {
-                                "$ref": "#/definitions/BlobResourceContents"
-                            }
-                        ]
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "contents"
-            ],
-            "type": "object"
-        },
-        "Request": {
-            "properties": {
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                            "properties": {
-                                "progressToken": {
-                                    "$ref": "#/definitions/ProgressToken",
-                                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                                }
-                            },
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "RequestId": {
-            "description": "A uniquely identifying ID for a request in JSON-RPC.",
-            "type": [
-                "string",
-                "integer"
-            ]
-        },
-        "Resource": {
-            "description": "A known resource that the server is capable of reading.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "annotations": {
-                    "$ref": "#/definitions/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "description": {
-                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
-                    "type": "string"
-                },
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "size": {
-                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
-                    "type": "integer"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ResourceContents": {
-            "description": "The contents of a specific resource or sub-resource.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ResourceLink": {
-            "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of `resources/list` requests.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "annotations": {
-                    "$ref": "#/definitions/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "description": {
-                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
-                    "type": "string"
-                },
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "size": {
-                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
-                    "type": "integer"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "resource_link",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "type",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ResourceListChangedNotification": {
-            "description": "An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This may be issued by servers without any previous subscription from the client.",
-            "properties": {
-                "method": {
-                    "const": "notifications/resources/list_changed",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ResourceTemplate": {
-            "description": "A template description for resources available on the server.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "annotations": {
-                    "$ref": "#/definitions/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "description": {
-                    "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
-                    "type": "string"
-                },
-                "mimeType": {
-                    "description": "The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                },
-                "uriTemplate": {
-                    "description": "A URI template (according to RFC 6570) that can be used to construct resource URIs.",
-                    "format": "uri-template",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "uriTemplate"
-            ],
-            "type": "object"
-        },
-        "ResourceTemplateReference": {
-            "description": "A reference to a resource or resource template definition.",
-            "properties": {
-                "type": {
-                    "const": "ref/resource",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI or URI template of the resource.",
-                    "format": "uri-template",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "type",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ResourceUpdatedNotification": {
-            "description": "A notification from the server to the client, informing it that a resource has changed and may need to be read again. This should only be sent if the client previously sent a resources/subscribe request.",
-            "properties": {
-                "method": {
-                    "const": "notifications/resources/updated",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "uri": {
-                            "description": "The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.",
-                            "format": "uri",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "uri"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "Result": {
-            "additionalProperties": {},
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "Role": {
-            "description": "The sender or recipient of messages and data in a conversation.",
-            "enum": [
-                "assistant",
-                "user"
-            ],
-            "type": "string"
-        },
-        "Root": {
-            "description": "Represents a root directory or file that the server can operate on.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "name": {
-                    "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI identifying the root. This *must* start with file:// for now.\nThis restriction may be relaxed in future versions of the protocol to allow\nother URI schemes.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "uri"
-            ],
-            "type": "object"
-        },
-        "RootsListChangedNotification": {
-            "description": "A notification from the client to the server, informing it that the list of roots has changed.\nThis notification should be sent whenever the client adds, removes, or modifies any root.\nThe server should then request an updated list of roots using the ListRootsRequest.",
-            "properties": {
-                "method": {
-                    "const": "notifications/roots/list_changed",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "SamplingMessage": {
-            "description": "Describes a message issued to or received from an LLM API.",
-            "properties": {
-                "content": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/TextContent"
-                        },
-                        {
-                            "$ref": "#/definitions/ImageContent"
-                        },
-                        {
-                            "$ref": "#/definitions/AudioContent"
-                        }
-                    ]
-                },
-                "role": {
-                    "$ref": "#/definitions/Role"
-                }
-            },
-            "required": [
-                "content",
-                "role"
-            ],
-            "type": "object"
-        },
-        "ServerCapabilities": {
-            "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
-            "properties": {
-                "completions": {
-                    "additionalProperties": true,
-                    "description": "Present if the server supports argument autocompletion suggestions.",
-                    "properties": {},
-                    "type": "object"
-                },
-                "experimental": {
-                    "additionalProperties": {
-                        "additionalProperties": true,
-                        "properties": {},
-                        "type": "object"
-                    },
-                    "description": "Experimental, non-standard capabilities that the server supports.",
-                    "type": "object"
-                },
-                "logging": {
-                    "additionalProperties": true,
-                    "description": "Present if the server supports sending log messages to the client.",
-                    "properties": {},
-                    "type": "object"
-                },
-                "prompts": {
-                    "description": "Present if the server offers any prompt templates.",
-                    "properties": {
-                        "listChanged": {
-                            "description": "Whether this server supports notifications for changes to the prompt list.",
-                            "type": "boolean"
-                        }
-                    },
-                    "type": "object"
-                },
-                "resources": {
-                    "description": "Present if the server offers any resources to read.",
-                    "properties": {
-                        "listChanged": {
-                            "description": "Whether this server supports notifications for changes to the resource list.",
-                            "type": "boolean"
-                        },
-                        "subscribe": {
-                            "description": "Whether this server supports subscribing to resource updates.",
-                            "type": "boolean"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": {
-                    "description": "Present if the server offers any tools to call.",
-                    "properties": {
-                        "listChanged": {
-                            "description": "Whether this server supports notifications for changes to the tool list.",
-                            "type": "boolean"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "ServerNotification": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/CancelledNotification"
-                },
-                {
-                    "$ref": "#/definitions/ProgressNotification"
-                },
-                {
-                    "$ref": "#/definitions/ResourceListChangedNotification"
-                },
-                {
-                    "$ref": "#/definitions/ResourceUpdatedNotification"
-                },
-                {
-                    "$ref": "#/definitions/PromptListChangedNotification"
-                },
-                {
-                    "$ref": "#/definitions/ToolListChangedNotification"
-                },
-                {
-                    "$ref": "#/definitions/LoggingMessageNotification"
-                }
-            ]
-        },
-        "ServerRequest": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/PingRequest"
-                },
-                {
-                    "$ref": "#/definitions/CreateMessageRequest"
-                },
-                {
-                    "$ref": "#/definitions/ListRootsRequest"
-                },
-                {
-                    "$ref": "#/definitions/ElicitRequest"
-                }
-            ]
-        },
-        "ServerResult": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/Result"
-                },
-                {
-                    "$ref": "#/definitions/InitializeResult"
-                },
-                {
-                    "$ref": "#/definitions/ListResourcesResult"
-                },
-                {
-                    "$ref": "#/definitions/ListResourceTemplatesResult"
-                },
-                {
-                    "$ref": "#/definitions/ReadResourceResult"
-                },
-                {
-                    "$ref": "#/definitions/ListPromptsResult"
-                },
-                {
-                    "$ref": "#/definitions/GetPromptResult"
-                },
-                {
-                    "$ref": "#/definitions/ListToolsResult"
-                },
-                {
-                    "$ref": "#/definitions/CallToolResult"
-                },
-                {
-                    "$ref": "#/definitions/CompleteResult"
-                }
-            ]
-        },
-        "SetLevelRequest": {
-            "description": "A request from the client to the server, to enable or adjust logging.",
-            "properties": {
-                "method": {
-                    "const": "logging/setLevel",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "level": {
-                            "$ref": "#/definitions/LoggingLevel",
-                            "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message."
-                        }
-                    },
-                    "required": [
-                        "level"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "StringSchema": {
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "format": {
-                    "enum": [
-                        "date",
-                        "date-time",
-                        "email",
-                        "uri"
-                    ],
-                    "type": "string"
-                },
-                "maxLength": {
-                    "type": "integer"
-                },
-                "minLength": {
-                    "type": "integer"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "type": {
-                    "const": "string",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "type"
-            ],
-            "type": "object"
-        },
-        "SubscribeRequest": {
-            "description": "Sent from the client to request resources/updated notifications from the server whenever a particular resource changes.",
-            "properties": {
-                "method": {
-                    "const": "resources/subscribe",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "uri": {
-                            "description": "The URI of the resource to subscribe to. The URI can use any protocol; it is up to the server how to interpret it.",
-                            "format": "uri",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "uri"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "TextContent": {
-            "description": "Text provided to or from an LLM.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "annotations": {
-                    "$ref": "#/definitions/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "text": {
-                    "description": "The text content of the message.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "text",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "text",
-                "type"
-            ],
-            "type": "object"
-        },
-        "TextResourceContents": {
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "text": {
-                    "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "text",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "Tool": {
-            "description": "Definition for a tool the client can call.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "annotations": {
-                    "$ref": "#/definitions/ToolAnnotations",
-                    "description": "Optional additional tool information.\n\nDisplay name precedence order is: title, annotations.title, then name."
-                },
-                "description": {
-                    "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
-                    "type": "string"
-                },
-                "inputSchema": {
-                    "description": "A JSON Schema object defining the expected parameters for the tool.",
-                    "properties": {
-                        "properties": {
-                            "additionalProperties": {
-                                "additionalProperties": true,
-                                "properties": {},
-                                "type": "object"
-                            },
-                            "type": "object"
-                        },
-                        "required": {
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "type": {
-                            "const": "object",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "type"
-                    ],
-                    "type": "object"
-                },
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "outputSchema": {
-                    "description": "An optional JSON Schema object defining the structure of the tool's output returned in\nthe structuredContent field of a CallToolResult.",
-                    "properties": {
-                        "properties": {
-                            "additionalProperties": {
-                                "additionalProperties": true,
-                                "properties": {},
-                                "type": "object"
-                            },
-                            "type": "object"
-                        },
-                        "required": {
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "type": {
-                            "const": "object",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "type"
-                    ],
-                    "type": "object"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "inputSchema",
-                "name"
-            ],
-            "type": "object"
-        },
-        "ToolAnnotations": {
-            "description": "Additional properties describing a Tool to clients.\n\nNOTE: all properties in ToolAnnotations are **hints**.\nThey are not guaranteed to provide a faithful description of\ntool behavior (including descriptive properties like `title`).\n\nClients should never make tool use decisions based on ToolAnnotations\nreceived from untrusted servers.",
-            "properties": {
-                "destructiveHint": {
-                    "description": "If true, the tool may perform destructive updates to its environment.\nIf false, the tool performs only additive updates.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: true",
-                    "type": "boolean"
-                },
-                "idempotentHint": {
-                    "description": "If true, calling the tool repeatedly with the same arguments\nwill have no additional effect on the its environment.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: false",
-                    "type": "boolean"
-                },
-                "openWorldHint": {
-                    "description": "If true, this tool may interact with an \"open world\" of external\nentities. If false, the tool's domain of interaction is closed.\nFor example, the world of a web search tool is open, whereas that\nof a memory tool is not.\n\nDefault: true",
-                    "type": "boolean"
-                },
-                "readOnlyHint": {
-                    "description": "If true, the tool does not modify its environment.\n\nDefault: false",
-                    "type": "boolean"
-                },
-                "title": {
-                    "description": "A human-readable title for the tool.",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "ToolListChangedNotification": {
-            "description": "An optional notification from the server to the client, informing it that the list of tools it offers has changed. This may be issued by servers without any previous subscription from the client.",
-            "properties": {
-                "method": {
-                    "const": "notifications/tools/list_changed",
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "properties": {
-                        "_meta": {
-                            "additionalProperties": {},
-                            "description": "See [General fields: `_meta`](/specification/2025-06-18/basic/index#meta) for notes on `_meta` usage.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "UnsubscribeRequest": {
-            "description": "Sent from the client to request cancellation of resources/updated notifications from the server. This should follow a previous resources/subscribe request.",
-            "properties": {
-                "method": {
-                    "const": "resources/unsubscribe",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "uri": {
-                            "description": "The URI of the resource to unsubscribe from.",
-                            "format": "uri",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "uri"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
         }
     }
 }
-

--- a/schema/2025-11-25/schema.json
+++ b/schema/2025-11-25/schema.json
@@ -1,64 +1,691 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$defs": {
-        "Annotations": {
-            "description": "Optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
-            "properties": {
-                "audience": {
-                    "description": "Describes who the intended audience of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
-                    "items": {
-                        "$ref": "#/$defs/Role"
-                    },
-                    "type": "array"
+        "JSONRPCMessage": {
+            "description": "Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent.",
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/JSONRPCRequest"
                 },
-                "lastModified": {
-                    "description": "The moment the resource was last modified, as an ISO 8601 formatted string.\n\nShould be an ISO 8601 formatted string (e.g., \"2025-01-12T15:00:58Z\").\n\nExamples: last activity timestamp in an open file, timestamp when the resource\nwas attached, etc.",
-                    "type": "string"
+                {
+                    "$ref": "#/$defs/JSONRPCNotification"
                 },
-                "priority": {
-                    "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
+                {
+                    "$ref": "#/$defs/JSONRPCResultResponse"
+                },
+                {
+                    "$ref": "#/$defs/JSONRPCErrorResponse"
                 }
-            },
-            "type": "object"
+            ]
         },
-        "AudioContent": {
-            "description": "Audio provided to or from an LLM.",
+        "ProgressToken": {
+            "description": "A progress token, used to associate progress notifications with the original request.",
+            "type": [
+                "string",
+                "integer"
+            ]
+        },
+        "Cursor": {
+            "description": "An opaque token used to represent a cursor for pagination.",
+            "type": "string"
+        },
+        "TaskAugmentedRequestParams": {
+            "description": "Common params for any task-augmented request.",
+            "type": "object",
+            "properties": {
+                "task": {
+                    "$ref": "#/$defs/TaskMetadata",
+                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    }
+                }
+            }
+        },
+        "RequestParams": {
+            "description": "Common params for any request.",
+            "type": "object",
             "properties": {
                 "_meta": {
-                    "additionalProperties": {},
                     "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    }
+                }
+            }
+        },
+        "NotificationParams": {
+            "type": "object",
+            "properties": {
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            }
+        },
+        "Notification": {
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string"
                 },
-                "annotations": {
-                    "$ref": "#/$defs/Annotations",
-                    "description": "Optional annotations for the client."
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "Result": {
+            "type": "object",
+            "additionalProperties": {},
+            "properties": {
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            }
+        },
+        "Error": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "description": "The error type that occurred.",
+                    "type": "integer"
+                },
+                "message": {
+                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+                    "type": "string"
                 },
                 "data": {
-                    "description": "The base64-encoded audio data.",
-                    "format": "byte",
+                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+                }
+            },
+            "required": [
+                "code",
+                "message"
+            ]
+        },
+        "RequestId": {
+            "description": "A uniquely identifying ID for a request in JSON-RPC.",
+            "type": [
+                "string",
+                "integer"
+            ]
+        },
+        "JSONRPCRequest": {
+            "description": "A request that expects a response.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "JSONRPCNotification": {
+            "description": "A notification which does not expect a response.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "JSONRPCResultResponse": {
+            "description": "A successful (non-error) response to a request.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "result": {
+                    "$ref": "#/$defs/Result"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ]
+        },
+        "JSONRPCErrorResponse": {
+            "description": "A response to a request that indicates an error occurred.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "error": {
+                    "$ref": "#/$defs/Error"
+                }
+            },
+            "required": [
+                "error",
+                "jsonrpc"
+            ]
+        },
+        "JSONRPCResponse": {
+            "description": "A response to a request, containing either the result or error.",
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/JSONRPCResultResponse"
+                },
+                {
+                    "$ref": "#/$defs/JSONRPCErrorResponse"
+                }
+            ]
+        },
+        "URLElicitationRequiredError": {
+            "description": "An error response that indicates that the server requires the client to provide additional information via an elicitation request.",
+            "type": "object",
+            "properties": {
+                "error": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/Error"
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "code": {
+                                    "type": "integer",
+                                    "const": -32042
+                                },
+                                "data": {
+                                    "type": "object",
+                                    "additionalProperties": {},
+                                    "properties": {
+                                        "elicitations": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/$defs/ElicitRequestURLParams"
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "elicitations"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "code",
+                                "data"
+                            ]
+                        }
+                    ]
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "error",
+                "jsonrpc"
+            ]
+        },
+        "EmptyResult": {
+            "$ref": "#/$defs/Result"
+        },
+        "CancelledNotificationParams": {
+            "description": "Parameters for a `notifications/cancelled` notification.",
+            "type": "object",
+            "properties": {
+                "requestId": {
+                    "$ref": "#/$defs/RequestId",
+                    "description": "The ID of the request to cancel.\n\nThis MUST correspond to the ID of a request previously issued in the same direction.\nThis MUST be provided for cancelling non-task requests.\nThis MUST NOT be used for cancelling tasks (use the `tasks/cancel` request instead)."
+                },
+                "reason": {
+                    "description": "An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            }
+        },
+        "CancelledNotification": {
+            "description": "This notification can be sent by either side to indicate that it is cancelling a previously-issued request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.\n\nA client MUST NOT attempt to cancel its `initialize` request.\n\nFor task cancellation, use the `tasks/cancel` request instead of this notification.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/cancelled"
+                },
+                "params": {
+                    "$ref": "#/$defs/CancelledNotificationParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "InitializeRequestParams": {
+            "description": "Parameters for an `initialize` request.",
+            "type": "object",
+            "properties": {
+                "protocolVersion": {
+                    "description": "The latest version of the Model Context Protocol that the client supports. The client MAY decide to support older versions as well.",
+                    "type": "string"
+                },
+                "capabilities": {
+                    "$ref": "#/$defs/ClientCapabilities"
+                },
+                "clientInfo": {
+                    "$ref": "#/$defs/Implementation"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    }
+                }
+            },
+            "required": [
+                "capabilities",
+                "clientInfo",
+                "protocolVersion"
+            ]
+        },
+        "InitializeRequest": {
+            "description": "This request is sent from the client to the server when it first connects, asking it to begin initialization.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "initialize"
+                },
+                "params": {
+                    "$ref": "#/$defs/InitializeRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "InitializeResult": {
+            "description": "After receiving an initialize request from the client, the server sends this response.",
+            "type": "object",
+            "properties": {
+                "protocolVersion": {
+                    "description": "The version of the Model Context Protocol that the server wants to use. This may not match the version that the client requested. If the client cannot support this version, it MUST disconnect.",
+                    "type": "string"
+                },
+                "capabilities": {
+                    "$ref": "#/$defs/ServerCapabilities"
+                },
+                "serverInfo": {
+                    "$ref": "#/$defs/Implementation"
+                },
+                "instructions": {
+                    "description": "Instructions describing how to use the server and its features.\n\nThis can be used by clients to improve the LLM's understanding of available tools, resources, etc. It can be thought of like a \"hint\" to the model. For example, this information MAY be added to the system prompt.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "capabilities",
+                "protocolVersion",
+                "serverInfo"
+            ]
+        },
+        "InitializedNotification": {
+            "description": "This notification is sent from the client to the server after initialization has finished.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/initialized"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "ClientCapabilities": {
+            "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
+            "type": "object",
+            "properties": {
+                "experimental": {
+                    "description": "Experimental, non-standard capabilities that the client supports.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": true
+                    }
+                },
+                "roots": {
+                    "description": "Present if the client supports listing roots.",
+                    "type": "object",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether the client supports notifications for changes to the roots list.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "sampling": {
+                    "description": "Present if the client supports sampling from an LLM.",
+                    "type": "object",
+                    "properties": {
+                        "context": {
+                            "description": "Whether the client supports context inclusion via includeContext parameter.\nIf not declared, servers SHOULD only use `includeContext: \"none\"` (or omit it).",
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": true
+                        },
+                        "tools": {
+                            "description": "Whether the client supports tool use via tools and toolChoice parameters.",
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": true
+                        }
+                    }
+                },
+                "elicitation": {
+                    "description": "Present if the client supports elicitation from the server.",
+                    "type": "object",
+                    "properties": {
+                        "form": {
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": true
+                        },
+                        "url": {
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": true
+                        }
+                    }
+                },
+                "tasks": {
+                    "description": "Present if the client supports task-augmented requests.",
+                    "type": "object",
+                    "properties": {
+                        "list": {
+                            "description": "Whether this client supports tasks/list.",
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": true
+                        },
+                        "cancel": {
+                            "description": "Whether this client supports tasks/cancel.",
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": true
+                        },
+                        "requests": {
+                            "description": "Specifies which request types can be augmented with tasks.",
+                            "type": "object",
+                            "properties": {
+                                "sampling": {
+                                    "description": "Task support for sampling-related requests.",
+                                    "type": "object",
+                                    "properties": {
+                                        "createMessage": {
+                                            "description": "Whether the client supports task-augmented sampling/createMessage requests.",
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": true
+                                        }
+                                    }
+                                },
+                                "elicitation": {
+                                    "description": "Task support for elicitation-related requests.",
+                                    "type": "object",
+                                    "properties": {
+                                        "create": {
+                                            "description": "Whether the client supports task-augmented elicitation/create requests.",
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": true
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "ServerCapabilities": {
+            "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
+            "type": "object",
+            "properties": {
+                "experimental": {
+                    "description": "Experimental, non-standard capabilities that the server supports.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": true
+                    }
+                },
+                "logging": {
+                    "description": "Present if the server supports sending log messages to the client.",
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true
+                },
+                "completions": {
+                    "description": "Present if the server supports argument autocompletion suggestions.",
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true
+                },
+                "prompts": {
+                    "description": "Present if the server offers any prompt templates.",
+                    "type": "object",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the prompt list.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "resources": {
+                    "description": "Present if the server offers any resources to read.",
+                    "type": "object",
+                    "properties": {
+                        "subscribe": {
+                            "description": "Whether this server supports subscribing to resource updates.",
+                            "type": "boolean"
+                        },
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the resource list.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "tools": {
+                    "description": "Present if the server offers any tools to call.",
+                    "type": "object",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the tool list.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "tasks": {
+                    "description": "Present if the server supports task-augmented requests.",
+                    "type": "object",
+                    "properties": {
+                        "list": {
+                            "description": "Whether this server supports tasks/list.",
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": true
+                        },
+                        "cancel": {
+                            "description": "Whether this server supports tasks/cancel.",
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": true
+                        },
+                        "requests": {
+                            "description": "Specifies which request types can be augmented with tasks.",
+                            "type": "object",
+                            "properties": {
+                                "tools": {
+                                    "description": "Task support for tool-related requests.",
+                                    "type": "object",
+                                    "properties": {
+                                        "call": {
+                                            "description": "Whether the server supports task-augmented tools/call requests.",
+                                            "type": "object",
+                                            "properties": {},
+                                            "additionalProperties": true
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "Icon": {
+            "description": "An optionally-sized icon that can be displayed in a user interface.",
+            "type": "object",
+            "properties": {
+                "src": {
+                    "description": "A standard URI pointing to an icon resource. May be an HTTP/HTTPS URL or a\n`data:` URI with Base64-encoded image data.\n\nConsumers SHOULD takes steps to ensure URLs serving icons are from the\nsame domain as the client/server or a trusted domain.\n\nConsumers SHOULD take appropriate precautions when consuming SVGs as they can contain\nexecutable JavaScript.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "mimeType": {
-                    "description": "The MIME type of the audio. Different providers may support different audio types.",
+                    "description": "Optional MIME type override if the source MIME type is missing or generic.\nFor example: `\"image/png\"`, `\"image/jpeg\"`, or `\"image/svg+xml\"`.",
                     "type": "string"
                 },
-                "type": {
-                    "const": "audio",
+                "sizes": {
+                    "description": "Optional array of strings that specify sizes at which the icon can be used.\nEach string should be in WxH format (e.g., `\"48x48\"`, `\"96x96\"`) or `\"any\"` for scalable formats like SVG.\n\nIf not provided, the client should assume that the icon can be used at any size.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "theme": {
+                    "description": "Optional specifier for the theme this icon is designed for. `light` indicates\nthe icon is designed to be used with a light background, and `dark` indicates\nthe icon is designed to be used with a dark background.\n\nIf not provided, the client should assume the icon can be used with any theme.",
+                    "enum": [
+                        "dark",
+                        "light"
+                    ],
                     "type": "string"
                 }
             },
             "required": [
-                "data",
-                "mimeType",
-                "type"
-            ],
-            "type": "object"
+                "src"
+            ]
+        },
+        "Icons": {
+            "description": "Base interface to add `icons` property.",
+            "type": "object",
+            "properties": {
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    }
+                }
+            }
         },
         "BaseMetadata": {
             "description": "Base interface for metadata with name (identifier) and title (display name) properties.",
+            "type": "object",
             "properties": {
                 "name": {
                     "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
@@ -71,74 +698,346 @@
             },
             "required": [
                 "name"
-            ],
-            "type": "object"
+            ]
         },
-        "BlobResourceContents": {
+        "Implementation": {
+            "description": "Describes the MCP implementation.",
+            "type": "object",
             "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "blob": {
-                    "description": "A base64-encoded string representing the binary data of the item.",
-                    "format": "byte",
+                "version": {
                     "type": "string"
-                },
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "blob",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "BooleanSchema": {
-            "properties": {
-                "default": {
-                    "type": "boolean"
                 },
                 "description": {
+                    "description": "An optional human-readable description of what this implementation does.\n\nThis can be used by clients or servers to provide context about their purpose\nand capabilities. For example, a server might describe the types of resources\nor tools it provides, while a client might describe its intended use case.",
+                    "type": "string"
+                },
+                "websiteUrl": {
+                    "description": "An optional URL of the website for this implementation.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
                     "type": "string"
                 },
                 "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
                     "type": "string"
                 },
-                "type": {
-                    "const": "boolean",
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "version"
+            ]
+        },
+        "PingRequest": {
+            "description": "A ping, issued by either the server or the client, to check that the other party is still alive. The receiver must promptly respond, or else may be disconnected.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "ping"
+                },
+                "params": {
+                    "$ref": "#/$defs/RequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "ProgressNotificationParams": {
+            "description": "Parameters for a `notifications/progress` notification.",
+            "type": "object",
+            "properties": {
+                "progressToken": {
+                    "$ref": "#/$defs/ProgressToken",
+                    "description": "The progress token which was given in the initial request, used to associate this notification with the request that is proceeding."
+                },
+                "progress": {
+                    "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
+                    "type": "number"
+                },
+                "total": {
+                    "description": "Total number of items to process (or total progress required), if known.",
+                    "type": "number"
+                },
+                "message": {
+                    "description": "An optional message describing the current progress.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "progress",
+                "progressToken"
+            ]
+        },
+        "ProgressNotification": {
+            "description": "An out-of-band notification used to inform the receiver of a progress update for a long-running request.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/progress"
+                },
+                "params": {
+                    "$ref": "#/$defs/ProgressNotificationParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "PaginatedRequestParams": {
+            "description": "Common parameters for paginated requests.",
+            "type": "object",
+            "properties": {
+                "cursor": {
+                    "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    }
+                }
+            }
+        },
+        "PaginatedRequest": {
+            "type": "object",
+            "properties": {
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "method": {
                     "type": "string"
                 }
             },
             "required": [
-                "type"
-            ],
-            "type": "object"
+                "id",
+                "jsonrpc",
+                "method"
+            ]
         },
-        "CallToolRequest": {
-            "description": "Used by the client to invoke a tool provided by the server.",
+        "PaginatedResult": {
+            "type": "object",
             "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
                     "type": "string"
                 },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            }
+        },
+        "ListResourcesRequest": {
+            "description": "Sent from the client to request a list of resources the server has.",
+            "type": "object",
+            "properties": {
                 "method": {
-                    "const": "tools/call",
-                    "type": "string"
+                    "type": "string",
+                    "const": "resources/list"
                 },
                 "params": {
-                    "$ref": "#/$defs/CallToolRequestParams"
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "ListResourcesResult": {
+            "description": "The server's response to a resources/list request from the client.",
+            "type": "object",
+            "properties": {
+                "resources": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Resource"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "resources"
+            ]
+        },
+        "ListResourceTemplatesRequest": {
+            "description": "Sent from the client to request a list of resource templates the server has.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/templates/list"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "ListResourceTemplatesResult": {
+            "description": "The server's response to a resources/templates/list request from the client.",
+            "type": "object",
+            "properties": {
+                "resourceTemplates": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/ResourceTemplate"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "resourceTemplates"
+            ]
+        },
+        "ResourceRequestParams": {
+            "description": "Common parameters when working with resources.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    }
+                }
+            },
+            "required": [
+                "uri"
+            ]
+        },
+        "ReadResourceRequestParams": {
+            "description": "Parameters for a `resources/read` request.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    }
+                }
+            },
+            "required": [
+                "uri"
+            ]
+        },
+        "ReadResourceRequest": {
+            "description": "Sent from the client to the server, to read a specific resource URI.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/read"
+                },
+                "params": {
+                    "$ref": "#/$defs/ReadResourceRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
                 }
             },
             "required": [
@@ -146,87 +1045,1153 @@
                 "jsonrpc",
                 "method",
                 "params"
-            ],
-            "type": "object"
+            ]
         },
-        "CallToolRequestParams": {
-            "description": "Parameters for a `tools/call` request.",
+        "ReadResourceResult": {
+            "description": "The server's response to a resources/read request from the client.",
+            "type": "object",
             "properties": {
+                "contents": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/$defs/TextResourceContents"
+                            },
+                            {
+                                "$ref": "#/$defs/BlobResourceContents"
+                            }
+                        ]
+                    }
+                },
                 "_meta": {
-                    "additionalProperties": {},
                     "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "contents"
+            ]
+        },
+        "ResourceListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This may be issued by servers without any previous subscription from the client.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/resources/list_changed"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "SubscribeRequestParams": {
+            "description": "Parameters for a `resources/subscribe` request.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {},
                     "properties": {
                         "progressToken": {
                             "$ref": "#/$defs/ProgressToken",
                             "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
                         }
-                    },
-                    "type": "object"
+                    }
+                }
+            },
+            "required": [
+                "uri"
+            ]
+        },
+        "SubscribeRequest": {
+            "description": "Sent from the client to request resources/updated notifications from the server whenever a particular resource changes.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/subscribe"
                 },
-                "arguments": {
-                    "additionalProperties": {},
-                    "description": "Arguments to use for the tool call.",
-                    "type": "object"
+                "params": {
+                    "$ref": "#/$defs/SubscribeRequestParams"
                 },
-                "name": {
-                    "description": "The name of the tool.",
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "UnsubscribeRequestParams": {
+            "description": "Parameters for a `resources/unsubscribe` request.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+                    "format": "uri",
                     "type": "string"
                 },
-                "task": {
-                    "$ref": "#/$defs/TaskMetadata",
-                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    }
+                }
+            },
+            "required": [
+                "uri"
+            ]
+        },
+        "UnsubscribeRequest": {
+            "description": "Sent from the client to request cancellation of resources/updated notifications from the server. This should follow a previous resources/subscribe request.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/unsubscribe"
+                },
+                "params": {
+                    "$ref": "#/$defs/UnsubscribeRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "ResourceUpdatedNotificationParams": {
+            "description": "Parameters for a `notifications/resources/updated` notification.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "uri"
+            ]
+        },
+        "ResourceUpdatedNotification": {
+            "description": "A notification from the server to the client, informing it that a resource has changed and may need to be read again. This should only be sent if the client previously sent a resources/subscribe request.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/resources/updated"
+                },
+                "params": {
+                    "$ref": "#/$defs/ResourceUpdatedNotificationParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "ResourceTemplate": {
+            "description": "A template description for resources available on the server.",
+            "type": "object",
+            "properties": {
+                "uriTemplate": {
+                    "description": "A URI template (according to RFC 6570) that can be used to construct resource URIs.",
+                    "format": "uri-template",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "uriTemplate"
+            ]
+        },
+        "ResourceContents": {
+            "description": "The contents of a specific resource or sub-resource.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "uri"
+            ]
+        },
+        "TextResourceContents": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "text",
+                "uri"
+            ]
+        },
+        "BlobResourceContents": {
+            "type": "object",
+            "properties": {
+                "blob": {
+                    "description": "A base64-encoded string representing the binary data of the item.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "blob",
+                "uri"
+            ]
+        },
+        "ListPromptsRequest": {
+            "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "prompts/list"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "ListPromptsResult": {
+            "description": "The server's response to a prompts/list request from the client.",
+            "type": "object",
+            "properties": {
+                "prompts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Prompt"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "prompts"
+            ]
+        },
+        "GetPromptRequestParams": {
+            "description": "Parameters for a `prompts/get` request.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The name of the prompt or prompt template.",
+                    "type": "string"
+                },
+                "arguments": {
+                    "description": "Arguments to use for templating the prompt.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    }
                 }
             },
             "required": [
                 "name"
+            ]
+        },
+        "GetPromptRequest": {
+            "description": "Used by the client to get a prompt provided by the server.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "prompts/get"
+                },
+                "params": {
+                    "$ref": "#/$defs/GetPromptRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "GetPromptResult": {
+            "description": "The server's response to a prompts/get request from the client.",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "An optional description for the prompt.",
+                    "type": "string"
+                },
+                "messages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/PromptMessage"
+                    }
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "messages"
+            ]
+        },
+        "Prompt": {
+            "description": "A prompt or prompt template that the server offers.",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "An optional description of what this prompt provides",
+                    "type": "string"
+                },
+                "arguments": {
+                    "description": "A list of arguments to use for templating the prompt.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/PromptArgument"
+                    }
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    }
+                }
+            },
+            "required": [
+                "name"
+            ]
+        },
+        "PromptArgument": {
+            "description": "Describes an argument that a prompt can accept.",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "A human-readable description of the argument.",
+                    "type": "string"
+                },
+                "required": {
+                    "description": "Whether this argument must be provided.",
+                    "type": "boolean"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ]
+        },
+        "Role": {
+            "description": "The sender or recipient of messages and data in a conversation.",
+            "enum": [
+                "assistant",
+                "user"
             ],
-            "type": "object"
+            "type": "string"
+        },
+        "PromptMessage": {
+            "description": "Describes a message returned as part of a prompt.\n\nThis is similar to `SamplingMessage`, but also supports the embedding of\nresources from the MCP server.",
+            "type": "object",
+            "properties": {
+                "role": {
+                    "$ref": "#/$defs/Role"
+                },
+                "content": {
+                    "$ref": "#/$defs/ContentBlock"
+                }
+            },
+            "required": [
+                "content",
+                "role"
+            ]
+        },
+        "ResourceLink": {
+            "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of `resources/list` requests.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "resource_link"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "size": {
+                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+                    "type": "integer"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "type",
+                "uri"
+            ]
+        },
+        "EmbeddedResource": {
+            "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "resource"
+                },
+                "resource": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TextResourceContents"
+                        },
+                        {
+                            "$ref": "#/$defs/BlobResourceContents"
+                        }
+                    ]
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "resource",
+                "type"
+            ]
+        },
+        "PromptListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/prompts/list_changed"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "ListToolsRequest": {
+            "description": "Sent from the client to request a list of tools the server has.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "tools/list"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "ListToolsResult": {
+            "description": "The server's response to a tools/list request from the client.",
+            "type": "object",
+            "properties": {
+                "tools": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Tool"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "tools"
+            ]
         },
         "CallToolResult": {
             "description": "The server's response to a tool call.",
+            "type": "object",
             "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
                 "content": {
                     "description": "A list of content objects that represent the unstructured result of the tool call.",
+                    "type": "array",
                     "items": {
                         "$ref": "#/$defs/ContentBlock"
-                    },
-                    "type": "array"
+                    }
+                },
+                "structuredContent": {
+                    "description": "An optional JSON object that represents the structured result of the tool call.",
+                    "type": "object",
+                    "additionalProperties": {}
                 },
                 "isError": {
                     "description": "Whether the tool call ended in an error.\n\nIf not set, this is assumed to be false (the call was successful).\n\nAny errors that originate from the tool SHOULD be reported inside the result\nobject, with `isError` set to true, _not_ as an MCP protocol-level error\nresponse. Otherwise, the LLM would not be able to see that an error occurred\nand self-correct.\n\nHowever, any errors in _finding_ the tool, an error indicating that the\nserver does not support tool calls, or any other exceptional conditions,\nshould be reported as an MCP error response.",
                     "type": "boolean"
                 },
-                "structuredContent": {
-                    "additionalProperties": {},
-                    "description": "An optional JSON object that represents the structured result of the tool call.",
-                    "type": "object"
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
                 }
             },
             "required": [
                 "content"
+            ]
+        },
+        "CallToolRequestParams": {
+            "description": "Parameters for a `tools/call` request.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The name of the tool.",
+                    "type": "string"
+                },
+                "arguments": {
+                    "description": "Arguments to use for the tool call.",
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "task": {
+                    "$ref": "#/$defs/TaskMetadata",
+                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    }
+                }
+            },
+            "required": [
+                "name"
+            ]
+        },
+        "CallToolRequest": {
+            "description": "Used by the client to invoke a tool provided by the server.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "tools/call"
+                },
+                "params": {
+                    "$ref": "#/$defs/CallToolRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "ToolListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of tools it offers has changed. This may be issued by servers without any previous subscription from the client.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/tools/list_changed"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "ToolAnnotations": {
+            "description": "Additional properties describing a Tool to clients.\n\nNOTE: all properties in ToolAnnotations are **hints**.\nThey are not guaranteed to provide a faithful description of\ntool behavior (including descriptive properties like `title`).\n\nClients should never make tool use decisions based on ToolAnnotations\nreceived from untrusted servers.",
+            "type": "object",
+            "properties": {
+                "title": {
+                    "description": "A human-readable title for the tool.",
+                    "type": "string"
+                },
+                "readOnlyHint": {
+                    "description": "If true, the tool does not modify its environment.\n\nDefault: false",
+                    "type": "boolean"
+                },
+                "destructiveHint": {
+                    "description": "If true, the tool may perform destructive updates to its environment.\nIf false, the tool performs only additive updates.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: true",
+                    "type": "boolean"
+                },
+                "idempotentHint": {
+                    "description": "If true, calling the tool repeatedly with the same arguments\nwill have no additional effect on its environment.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: false",
+                    "type": "boolean"
+                },
+                "openWorldHint": {
+                    "description": "If true, this tool may interact with an \"open world\" of external\nentities. If false, the tool's domain of interaction is closed.\nFor example, the world of a web search tool is open, whereas that\nof a memory tool is not.\n\nDefault: true",
+                    "type": "boolean"
+                }
+            }
+        },
+        "ToolExecution": {
+            "description": "Execution-related properties for a tool.",
+            "type": "object",
+            "properties": {
+                "taskSupport": {
+                    "description": "Indicates whether this tool supports task-augmented execution.\nThis allows clients to handle long-running operations through polling\nthe task system.\n\n- \"forbidden\": Tool does not support task-augmented execution (default when absent)\n- \"optional\": Tool may support task-augmented execution\n- \"required\": Tool requires task-augmented execution\n\nDefault: \"forbidden\"",
+                    "enum": [
+                        "forbidden",
+                        "optional",
+                        "required"
+                    ],
+                    "type": "string"
+                }
+            }
+        },
+        "Tool": {
+            "description": "Definition for a tool the client can call.",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "inputSchema": {
+                    "description": "A JSON Schema object defining the expected parameters for the tool.",
+                    "type": "object",
+                    "properties": {
+                        "$schema": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string",
+                            "const": "object"
+                        },
+                        "properties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": true
+                            }
+                        },
+                        "required": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ]
+                },
+                "execution": {
+                    "$ref": "#/$defs/ToolExecution",
+                    "description": "Execution-related properties for this tool."
+                },
+                "outputSchema": {
+                    "description": "An optional JSON Schema object defining the structure of the tool's output returned in\nthe structuredContent field of a CallToolResult.\n\nDefaults to JSON Schema 2020-12 when no explicit $schema is provided.\nCurrently restricted to type: \"object\" at the root level.",
+                    "type": "object",
+                    "properties": {
+                        "$schema": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string",
+                            "const": "object"
+                        },
+                        "properties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": true
+                            }
+                        },
+                        "required": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ]
+                },
+                "annotations": {
+                    "$ref": "#/$defs/ToolAnnotations",
+                    "description": "Optional additional tool information.\n\nDisplay name precedence order is: title, annotations.title, then name."
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    }
+                }
+            },
+            "required": [
+                "inputSchema",
+                "name"
+            ]
+        },
+        "TaskStatus": {
+            "description": "The status of a task.",
+            "enum": [
+                "cancelled",
+                "completed",
+                "failed",
+                "input_required",
+                "working"
             ],
-            "type": "object"
+            "type": "string"
+        },
+        "TaskMetadata": {
+            "description": "Metadata for augmenting a request with task execution.\nInclude this in the `task` field of the request parameters.",
+            "type": "object",
+            "properties": {
+                "ttl": {
+                    "description": "Requested duration in milliseconds to retain task from creation.",
+                    "type": "integer"
+                }
+            }
+        },
+        "RelatedTaskMetadata": {
+            "description": "Metadata for associating messages with a task.\nInclude this in the `_meta` field under the key `io.modelcontextprotocol/related-task`.",
+            "type": "object",
+            "properties": {
+                "taskId": {
+                    "description": "The task identifier this message is associated with.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "taskId"
+            ]
+        },
+        "Task": {
+            "description": "Data associated with a task.",
+            "type": "object",
+            "properties": {
+                "taskId": {
+                    "description": "The task identifier.",
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/$defs/TaskStatus",
+                    "description": "Current task state."
+                },
+                "statusMessage": {
+                    "description": "Optional human-readable message describing the current task state.\nThis can provide context for any status, including:\n- Reasons for \"cancelled\" status\n- Summaries for \"completed\" status\n- Diagnostic information for \"failed\" status (e.g., error details, what went wrong)",
+                    "type": "string"
+                },
+                "createdAt": {
+                    "description": "ISO 8601 timestamp when the task was created.",
+                    "type": "string"
+                },
+                "lastUpdatedAt": {
+                    "description": "ISO 8601 timestamp when the task was last updated.",
+                    "type": "string"
+                },
+                "ttl": {
+                    "description": "Actual retention duration from creation in milliseconds, null for unlimited.",
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "pollInterval": {
+                    "description": "Suggested polling interval in milliseconds.",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "createdAt",
+                "lastUpdatedAt",
+                "status",
+                "taskId",
+                "ttl"
+            ]
+        },
+        "CreateTaskResult": {
+            "description": "A response to a task-augmented request.",
+            "type": "object",
+            "properties": {
+                "task": {
+                    "$ref": "#/$defs/Task"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "task"
+            ]
+        },
+        "GetTaskRequest": {
+            "description": "A request to retrieve the state of a task.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "tasks/get"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "taskId": {
+                            "description": "The task identifier to query.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "taskId"
+                    ]
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "GetTaskResult": {
+            "description": "The response to a tasks/get request.",
+            "allOf": [
+                {
+                    "$ref": "#/$defs/Result"
+                },
+                {
+                    "$ref": "#/$defs/Task"
+                }
+            ]
+        },
+        "GetTaskPayloadRequest": {
+            "description": "A request to retrieve the result of a completed task.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "tasks/result"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "taskId": {
+                            "description": "The task identifier to retrieve results for.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "taskId"
+                    ]
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "GetTaskPayloadResult": {
+            "description": "The response to a tasks/result request.\nThe structure matches the result type of the original request.\nFor example, a tools/call task would return the CallToolResult structure.",
+            "type": "object",
+            "additionalProperties": {},
+            "properties": {
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            }
         },
         "CancelTaskRequest": {
             "description": "A request to cancel a task.",
+            "type": "object",
             "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
                 "method": {
-                    "const": "tasks/cancel",
-                    "type": "string"
+                    "type": "string",
+                    "const": "tasks/cancel"
                 },
                 "params": {
+                    "type": "object",
                     "properties": {
                         "taskId": {
                             "description": "The task identifier to cancel.",
@@ -235,8 +2200,14 @@
                     },
                     "required": [
                         "taskId"
-                    ],
-                    "type": "object"
+                    ]
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
                 }
             },
             "required": [
@@ -244,10 +2215,10 @@
                 "jsonrpc",
                 "method",
                 "params"
-            ],
-            "type": "object"
+            ]
         },
         "CancelTaskResult": {
+            "description": "The response to a tasks/cancel request.",
             "allOf": [
                 {
                     "$ref": "#/$defs/Result"
@@ -255,156 +2226,1532 @@
                 {
                     "$ref": "#/$defs/Task"
                 }
-            ],
-            "description": "The response to a tasks/cancel request."
+            ]
         },
-        "CancelledNotification": {
-            "description": "This notification can be sent by either side to indicate that it is cancelling a previously-issued request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.\n\nA client MUST NOT attempt to cancel its `initialize` request.\n\nFor task cancellation, use the `tasks/cancel` request instead of this notification.",
+        "ListTasksRequest": {
+            "description": "A request to retrieve a list of tasks.",
+            "type": "object",
             "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
                 "method": {
-                    "const": "notifications/cancelled",
-                    "type": "string"
+                    "type": "string",
+                    "const": "tasks/list"
                 },
                 "params": {
-                    "$ref": "#/$defs/CancelledNotificationParams"
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "ListTasksResult": {
+            "description": "The response to a tasks/list request.",
+            "type": "object",
+            "properties": {
+                "tasks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Task"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "tasks"
+            ]
+        },
+        "TaskStatusNotificationParams": {
+            "description": "Parameters for a `notifications/tasks/status` notification.",
+            "allOf": [
+                {
+                    "$ref": "#/$defs/NotificationParams"
+                },
+                {
+                    "$ref": "#/$defs/Task"
+                }
+            ]
+        },
+        "TaskStatusNotification": {
+            "description": "An optional notification from the receiver to the requestor, informing them that a task's status has changed. Receivers are not required to send these notifications.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/tasks/status"
+                },
+                "params": {
+                    "$ref": "#/$defs/TaskStatusNotificationParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
                 }
             },
             "required": [
                 "jsonrpc",
                 "method",
                 "params"
-            ],
-            "type": "object"
+            ]
         },
-        "CancelledNotificationParams": {
-            "description": "Parameters for a `notifications/cancelled` notification.",
+        "SetLevelRequestParams": {
+            "description": "Parameters for a `logging/setLevel` request.",
+            "type": "object",
             "properties": {
+                "level": {
+                    "$ref": "#/$defs/LoggingLevel",
+                    "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message."
+                },
                 "_meta": {
-                    "additionalProperties": {},
                     "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "reason": {
-                    "description": "An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.",
-                    "type": "string"
-                },
-                "requestId": {
-                    "$ref": "#/$defs/RequestId",
-                    "description": "The ID of the request to cancel.\n\nThis MUST correspond to the ID of a request previously issued in the same direction.\nThis MUST be provided for cancelling non-task requests.\nThis MUST NOT be used for cancelling tasks (use the `tasks/cancel` request instead)."
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    }
                 }
             },
-            "type": "object"
+            "required": [
+                "level"
+            ]
         },
-        "ClientCapabilities": {
-            "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
+        "SetLevelRequest": {
+            "description": "A request from the client to the server, to enable or adjust logging.",
+            "type": "object",
             "properties": {
-                "elicitation": {
-                    "description": "Present if the client supports elicitation from the server.",
+                "method": {
+                    "type": "string",
+                    "const": "logging/setLevel"
+                },
+                "params": {
+                    "$ref": "#/$defs/SetLevelRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "LoggingMessageNotificationParams": {
+            "description": "Parameters for a `notifications/message` notification.",
+            "type": "object",
+            "properties": {
+                "level": {
+                    "$ref": "#/$defs/LoggingLevel",
+                    "description": "The severity of this log message."
+                },
+                "logger": {
+                    "description": "An optional name of the logger issuing this message.",
+                    "type": "string"
+                },
+                "data": {
+                    "description": "The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here."
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "data",
+                "level"
+            ]
+        },
+        "LoggingMessageNotification": {
+            "description": "JSONRPCNotification of a log message passed from server to client. If no logging/setLevel request has been sent from the client, the server MAY decide which messages to send automatically.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/message"
+                },
+                "params": {
+                    "$ref": "#/$defs/LoggingMessageNotificationParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "LoggingLevel": {
+            "description": "The severity of a log message.\n\nThese map to syslog message severities, as specified in RFC-5424:\nhttps://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1",
+            "enum": [
+                "alert",
+                "critical",
+                "debug",
+                "emergency",
+                "error",
+                "info",
+                "notice",
+                "warning"
+            ],
+            "type": "string"
+        },
+        "CreateMessageRequestParams": {
+            "description": "Parameters for a `sampling/createMessage` request.",
+            "type": "object",
+            "properties": {
+                "messages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/SamplingMessage"
+                    }
+                },
+                "modelPreferences": {
+                    "$ref": "#/$defs/ModelPreferences",
+                    "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
+                },
+                "systemPrompt": {
+                    "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
+                    "type": "string"
+                },
+                "includeContext": {
+                    "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.\nThe client MAY ignore this request.\n\nDefault is \"none\". Values \"thisServer\" and \"allServers\" are soft-deprecated. Servers SHOULD only use these values if the client\ndeclares ClientCapabilities.sampling.context. These values may be removed in future spec releases.",
+                    "enum": [
+                        "allServers",
+                        "none",
+                        "thisServer"
+                    ],
+                    "type": "string"
+                },
+                "temperature": {
+                    "type": "number"
+                },
+                "maxTokens": {
+                    "description": "The requested maximum number of tokens to sample (to prevent runaway completions).\n\nThe client MAY choose to sample fewer tokens than the requested maximum.",
+                    "type": "integer"
+                },
+                "stopSequences": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "metadata": {
+                    "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific.",
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": true
+                },
+                "tools": {
+                    "description": "Tools that the model may use during generation.\nThe client MUST return an error if this field is provided but ClientCapabilities.sampling.tools is not declared.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Tool"
+                    }
+                },
+                "toolChoice": {
+                    "$ref": "#/$defs/ToolChoice",
+                    "description": "Controls how the model uses tools.\nThe client MUST return an error if this field is provided but ClientCapabilities.sampling.tools is not declared.\nDefault is `{ mode: \"auto\" }`."
+                },
+                "task": {
+                    "$ref": "#/$defs/TaskMetadata",
+                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {},
                     "properties": {
-                        "form": {
-                            "additionalProperties": true,
-                            "properties": {},
-                            "type": "object"
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    }
+                }
+            },
+            "required": [
+                "maxTokens",
+                "messages"
+            ]
+        },
+        "ToolChoice": {
+            "description": "Controls tool selection behavior for sampling requests.",
+            "type": "object",
+            "properties": {
+                "mode": {
+                    "description": "Controls the tool use ability of the model:\n- \"auto\": Model decides whether to use tools (default)\n- \"required\": Model MUST use at least one tool before completing\n- \"none\": Model MUST NOT use any tools",
+                    "enum": [
+                        "auto",
+                        "none",
+                        "required"
+                    ],
+                    "type": "string"
+                }
+            }
+        },
+        "CreateMessageRequest": {
+            "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "sampling/createMessage"
+                },
+                "params": {
+                    "$ref": "#/$defs/CreateMessageRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "CreateMessageResult": {
+            "description": "The client's response to a sampling/createMessage request from the server.\nThe client should inform the user before returning the sampled message, to allow them\nto inspect the response (human in the loop) and decide whether to allow the server to see it.",
+            "type": "object",
+            "properties": {
+                "model": {
+                    "description": "The name of the model that generated the message.",
+                    "type": "string"
+                },
+                "stopReason": {
+                    "description": "The reason why sampling stopped, if known.\n\nStandard values:\n- \"endTurn\": Natural end of the assistant's turn\n- \"stopSequence\": A stop sequence was encountered\n- \"maxTokens\": Maximum token limit was reached\n- \"toolUse\": The model wants to use one or more tools\n\nThis field is an open string to allow for provider-specific stop reasons.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "role": {
+                    "$ref": "#/$defs/Role"
+                },
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TextContent"
                         },
-                        "url": {
-                            "additionalProperties": true,
-                            "properties": {},
-                            "type": "object"
+                        {
+                            "$ref": "#/$defs/ImageContent"
+                        },
+                        {
+                            "$ref": "#/$defs/AudioContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolUseContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolResultContent"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/SamplingMessageContentBlock"
+                            }
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "content",
+                "model",
+                "role"
+            ]
+        },
+        "SamplingMessage": {
+            "description": "Describes a message issued to or received from an LLM API.",
+            "type": "object",
+            "properties": {
+                "role": {
+                    "$ref": "#/$defs/Role"
+                },
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TextContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ImageContent"
+                        },
+                        {
+                            "$ref": "#/$defs/AudioContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolUseContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolResultContent"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/SamplingMessageContentBlock"
+                            }
+                        }
+                    ]
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "content",
+                "role"
+            ]
+        },
+        "SamplingMessageContentBlock": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/TextContent"
+                },
+                {
+                    "$ref": "#/$defs/ImageContent"
+                },
+                {
+                    "$ref": "#/$defs/AudioContent"
+                },
+                {
+                    "$ref": "#/$defs/ToolUseContent"
+                },
+                {
+                    "$ref": "#/$defs/ToolResultContent"
+                }
+            ]
+        },
+        "Annotations": {
+            "description": "Optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
+            "type": "object",
+            "properties": {
+                "audience": {
+                    "description": "Describes who the intended audience of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Role"
+                    }
+                },
+                "priority": {
+                    "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "lastModified": {
+                    "description": "The moment the resource was last modified, as an ISO 8601 formatted string.\n\nShould be an ISO 8601 formatted string (e.g., \"2025-01-12T15:00:58Z\").\n\nExamples: last activity timestamp in an open file, timestamp when the resource\nwas attached, etc.",
+                    "type": "string"
+                }
+            }
+        },
+        "ContentBlock": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/TextContent"
+                },
+                {
+                    "$ref": "#/$defs/ImageContent"
+                },
+                {
+                    "$ref": "#/$defs/AudioContent"
+                },
+                {
+                    "$ref": "#/$defs/ResourceLink"
+                },
+                {
+                    "$ref": "#/$defs/EmbeddedResource"
+                }
+            ]
+        },
+        "TextContent": {
+            "description": "Text provided to or from an LLM.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "text"
+                },
+                "text": {
+                    "description": "The text content of the message.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "text",
+                "type"
+            ]
+        },
+        "ImageContent": {
+            "description": "An image provided to or from an LLM.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "image"
+                },
+                "data": {
+                    "description": "The base64-encoded image data.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of the image. Different providers may support different image types.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "data",
+                "mimeType",
+                "type"
+            ]
+        },
+        "AudioContent": {
+            "description": "Audio provided to or from an LLM.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "audio"
+                },
+                "data": {
+                    "description": "The base64-encoded audio data.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of the audio. Different providers may support different audio types.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "data",
+                "mimeType",
+                "type"
+            ]
+        },
+        "ToolUseContent": {
+            "description": "A request from the assistant to call a tool.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "tool_use"
+                },
+                "id": {
+                    "description": "A unique identifier for this tool use.\n\nThis ID is used to match tool results to their corresponding tool uses.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The name of the tool to call.",
+                    "type": "string"
+                },
+                "input": {
+                    "description": "The arguments to pass to the tool, conforming to the tool's input schema.",
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "_meta": {
+                    "description": "Optional metadata about the tool use. Clients SHOULD preserve this field when\nincluding tool uses in subsequent sampling requests to enable caching optimizations.\n\nSee [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "id",
+                "input",
+                "name",
+                "type"
+            ]
+        },
+        "ToolResultContent": {
+            "description": "The result of a tool use, provided by the user back to the assistant.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "tool_result"
+                },
+                "toolUseId": {
+                    "description": "The ID of the tool use this result corresponds to.\n\nThis MUST match the ID from a previous ToolUseContent.",
+                    "type": "string"
+                },
+                "content": {
+                    "description": "The unstructured result content of the tool use.\n\nThis has the same format as CallToolResult.content and can include text, images,\naudio, resource links, and embedded resources.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/ContentBlock"
+                    }
+                },
+                "structuredContent": {
+                    "description": "An optional structured result object.\n\nIf the tool defined an outputSchema, this SHOULD conform to that schema.",
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "isError": {
+                    "description": "Whether the tool use resulted in an error.\n\nIf true, the content typically describes the error that occurred.\nDefault: false",
+                    "type": "boolean"
+                },
+                "_meta": {
+                    "description": "Optional metadata about the tool result. Clients SHOULD preserve this field when\nincluding tool results in subsequent sampling requests to enable caching optimizations.\n\nSee [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "content",
+                "toolUseId",
+                "type"
+            ]
+        },
+        "ModelPreferences": {
+            "description": "The server's preferences for model selection, requested of the client during sampling.\n\nBecause LLMs can vary along multiple dimensions, choosing the \"best\" model is\nrarely straightforward.  Different models excel in different areas—some are\nfaster but less capable, others are more capable but more expensive, and so\non. This interface allows servers to express their priorities across multiple\ndimensions to help clients make an appropriate selection for their use case.\n\nThese preferences are always advisory. The client MAY ignore them. It is also\nup to the client to decide how to interpret these preferences and how to\nbalance them against other considerations.",
+            "type": "object",
+            "properties": {
+                "hints": {
+                    "description": "Optional hints to use for model selection.\n\nIf multiple hints are specified, the client MUST evaluate them in order\n(such that the first match is taken).\n\nThe client SHOULD prioritize these hints over the numeric priorities, but\nMAY still use the priorities to select from ambiguous matches.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/ModelHint"
+                    }
+                },
+                "costPriority": {
+                    "description": "How much to prioritize cost when selecting a model. A value of 0 means cost\nis not important, while a value of 1 means cost is the most important\nfactor.",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "speedPriority": {
+                    "description": "How much to prioritize sampling speed (latency) when selecting a model. A\nvalue of 0 means speed is not important, while a value of 1 means speed is\nthe most important factor.",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "intelligencePriority": {
+                    "description": "How much to prioritize intelligence and capabilities when selecting a\nmodel. A value of 0 means intelligence is not important, while a value of 1\nmeans intelligence is the most important factor.",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                }
+            }
+        },
+        "ModelHint": {
+            "description": "Hints to use for model selection.\n\nKeys not declared here are currently left unspecified by the spec and are up\nto the client to interpret.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "A hint for a model name.\n\nThe client SHOULD treat this as a substring of a model name; for example:\n - `claude-3-5-sonnet` should match `claude-3-5-sonnet-20241022`\n - `sonnet` should match `claude-3-5-sonnet-20241022`, `claude-3-sonnet-20240229`, etc.\n - `claude` should match any Claude model\n\nThe client MAY also map the string to a different provider's model name or a different model family, as long as it fills a similar niche; for example:\n - `gemini-1.5-flash` could match `claude-3-haiku-20240307`",
+                    "type": "string"
+                }
+            }
+        },
+        "CompleteRequestParams": {
+            "description": "Parameters for a `completion/complete` request.",
+            "type": "object",
+            "properties": {
+                "ref": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/PromptReference"
+                        },
+                        {
+                            "$ref": "#/$defs/ResourceTemplateReference"
+                        }
+                    ]
+                },
+                "argument": {
+                    "description": "The argument's information",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "description": "The name of the argument",
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "The value of the argument to use for completion matching.",
+                            "type": "string"
                         }
                     },
-                    "type": "object"
+                    "required": [
+                        "name",
+                        "value"
+                    ]
                 },
-                "experimental": {
-                    "additionalProperties": {
-                        "additionalProperties": true,
-                        "properties": {},
-                        "type": "object"
-                    },
-                    "description": "Experimental, non-standard capabilities that the client supports.",
-                    "type": "object"
-                },
-                "roots": {
-                    "description": "Present if the client supports listing roots.",
+                "context": {
+                    "description": "Additional, optional context for completions",
+                    "type": "object",
                     "properties": {
-                        "listChanged": {
-                            "description": "Whether the client supports notifications for changes to the roots list.",
+                        "arguments": {
+                            "description": "Previously-resolved variables in a URI template or prompt.",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    }
+                }
+            },
+            "required": [
+                "argument",
+                "ref"
+            ]
+        },
+        "CompleteRequest": {
+            "description": "A request from the client to the server, to ask for completion options.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "completion/complete"
+                },
+                "params": {
+                    "$ref": "#/$defs/CompleteRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "CompleteResult": {
+            "description": "The server's response to a completion/complete request",
+            "type": "object",
+            "properties": {
+                "completion": {
+                    "type": "object",
+                    "properties": {
+                        "values": {
+                            "description": "An array of completion values. Must not exceed 100 items.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "total": {
+                            "description": "The total number of completion options available. This can exceed the number of values actually sent in the response.",
+                            "type": "integer"
+                        },
+                        "hasMore": {
+                            "description": "Indicates whether there are additional completion options beyond those provided in the current response, even if the exact total is unknown.",
                             "type": "boolean"
                         }
                     },
-                    "type": "object"
+                    "required": [
+                        "values"
+                    ]
                 },
-                "sampling": {
-                    "description": "Present if the client supports sampling from an LLM.",
-                    "properties": {
-                        "context": {
-                            "additionalProperties": true,
-                            "description": "Whether the client supports context inclusion via includeContext parameter.\nIf not declared, servers SHOULD only use `includeContext: \"none\"` (or omit it).",
-                            "properties": {},
-                            "type": "object"
-                        },
-                        "tools": {
-                            "additionalProperties": true,
-                            "description": "Whether the client supports tool use via tools and toolChoice parameters.",
-                            "properties": {},
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tasks": {
-                    "description": "Present if the client supports task-augmented requests.",
-                    "properties": {
-                        "cancel": {
-                            "additionalProperties": true,
-                            "description": "Whether this client supports tasks/cancel.",
-                            "properties": {},
-                            "type": "object"
-                        },
-                        "list": {
-                            "additionalProperties": true,
-                            "description": "Whether this client supports tasks/list.",
-                            "properties": {},
-                            "type": "object"
-                        },
-                        "requests": {
-                            "description": "Specifies which request types can be augmented with tasks.",
-                            "properties": {
-                                "elicitation": {
-                                    "description": "Task support for elicitation-related requests.",
-                                    "properties": {
-                                        "create": {
-                                            "additionalProperties": true,
-                                            "description": "Whether the client supports task-augmented elicitation/create requests.",
-                                            "properties": {},
-                                            "type": "object"
-                                        }
-                                    },
-                                    "type": "object"
-                                },
-                                "sampling": {
-                                    "description": "Task support for sampling-related requests.",
-                                    "properties": {
-                                        "createMessage": {
-                                            "additionalProperties": true,
-                                            "description": "Whether the client supports task-augmented sampling/createMessage requests.",
-                                            "properties": {},
-                                            "type": "object"
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            },
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
                 }
             },
-            "type": "object"
+            "required": [
+                "completion"
+            ]
+        },
+        "ResourceTemplateReference": {
+            "description": "A reference to a resource or resource template definition.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "ref/resource"
+                },
+                "uri": {
+                    "description": "The URI or URI template of the resource.",
+                    "format": "uri-template",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type",
+                "uri"
+            ]
+        },
+        "PromptReference": {
+            "description": "Identifies a prompt.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "ref/prompt"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "type"
+            ]
+        },
+        "ListRootsRequest": {
+            "description": "Sent from the server to request a list of root URIs from the client. Roots allow\nservers to ask for specific directories or files to operate on. A common example\nfor roots is providing a set of repositories or directories a server should operate\non.\n\nThis request is typically used when the server needs to understand the file system\nstructure or access specific locations that the client has permission to read from.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "roots/list"
+                },
+                "params": {
+                    "$ref": "#/$defs/RequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "ListRootsResult": {
+            "description": "The client's response to a roots/list request from the server.\nThis result contains an array of Root objects, each representing a root directory\nor file that the server can operate on.",
+            "type": "object",
+            "properties": {
+                "roots": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Root"
+                    }
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "roots"
+            ]
+        },
+        "RootsListChangedNotification": {
+            "description": "A notification from the client to the server, informing it that the list of roots has changed.\nThis notification should be sent whenever the client adds, removes, or modifies any root.\nThe server should then request an updated list of roots using the ListRootsRequest.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/roots/list_changed"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "ElicitRequestFormParams": {
+            "description": "The parameters for a request to elicit non-sensitive information from the user via a form in the client.",
+            "type": "object",
+            "properties": {
+                "mode": {
+                    "description": "The elicitation mode.",
+                    "type": "string",
+                    "const": "form"
+                },
+                "message": {
+                    "description": "The message to present to the user describing what information is being requested.",
+                    "type": "string"
+                },
+                "requestedSchema": {
+                    "description": "A restricted subset of JSON Schema.\nOnly top-level properties are allowed, without nesting.",
+                    "type": "object",
+                    "properties": {
+                        "$schema": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string",
+                            "const": "object"
+                        },
+                        "properties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "#/$defs/PrimitiveSchemaDefinition"
+                            }
+                        },
+                        "required": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "properties",
+                        "type"
+                    ]
+                },
+                "task": {
+                    "$ref": "#/$defs/TaskMetadata",
+                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    }
+                }
+            },
+            "required": [
+                "message",
+                "requestedSchema"
+            ]
+        },
+        "ElicitRequestURLParams": {
+            "description": "The parameters for a request to elicit information from the user via a URL in the client.",
+            "type": "object",
+            "properties": {
+                "mode": {
+                    "description": "The elicitation mode.",
+                    "type": "string",
+                    "const": "url"
+                },
+                "message": {
+                    "description": "The message to present to the user explaining why the interaction is needed.",
+                    "type": "string"
+                },
+                "elicitationId": {
+                    "description": "The ID of the elicitation, which must be unique within the context of the server.\nThe client MUST treat this ID as an opaque value.",
+                    "type": "string"
+                },
+                "url": {
+                    "description": "The URL that the user should navigate to.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "task": {
+                    "$ref": "#/$defs/TaskMetadata",
+                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    }
+                }
+            },
+            "required": [
+                "elicitationId",
+                "message",
+                "mode",
+                "url"
+            ]
+        },
+        "ElicitRequestParams": {
+            "description": "The parameters for a request to elicit additional information from the user via the client.",
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/ElicitRequestURLParams"
+                },
+                {
+                    "$ref": "#/$defs/ElicitRequestFormParams"
+                }
+            ]
+        },
+        "ElicitRequest": {
+            "description": "A request from the server to elicit additional information from the user via the client.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "elicitation/create"
+                },
+                "params": {
+                    "$ref": "#/$defs/ElicitRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "PrimitiveSchemaDefinition": {
+            "description": "Restricted schema definitions that only allow primitive types\nwithout nested objects or arrays.",
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/StringSchema"
+                },
+                {
+                    "$ref": "#/$defs/NumberSchema"
+                },
+                {
+                    "$ref": "#/$defs/BooleanSchema"
+                },
+                {
+                    "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/LegacyTitledEnumSchema"
+                }
+            ]
+        },
+        "StringSchema": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "minLength": {
+                    "type": "integer"
+                },
+                "maxLength": {
+                    "type": "integer"
+                },
+                "format": {
+                    "enum": [
+                        "date",
+                        "date-time",
+                        "email",
+                        "uri"
+                    ],
+                    "type": "string"
+                },
+                "default": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
+            ]
+        },
+        "NumberSchema": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "enum": [
+                        "integer",
+                        "number"
+                    ],
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "minimum": {
+                    "type": "integer"
+                },
+                "maximum": {
+                    "type": "integer"
+                },
+                "default": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "type"
+            ]
+        },
+        "BooleanSchema": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "boolean"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "default": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "type"
+            ]
+        },
+        "UntitledSingleSelectEnumSchema": {
+            "description": "Schema for single-selection enumeration without display titles for options.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "string"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Optional description for the enum field.",
+                    "type": "string"
+                },
+                "enum": {
+                    "description": "Array of enum values to choose from.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "default": {
+                    "description": "Optional default value.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "enum",
+                "type"
+            ]
+        },
+        "TitledSingleSelectEnumSchema": {
+            "description": "Schema for single-selection enumeration with display titles for each option.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "string"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Optional description for the enum field.",
+                    "type": "string"
+                },
+                "oneOf": {
+                    "description": "Array of enum options with values and display labels.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "const": {
+                                "description": "The enum value.",
+                                "type": "string"
+                            },
+                            "title": {
+                                "description": "Display label for this option.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "const",
+                            "title"
+                        ]
+                    }
+                },
+                "default": {
+                    "description": "Optional default value.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "oneOf",
+                "type"
+            ]
+        },
+        "SingleSelectEnumSchema": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+                }
+            ]
+        },
+        "UntitledMultiSelectEnumSchema": {
+            "description": "Schema for multiple-selection enumeration without display titles for options.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "array"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Optional description for the enum field.",
+                    "type": "string"
+                },
+                "minItems": {
+                    "description": "Minimum number of items to select.",
+                    "type": "integer"
+                },
+                "maxItems": {
+                    "description": "Maximum number of items to select.",
+                    "type": "integer"
+                },
+                "items": {
+                    "description": "Schema for the array items.",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "string"
+                        },
+                        "enum": {
+                            "description": "Array of enum values to choose from.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "enum",
+                        "type"
+                    ]
+                },
+                "default": {
+                    "description": "Optional default value.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "items",
+                "type"
+            ]
+        },
+        "TitledMultiSelectEnumSchema": {
+            "description": "Schema for multiple-selection enumeration with display titles for each option.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "array"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Optional description for the enum field.",
+                    "type": "string"
+                },
+                "minItems": {
+                    "description": "Minimum number of items to select.",
+                    "type": "integer"
+                },
+                "maxItems": {
+                    "description": "Maximum number of items to select.",
+                    "type": "integer"
+                },
+                "items": {
+                    "description": "Schema for array items with enum options and display labels.",
+                    "type": "object",
+                    "properties": {
+                        "anyOf": {
+                            "description": "Array of enum options with values and display labels.",
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "const": {
+                                        "description": "The constant enum value.",
+                                        "type": "string"
+                                    },
+                                    "title": {
+                                        "description": "Display title for this option.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "const",
+                                    "title"
+                                ]
+                            }
+                        }
+                    },
+                    "required": [
+                        "anyOf"
+                    ]
+                },
+                "default": {
+                    "description": "Optional default value.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "items",
+                "type"
+            ]
+        },
+        "MultiSelectEnumSchema": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+                }
+            ]
+        },
+        "LegacyTitledEnumSchema": {
+            "description": "Use TitledSingleSelectEnumSchema instead.\nThis interface will be removed in a future version.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "enum": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "enumNames": {
+                    "description": "(Legacy) Display names for enum values.\nNon-standard according to JSON schema 2020-12.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "default": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "enum",
+                "type"
+            ]
+        },
+        "EnumSchema": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/LegacyTitledEnumSchema"
+                }
+            ]
+        },
+        "ElicitResult": {
+            "description": "The client's response to an elicitation request.",
+            "type": "object",
+            "properties": {
+                "action": {
+                    "description": "The user action in response to the elicitation.\n- \"accept\": User submitted the form/confirmed the action\n- \"decline\": User explicitly decline the action\n- \"cancel\": User dismissed without making an explicit choice",
+                    "enum": [
+                        "accept",
+                        "cancel",
+                        "decline"
+                    ],
+                    "type": "string"
+                },
+                "content": {
+                    "description": "The submitted form data, only present when action is \"accept\" and mode was \"form\".\nContains values matching the requested schema.\nOmitted for out-of-band mode responses.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "anyOf": [
+                            {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            {
+                                "type": [
+                                    "string",
+                                    "integer",
+                                    "boolean"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "action"
+            ]
+        },
+        "ElicitationCompleteNotification": {
+            "description": "An optional notification from the server to the client, informing it of a completion of a out-of-band elicitation request.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/elicitation/complete"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "elicitationId": {
+                            "description": "The ID of the elicitation that completed.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "elicitationId"
+                    ]
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ]
         },
         "ClientNotification": {
             "anyOf": [
@@ -423,6 +3770,232 @@
                 {
                     "$ref": "#/$defs/RootsListChangedNotification"
                 }
+            ]
+        },
+        "ClientResult": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/Result"
+                },
+                {
+                    "$ref": "#/$defs/GetTaskResult",
+                    "description": "The response to a tasks/get request."
+                },
+                {
+                    "$ref": "#/$defs/GetTaskPayloadResult"
+                },
+                {
+                    "$ref": "#/$defs/CancelTaskResult",
+                    "description": "The response to a tasks/cancel request."
+                },
+                {
+                    "$ref": "#/$defs/ListTasksResult"
+                },
+                {
+                    "$ref": "#/$defs/CreateMessageResult"
+                },
+                {
+                    "$ref": "#/$defs/ListRootsResult"
+                },
+                {
+                    "$ref": "#/$defs/ElicitResult"
+                }
+            ]
+        },
+        "ServerRequest": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/PingRequest"
+                },
+                {
+                    "$ref": "#/$defs/GetTaskRequest"
+                },
+                {
+                    "$ref": "#/$defs/GetTaskPayloadRequest"
+                },
+                {
+                    "$ref": "#/$defs/CancelTaskRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListTasksRequest"
+                },
+                {
+                    "$ref": "#/$defs/CreateMessageRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListRootsRequest"
+                },
+                {
+                    "$ref": "#/$defs/ElicitRequest"
+                }
+            ]
+        },
+        "ServerNotification": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/CancelledNotification"
+                },
+                {
+                    "$ref": "#/$defs/ProgressNotification"
+                },
+                {
+                    "$ref": "#/$defs/ResourceListChangedNotification"
+                },
+                {
+                    "$ref": "#/$defs/ResourceUpdatedNotification"
+                },
+                {
+                    "$ref": "#/$defs/PromptListChangedNotification"
+                },
+                {
+                    "$ref": "#/$defs/ToolListChangedNotification"
+                },
+                {
+                    "$ref": "#/$defs/TaskStatusNotification"
+                },
+                {
+                    "$ref": "#/$defs/LoggingMessageNotification"
+                },
+                {
+                    "$ref": "#/$defs/ElicitationCompleteNotification"
+                }
+            ]
+        },
+        "ServerResult": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/Result"
+                },
+                {
+                    "$ref": "#/$defs/InitializeResult"
+                },
+                {
+                    "$ref": "#/$defs/ListResourcesResult"
+                },
+                {
+                    "$ref": "#/$defs/ListResourceTemplatesResult"
+                },
+                {
+                    "$ref": "#/$defs/ReadResourceResult"
+                },
+                {
+                    "$ref": "#/$defs/ListPromptsResult"
+                },
+                {
+                    "$ref": "#/$defs/GetPromptResult"
+                },
+                {
+                    "$ref": "#/$defs/ListToolsResult"
+                },
+                {
+                    "$ref": "#/$defs/CallToolResult"
+                },
+                {
+                    "$ref": "#/$defs/GetTaskResult",
+                    "description": "The response to a tasks/get request."
+                },
+                {
+                    "$ref": "#/$defs/GetTaskPayloadResult"
+                },
+                {
+                    "$ref": "#/$defs/CancelTaskResult",
+                    "description": "The response to a tasks/cancel request."
+                },
+                {
+                    "$ref": "#/$defs/ListTasksResult"
+                },
+                {
+                    "$ref": "#/$defs/CompleteResult"
+                }
+            ]
+        },
+        "Request": {
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "Resource": {
+            "description": "A known resource that the server is capable of reading.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "size": {
+                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+                    "type": "integer"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "uri"
+            ]
+        },
+        "Root": {
+            "description": "Represents a root directory or file that the server can operate on.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI identifying the root. This *must* start with file:// for now.\nThis restriction may be relaxed in future versions of the protocol to allow\nother URI schemes.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "uri"
             ]
         },
         "ClientRequest": {
@@ -479,3580 +4052,6 @@
                     "$ref": "#/$defs/CompleteRequest"
                 }
             ]
-        },
-        "ClientResult": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/Result"
-                },
-                {
-                    "$ref": "#/$defs/GetTaskResult",
-                    "description": "The response to a tasks/get request."
-                },
-                {
-                    "$ref": "#/$defs/GetTaskPayloadResult"
-                },
-                {
-                    "$ref": "#/$defs/CancelTaskResult",
-                    "description": "The response to a tasks/cancel request."
-                },
-                {
-                    "$ref": "#/$defs/ListTasksResult"
-                },
-                {
-                    "$ref": "#/$defs/CreateMessageResult"
-                },
-                {
-                    "$ref": "#/$defs/ListRootsResult"
-                },
-                {
-                    "$ref": "#/$defs/ElicitResult"
-                }
-            ]
-        },
-        "CompleteRequest": {
-            "description": "A request from the client to the server, to ask for completion options.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "completion/complete",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/CompleteRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "CompleteRequestParams": {
-            "description": "Parameters for a `completion/complete` request.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "properties": {
-                        "progressToken": {
-                            "$ref": "#/$defs/ProgressToken",
-                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                        }
-                    },
-                    "type": "object"
-                },
-                "argument": {
-                    "description": "The argument's information",
-                    "properties": {
-                        "name": {
-                            "description": "The name of the argument",
-                            "type": "string"
-                        },
-                        "value": {
-                            "description": "The value of the argument to use for completion matching.",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "name",
-                        "value"
-                    ],
-                    "type": "object"
-                },
-                "context": {
-                    "description": "Additional, optional context for completions",
-                    "properties": {
-                        "arguments": {
-                            "additionalProperties": {
-                                "type": "string"
-                            },
-                            "description": "Previously-resolved variables in a URI template or prompt.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                },
-                "ref": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/$defs/PromptReference"
-                        },
-                        {
-                            "$ref": "#/$defs/ResourceTemplateReference"
-                        }
-                    ]
-                }
-            },
-            "required": [
-                "argument",
-                "ref"
-            ],
-            "type": "object"
-        },
-        "CompleteResult": {
-            "description": "The server's response to a completion/complete request",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "completion": {
-                    "properties": {
-                        "hasMore": {
-                            "description": "Indicates whether there are additional completion options beyond those provided in the current response, even if the exact total is unknown.",
-                            "type": "boolean"
-                        },
-                        "total": {
-                            "description": "The total number of completion options available. This can exceed the number of values actually sent in the response.",
-                            "type": "integer"
-                        },
-                        "values": {
-                            "description": "An array of completion values. Must not exceed 100 items.",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "required": [
-                        "values"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "completion"
-            ],
-            "type": "object"
-        },
-        "ContentBlock": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/TextContent"
-                },
-                {
-                    "$ref": "#/$defs/ImageContent"
-                },
-                {
-                    "$ref": "#/$defs/AudioContent"
-                },
-                {
-                    "$ref": "#/$defs/ResourceLink"
-                },
-                {
-                    "$ref": "#/$defs/EmbeddedResource"
-                }
-            ]
-        },
-        "CreateMessageRequest": {
-            "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "sampling/createMessage",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/CreateMessageRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "CreateMessageRequestParams": {
-            "description": "Parameters for a `sampling/createMessage` request.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "properties": {
-                        "progressToken": {
-                            "$ref": "#/$defs/ProgressToken",
-                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                        }
-                    },
-                    "type": "object"
-                },
-                "includeContext": {
-                    "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.\nThe client MAY ignore this request.\n\nDefault is \"none\". Values \"thisServer\" and \"allServers\" are soft-deprecated. Servers SHOULD only use these values if the client\ndeclares ClientCapabilities.sampling.context. These values may be removed in future spec releases.",
-                    "enum": [
-                        "allServers",
-                        "none",
-                        "thisServer"
-                    ],
-                    "type": "string"
-                },
-                "maxTokens": {
-                    "description": "The requested maximum number of tokens to sample (to prevent runaway completions).\n\nThe client MAY choose to sample fewer tokens than the requested maximum.",
-                    "type": "integer"
-                },
-                "messages": {
-                    "items": {
-                        "$ref": "#/$defs/SamplingMessage"
-                    },
-                    "type": "array"
-                },
-                "metadata": {
-                    "additionalProperties": true,
-                    "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific.",
-                    "properties": {},
-                    "type": "object"
-                },
-                "modelPreferences": {
-                    "$ref": "#/$defs/ModelPreferences",
-                    "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
-                },
-                "stopSequences": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "systemPrompt": {
-                    "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
-                    "type": "string"
-                },
-                "task": {
-                    "$ref": "#/$defs/TaskMetadata",
-                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
-                },
-                "temperature": {
-                    "type": "number"
-                },
-                "toolChoice": {
-                    "$ref": "#/$defs/ToolChoice",
-                    "description": "Controls how the model uses tools.\nThe client MUST return an error if this field is provided but ClientCapabilities.sampling.tools is not declared.\nDefault is `{ mode: \"auto\" }`."
-                },
-                "tools": {
-                    "description": "Tools that the model may use during generation.\nThe client MUST return an error if this field is provided but ClientCapabilities.sampling.tools is not declared.",
-                    "items": {
-                        "$ref": "#/$defs/Tool"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "maxTokens",
-                "messages"
-            ],
-            "type": "object"
-        },
-        "CreateMessageResult": {
-            "description": "The client's response to a sampling/createMessage request from the server.\nThe client should inform the user before returning the sampled message, to allow them\nto inspect the response (human in the loop) and decide whether to allow the server to see it.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "content": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/$defs/TextContent"
-                        },
-                        {
-                            "$ref": "#/$defs/ImageContent"
-                        },
-                        {
-                            "$ref": "#/$defs/AudioContent"
-                        },
-                        {
-                            "$ref": "#/$defs/ToolUseContent"
-                        },
-                        {
-                            "$ref": "#/$defs/ToolResultContent"
-                        },
-                        {
-                            "items": {
-                                "$ref": "#/$defs/SamplingMessageContentBlock"
-                            },
-                            "type": "array"
-                        }
-                    ]
-                },
-                "model": {
-                    "description": "The name of the model that generated the message.",
-                    "type": "string"
-                },
-                "role": {
-                    "$ref": "#/$defs/Role"
-                },
-                "stopReason": {
-                    "description": "The reason why sampling stopped, if known.\n\nStandard values:\n- \"endTurn\": Natural end of the assistant's turn\n- \"stopSequence\": A stop sequence was encountered\n- \"maxTokens\": Maximum token limit was reached\n- \"toolUse\": The model wants to use one or more tools\n\nThis field is an open string to allow for provider-specific stop reasons.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "content",
-                "model",
-                "role"
-            ],
-            "type": "object"
-        },
-        "CreateTaskResult": {
-            "description": "A response to a task-augmented request.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "task": {
-                    "$ref": "#/$defs/Task"
-                }
-            },
-            "required": [
-                "task"
-            ],
-            "type": "object"
-        },
-        "Cursor": {
-            "description": "An opaque token used to represent a cursor for pagination.",
-            "type": "string"
-        },
-        "ElicitRequest": {
-            "description": "A request from the server to elicit additional information from the user via the client.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "elicitation/create",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/ElicitRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ElicitRequestFormParams": {
-            "description": "The parameters for a request to elicit non-sensitive information from the user via a form in the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "properties": {
-                        "progressToken": {
-                            "$ref": "#/$defs/ProgressToken",
-                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                        }
-                    },
-                    "type": "object"
-                },
-                "message": {
-                    "description": "The message to present to the user describing what information is being requested.",
-                    "type": "string"
-                },
-                "mode": {
-                    "const": "form",
-                    "description": "The elicitation mode.",
-                    "type": "string"
-                },
-                "requestedSchema": {
-                    "description": "A restricted subset of JSON Schema.\nOnly top-level properties are allowed, without nesting.",
-                    "properties": {
-                        "$schema": {
-                            "type": "string"
-                        },
-                        "properties": {
-                            "additionalProperties": {
-                                "$ref": "#/$defs/PrimitiveSchemaDefinition"
-                            },
-                            "type": "object"
-                        },
-                        "required": {
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "type": {
-                            "const": "object",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "properties",
-                        "type"
-                    ],
-                    "type": "object"
-                },
-                "task": {
-                    "$ref": "#/$defs/TaskMetadata",
-                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
-                }
-            },
-            "required": [
-                "message",
-                "requestedSchema"
-            ],
-            "type": "object"
-        },
-        "ElicitRequestParams": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/ElicitRequestURLParams"
-                },
-                {
-                    "$ref": "#/$defs/ElicitRequestFormParams"
-                }
-            ],
-            "description": "The parameters for a request to elicit additional information from the user via the client."
-        },
-        "ElicitRequestURLParams": {
-            "description": "The parameters for a request to elicit information from the user via a URL in the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "properties": {
-                        "progressToken": {
-                            "$ref": "#/$defs/ProgressToken",
-                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                        }
-                    },
-                    "type": "object"
-                },
-                "elicitationId": {
-                    "description": "The ID of the elicitation, which must be unique within the context of the server.\nThe client MUST treat this ID as an opaque value.",
-                    "type": "string"
-                },
-                "message": {
-                    "description": "The message to present to the user explaining why the interaction is needed.",
-                    "type": "string"
-                },
-                "mode": {
-                    "const": "url",
-                    "description": "The elicitation mode.",
-                    "type": "string"
-                },
-                "task": {
-                    "$ref": "#/$defs/TaskMetadata",
-                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
-                },
-                "url": {
-                    "description": "The URL that the user should navigate to.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "elicitationId",
-                "message",
-                "mode",
-                "url"
-            ],
-            "type": "object"
-        },
-        "ElicitResult": {
-            "description": "The client's response to an elicitation request.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "action": {
-                    "description": "The user action in response to the elicitation.\n- \"accept\": User submitted the form/confirmed the action\n- \"decline\": User explicitly decline the action\n- \"cancel\": User dismissed without making an explicit choice",
-                    "enum": [
-                        "accept",
-                        "cancel",
-                        "decline"
-                    ],
-                    "type": "string"
-                },
-                "content": {
-                    "additionalProperties": {
-                        "anyOf": [
-                            {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
-                            {
-                                "type": [
-                                    "string",
-                                    "integer",
-                                    "boolean"
-                                ]
-                            }
-                        ]
-                    },
-                    "description": "The submitted form data, only present when action is \"accept\" and mode was \"form\".\nContains values matching the requested schema.\nOmitted for out-of-band mode responses.",
-                    "type": "object"
-                }
-            },
-            "required": [
-                "action"
-            ],
-            "type": "object"
-        },
-        "ElicitationCompleteNotification": {
-            "description": "An optional notification from the server to the client, informing it of a completion of a out-of-band elicitation request.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "notifications/elicitation/complete",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "elicitationId": {
-                            "description": "The ID of the elicitation that completed.",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "elicitationId"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "EmbeddedResource": {
-            "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "annotations": {
-                    "$ref": "#/$defs/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "resource": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/$defs/TextResourceContents"
-                        },
-                        {
-                            "$ref": "#/$defs/BlobResourceContents"
-                        }
-                    ]
-                },
-                "type": {
-                    "const": "resource",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "resource",
-                "type"
-            ],
-            "type": "object"
-        },
-        "EmptyResult": {
-            "$ref": "#/$defs/Result"
-        },
-        "EnumSchema": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
-                },
-                {
-                    "$ref": "#/$defs/TitledSingleSelectEnumSchema"
-                },
-                {
-                    "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
-                },
-                {
-                    "$ref": "#/$defs/TitledMultiSelectEnumSchema"
-                },
-                {
-                    "$ref": "#/$defs/LegacyTitledEnumSchema"
-                }
-            ]
-        },
-        "Error": {
-            "properties": {
-                "code": {
-                    "description": "The error type that occurred.",
-                    "type": "integer"
-                },
-                "data": {
-                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
-                },
-                "message": {
-                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "code",
-                "message"
-            ],
-            "type": "object"
-        },
-        "GetPromptRequest": {
-            "description": "Used by the client to get a prompt provided by the server.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "prompts/get",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/GetPromptRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "GetPromptRequestParams": {
-            "description": "Parameters for a `prompts/get` request.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "properties": {
-                        "progressToken": {
-                            "$ref": "#/$defs/ProgressToken",
-                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                        }
-                    },
-                    "type": "object"
-                },
-                "arguments": {
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "description": "Arguments to use for templating the prompt.",
-                    "type": "object"
-                },
-                "name": {
-                    "description": "The name of the prompt or prompt template.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "type": "object"
-        },
-        "GetPromptResult": {
-            "description": "The server's response to a prompts/get request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "description": {
-                    "description": "An optional description for the prompt.",
-                    "type": "string"
-                },
-                "messages": {
-                    "items": {
-                        "$ref": "#/$defs/PromptMessage"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "messages"
-            ],
-            "type": "object"
-        },
-        "GetTaskPayloadRequest": {
-            "description": "A request to retrieve the result of a completed task.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "tasks/result",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "taskId": {
-                            "description": "The task identifier to retrieve results for.",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "taskId"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "GetTaskPayloadResult": {
-            "additionalProperties": {},
-            "description": "The response to a tasks/result request.\nThe structure matches the result type of the original request.\nFor example, a tools/call task would return the CallToolResult structure.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "GetTaskRequest": {
-            "description": "A request to retrieve the state of a task.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "tasks/get",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "taskId": {
-                            "description": "The task identifier to query.",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "taskId"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "GetTaskResult": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/Result"
-                },
-                {
-                    "$ref": "#/$defs/Task"
-                }
-            ],
-            "description": "The response to a tasks/get request."
-        },
-        "Icon": {
-            "description": "An optionally-sized icon that can be displayed in a user interface.",
-            "properties": {
-                "mimeType": {
-                    "description": "Optional MIME type override if the source MIME type is missing or generic.\nFor example: `\"image/png\"`, `\"image/jpeg\"`, or `\"image/svg+xml\"`.",
-                    "type": "string"
-                },
-                "sizes": {
-                    "description": "Optional array of strings that specify sizes at which the icon can be used.\nEach string should be in WxH format (e.g., `\"48x48\"`, `\"96x96\"`) or `\"any\"` for scalable formats like SVG.\n\nIf not provided, the client should assume that the icon can be used at any size.",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "src": {
-                    "description": "A standard URI pointing to an icon resource. May be an HTTP/HTTPS URL or a\n`data:` URI with Base64-encoded image data.\n\nConsumers SHOULD takes steps to ensure URLs serving icons are from the\nsame domain as the client/server or a trusted domain.\n\nConsumers SHOULD take appropriate precautions when consuming SVGs as they can contain\nexecutable JavaScript.",
-                    "format": "uri",
-                    "type": "string"
-                },
-                "theme": {
-                    "description": "Optional specifier for the theme this icon is designed for. `light` indicates\nthe icon is designed to be used with a light background, and `dark` indicates\nthe icon is designed to be used with a dark background.\n\nIf not provided, the client should assume the icon can be used with any theme.",
-                    "enum": [
-                        "dark",
-                        "light"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "src"
-            ],
-            "type": "object"
-        },
-        "Icons": {
-            "description": "Base interface to add `icons` property.",
-            "properties": {
-                "icons": {
-                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
-                    "items": {
-                        "$ref": "#/$defs/Icon"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "ImageContent": {
-            "description": "An image provided to or from an LLM.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "annotations": {
-                    "$ref": "#/$defs/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "data": {
-                    "description": "The base64-encoded image data.",
-                    "format": "byte",
-                    "type": "string"
-                },
-                "mimeType": {
-                    "description": "The MIME type of the image. Different providers may support different image types.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "image",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "data",
-                "mimeType",
-                "type"
-            ],
-            "type": "object"
-        },
-        "Implementation": {
-            "description": "Describes the MCP implementation.",
-            "properties": {
-                "description": {
-                    "description": "An optional human-readable description of what this implementation does.\n\nThis can be used by clients or servers to provide context about their purpose\nand capabilities. For example, a server might describe the types of resources\nor tools it provides, while a client might describe its intended use case.",
-                    "type": "string"
-                },
-                "icons": {
-                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
-                    "items": {
-                        "$ref": "#/$defs/Icon"
-                    },
-                    "type": "array"
-                },
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                },
-                "version": {
-                    "type": "string"
-                },
-                "websiteUrl": {
-                    "description": "An optional URL of the website for this implementation.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "version"
-            ],
-            "type": "object"
-        },
-        "InitializeRequest": {
-            "description": "This request is sent from the client to the server when it first connects, asking it to begin initialization.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "initialize",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/InitializeRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "InitializeRequestParams": {
-            "description": "Parameters for an `initialize` request.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "properties": {
-                        "progressToken": {
-                            "$ref": "#/$defs/ProgressToken",
-                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                        }
-                    },
-                    "type": "object"
-                },
-                "capabilities": {
-                    "$ref": "#/$defs/ClientCapabilities"
-                },
-                "clientInfo": {
-                    "$ref": "#/$defs/Implementation"
-                },
-                "protocolVersion": {
-                    "description": "The latest version of the Model Context Protocol that the client supports. The client MAY decide to support older versions as well.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "capabilities",
-                "clientInfo",
-                "protocolVersion"
-            ],
-            "type": "object"
-        },
-        "InitializeResult": {
-            "description": "After receiving an initialize request from the client, the server sends this response.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "capabilities": {
-                    "$ref": "#/$defs/ServerCapabilities"
-                },
-                "instructions": {
-                    "description": "Instructions describing how to use the server and its features.\n\nThis can be used by clients to improve the LLM's understanding of available tools, resources, etc. It can be thought of like a \"hint\" to the model. For example, this information MAY be added to the system prompt.",
-                    "type": "string"
-                },
-                "protocolVersion": {
-                    "description": "The version of the Model Context Protocol that the server wants to use. This may not match the version that the client requested. If the client cannot support this version, it MUST disconnect.",
-                    "type": "string"
-                },
-                "serverInfo": {
-                    "$ref": "#/$defs/Implementation"
-                }
-            },
-            "required": [
-                "capabilities",
-                "protocolVersion",
-                "serverInfo"
-            ],
-            "type": "object"
-        },
-        "InitializedNotification": {
-            "description": "This notification is sent from the client to the server after initialization has finished.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "notifications/initialized",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/NotificationParams"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "JSONRPCErrorResponse": {
-            "description": "A response to a request that indicates an error occurred.",
-            "properties": {
-                "error": {
-                    "$ref": "#/$defs/Error"
-                },
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "error",
-                "jsonrpc"
-            ],
-            "type": "object"
-        },
-        "JSONRPCMessage": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/JSONRPCRequest"
-                },
-                {
-                    "$ref": "#/$defs/JSONRPCNotification"
-                },
-                {
-                    "$ref": "#/$defs/JSONRPCResultResponse"
-                },
-                {
-                    "$ref": "#/$defs/JSONRPCErrorResponse"
-                }
-            ],
-            "description": "Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent."
-        },
-        "JSONRPCNotification": {
-            "description": "A notification which does not expect a response.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "type": "object"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "JSONRPCRequest": {
-            "description": "A request that expects a response.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "type": "object"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "JSONRPCResponse": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/JSONRPCResultResponse"
-                },
-                {
-                    "$ref": "#/$defs/JSONRPCErrorResponse"
-                }
-            ],
-            "description": "A response to a request, containing either the result or error."
-        },
-        "JSONRPCResultResponse": {
-            "description": "A successful (non-error) response to a request.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "result": {
-                    "$ref": "#/$defs/Result"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "result"
-            ],
-            "type": "object"
-        },
-        "LegacyTitledEnumSchema": {
-            "description": "Use TitledSingleSelectEnumSchema instead.\nThis interface will be removed in a future version.",
-            "properties": {
-                "default": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "enum": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "enumNames": {
-                    "description": "(Legacy) Display names for enum values.\nNon-standard according to JSON schema 2020-12.",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "type": {
-                    "const": "string",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "enum",
-                "type"
-            ],
-            "type": "object"
-        },
-        "ListPromptsRequest": {
-            "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "prompts/list",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/PaginatedRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListPromptsResult": {
-            "description": "The server's response to a prompts/list request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "prompts": {
-                    "items": {
-                        "$ref": "#/$defs/Prompt"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "prompts"
-            ],
-            "type": "object"
-        },
-        "ListResourceTemplatesRequest": {
-            "description": "Sent from the client to request a list of resource templates the server has.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "resources/templates/list",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/PaginatedRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListResourceTemplatesResult": {
-            "description": "The server's response to a resources/templates/list request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "resourceTemplates": {
-                    "items": {
-                        "$ref": "#/$defs/ResourceTemplate"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "resourceTemplates"
-            ],
-            "type": "object"
-        },
-        "ListResourcesRequest": {
-            "description": "Sent from the client to request a list of resources the server has.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "resources/list",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/PaginatedRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListResourcesResult": {
-            "description": "The server's response to a resources/list request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "resources": {
-                    "items": {
-                        "$ref": "#/$defs/Resource"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "resources"
-            ],
-            "type": "object"
-        },
-        "ListRootsRequest": {
-            "description": "Sent from the server to request a list of root URIs from the client. Roots allow\nservers to ask for specific directories or files to operate on. A common example\nfor roots is providing a set of repositories or directories a server should operate\non.\n\nThis request is typically used when the server needs to understand the file system\nstructure or access specific locations that the client has permission to read from.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "roots/list",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/RequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListRootsResult": {
-            "description": "The client's response to a roots/list request from the server.\nThis result contains an array of Root objects, each representing a root directory\nor file that the server can operate on.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "roots": {
-                    "items": {
-                        "$ref": "#/$defs/Root"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "roots"
-            ],
-            "type": "object"
-        },
-        "ListTasksRequest": {
-            "description": "A request to retrieve a list of tasks.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "tasks/list",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/PaginatedRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListTasksResult": {
-            "description": "The response to a tasks/list request.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "tasks": {
-                    "items": {
-                        "$ref": "#/$defs/Task"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "tasks"
-            ],
-            "type": "object"
-        },
-        "ListToolsRequest": {
-            "description": "Sent from the client to request a list of tools the server has.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "tools/list",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/PaginatedRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListToolsResult": {
-            "description": "The server's response to a tools/list request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "tools": {
-                    "items": {
-                        "$ref": "#/$defs/Tool"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "tools"
-            ],
-            "type": "object"
-        },
-        "LoggingLevel": {
-            "description": "The severity of a log message.\n\nThese map to syslog message severities, as specified in RFC-5424:\nhttps://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1",
-            "enum": [
-                "alert",
-                "critical",
-                "debug",
-                "emergency",
-                "error",
-                "info",
-                "notice",
-                "warning"
-            ],
-            "type": "string"
-        },
-        "LoggingMessageNotification": {
-            "description": "JSONRPCNotification of a log message passed from server to client. If no logging/setLevel request has been sent from the client, the server MAY decide which messages to send automatically.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "notifications/message",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/LoggingMessageNotificationParams"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "LoggingMessageNotificationParams": {
-            "description": "Parameters for a `notifications/message` notification.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "data": {
-                    "description": "The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here."
-                },
-                "level": {
-                    "$ref": "#/$defs/LoggingLevel",
-                    "description": "The severity of this log message."
-                },
-                "logger": {
-                    "description": "An optional name of the logger issuing this message.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "data",
-                "level"
-            ],
-            "type": "object"
-        },
-        "ModelHint": {
-            "description": "Hints to use for model selection.\n\nKeys not declared here are currently left unspecified by the spec and are up\nto the client to interpret.",
-            "properties": {
-                "name": {
-                    "description": "A hint for a model name.\n\nThe client SHOULD treat this as a substring of a model name; for example:\n - `claude-3-5-sonnet` should match `claude-3-5-sonnet-20241022`\n - `sonnet` should match `claude-3-5-sonnet-20241022`, `claude-3-sonnet-20240229`, etc.\n - `claude` should match any Claude model\n\nThe client MAY also map the string to a different provider's model name or a different model family, as long as it fills a similar niche; for example:\n - `gemini-1.5-flash` could match `claude-3-haiku-20240307`",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "ModelPreferences": {
-            "description": "The server's preferences for model selection, requested of the client during sampling.\n\nBecause LLMs can vary along multiple dimensions, choosing the \"best\" model is\nrarely straightforward.  Different models excel in different areas—some are\nfaster but less capable, others are more capable but more expensive, and so\non. This interface allows servers to express their priorities across multiple\ndimensions to help clients make an appropriate selection for their use case.\n\nThese preferences are always advisory. The client MAY ignore them. It is also\nup to the client to decide how to interpret these preferences and how to\nbalance them against other considerations.",
-            "properties": {
-                "costPriority": {
-                    "description": "How much to prioritize cost when selecting a model. A value of 0 means cost\nis not important, while a value of 1 means cost is the most important\nfactor.",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "hints": {
-                    "description": "Optional hints to use for model selection.\n\nIf multiple hints are specified, the client MUST evaluate them in order\n(such that the first match is taken).\n\nThe client SHOULD prioritize these hints over the numeric priorities, but\nMAY still use the priorities to select from ambiguous matches.",
-                    "items": {
-                        "$ref": "#/$defs/ModelHint"
-                    },
-                    "type": "array"
-                },
-                "intelligencePriority": {
-                    "description": "How much to prioritize intelligence and capabilities when selecting a\nmodel. A value of 0 means intelligence is not important, while a value of 1\nmeans intelligence is the most important factor.",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "speedPriority": {
-                    "description": "How much to prioritize sampling speed (latency) when selecting a model. A\nvalue of 0 means speed is not important, while a value of 1 means speed is\nthe most important factor.",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
-                }
-            },
-            "type": "object"
-        },
-        "MultiSelectEnumSchema": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
-                },
-                {
-                    "$ref": "#/$defs/TitledMultiSelectEnumSchema"
-                }
-            ]
-        },
-        "Notification": {
-            "properties": {
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "NotificationParams": {
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "NumberSchema": {
-            "properties": {
-                "default": {
-                    "type": "integer"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "maximum": {
-                    "type": "integer"
-                },
-                "minimum": {
-                    "type": "integer"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "type": {
-                    "enum": [
-                        "integer",
-                        "number"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "type"
-            ],
-            "type": "object"
-        },
-        "PaginatedRequest": {
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/PaginatedRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "PaginatedRequestParams": {
-            "description": "Common parameters for paginated requests.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "properties": {
-                        "progressToken": {
-                            "$ref": "#/$defs/ProgressToken",
-                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                        }
-                    },
-                    "type": "object"
-                },
-                "cursor": {
-                    "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "PaginatedResult": {
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "PingRequest": {
-            "description": "A ping, issued by either the server or the client, to check that the other party is still alive. The receiver must promptly respond, or else may be disconnected.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "ping",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/RequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "PrimitiveSchemaDefinition": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/StringSchema"
-                },
-                {
-                    "$ref": "#/$defs/NumberSchema"
-                },
-                {
-                    "$ref": "#/$defs/BooleanSchema"
-                },
-                {
-                    "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
-                },
-                {
-                    "$ref": "#/$defs/TitledSingleSelectEnumSchema"
-                },
-                {
-                    "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
-                },
-                {
-                    "$ref": "#/$defs/TitledMultiSelectEnumSchema"
-                },
-                {
-                    "$ref": "#/$defs/LegacyTitledEnumSchema"
-                }
-            ],
-            "description": "Restricted schema definitions that only allow primitive types\nwithout nested objects or arrays."
-        },
-        "ProgressNotification": {
-            "description": "An out-of-band notification used to inform the receiver of a progress update for a long-running request.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "notifications/progress",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/ProgressNotificationParams"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ProgressNotificationParams": {
-            "description": "Parameters for a `notifications/progress` notification.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "message": {
-                    "description": "An optional message describing the current progress.",
-                    "type": "string"
-                },
-                "progress": {
-                    "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
-                    "type": "number"
-                },
-                "progressToken": {
-                    "$ref": "#/$defs/ProgressToken",
-                    "description": "The progress token which was given in the initial request, used to associate this notification with the request that is proceeding."
-                },
-                "total": {
-                    "description": "Total number of items to process (or total progress required), if known.",
-                    "type": "number"
-                }
-            },
-            "required": [
-                "progress",
-                "progressToken"
-            ],
-            "type": "object"
-        },
-        "ProgressToken": {
-            "description": "A progress token, used to associate progress notifications with the original request.",
-            "type": [
-                "string",
-                "integer"
-            ]
-        },
-        "Prompt": {
-            "description": "A prompt or prompt template that the server offers.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "arguments": {
-                    "description": "A list of arguments to use for templating the prompt.",
-                    "items": {
-                        "$ref": "#/$defs/PromptArgument"
-                    },
-                    "type": "array"
-                },
-                "description": {
-                    "description": "An optional description of what this prompt provides",
-                    "type": "string"
-                },
-                "icons": {
-                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
-                    "items": {
-                        "$ref": "#/$defs/Icon"
-                    },
-                    "type": "array"
-                },
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "type": "object"
-        },
-        "PromptArgument": {
-            "description": "Describes an argument that a prompt can accept.",
-            "properties": {
-                "description": {
-                    "description": "A human-readable description of the argument.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "required": {
-                    "description": "Whether this argument must be provided.",
-                    "type": "boolean"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "type": "object"
-        },
-        "PromptListChangedNotification": {
-            "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "notifications/prompts/list_changed",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/NotificationParams"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "PromptMessage": {
-            "description": "Describes a message returned as part of a prompt.\n\nThis is similar to `SamplingMessage`, but also supports the embedding of\nresources from the MCP server.",
-            "properties": {
-                "content": {
-                    "$ref": "#/$defs/ContentBlock"
-                },
-                "role": {
-                    "$ref": "#/$defs/Role"
-                }
-            },
-            "required": [
-                "content",
-                "role"
-            ],
-            "type": "object"
-        },
-        "PromptReference": {
-            "description": "Identifies a prompt.",
-            "properties": {
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "ref/prompt",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "type"
-            ],
-            "type": "object"
-        },
-        "ReadResourceRequest": {
-            "description": "Sent from the client to the server, to read a specific resource URI.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "resources/read",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/ReadResourceRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ReadResourceRequestParams": {
-            "description": "Parameters for a `resources/read` request.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "properties": {
-                        "progressToken": {
-                            "$ref": "#/$defs/ProgressToken",
-                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                        }
-                    },
-                    "type": "object"
-                },
-                "uri": {
-                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ReadResourceResult": {
-            "description": "The server's response to a resources/read request from the client.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "contents": {
-                    "items": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/$defs/TextResourceContents"
-                            },
-                            {
-                                "$ref": "#/$defs/BlobResourceContents"
-                            }
-                        ]
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "contents"
-            ],
-            "type": "object"
-        },
-        "RelatedTaskMetadata": {
-            "description": "Metadata for associating messages with a task.\nInclude this in the `_meta` field under the key `io.modelcontextprotocol/related-task`.",
-            "properties": {
-                "taskId": {
-                    "description": "The task identifier this message is associated with.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "taskId"
-            ],
-            "type": "object"
-        },
-        "Request": {
-            "properties": {
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "RequestId": {
-            "description": "A uniquely identifying ID for a request in JSON-RPC.",
-            "type": [
-                "string",
-                "integer"
-            ]
-        },
-        "RequestParams": {
-            "description": "Common params for any request.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "properties": {
-                        "progressToken": {
-                            "$ref": "#/$defs/ProgressToken",
-                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "Resource": {
-            "description": "A known resource that the server is capable of reading.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "annotations": {
-                    "$ref": "#/$defs/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "description": {
-                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
-                    "type": "string"
-                },
-                "icons": {
-                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
-                    "items": {
-                        "$ref": "#/$defs/Icon"
-                    },
-                    "type": "array"
-                },
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "size": {
-                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
-                    "type": "integer"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ResourceContents": {
-            "description": "The contents of a specific resource or sub-resource.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ResourceLink": {
-            "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of `resources/list` requests.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "annotations": {
-                    "$ref": "#/$defs/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "description": {
-                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
-                    "type": "string"
-                },
-                "icons": {
-                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
-                    "items": {
-                        "$ref": "#/$defs/Icon"
-                    },
-                    "type": "array"
-                },
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "size": {
-                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
-                    "type": "integer"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "resource_link",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "type",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ResourceListChangedNotification": {
-            "description": "An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This may be issued by servers without any previous subscription from the client.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "notifications/resources/list_changed",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/NotificationParams"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "ResourceRequestParams": {
-            "description": "Common parameters when working with resources.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "properties": {
-                        "progressToken": {
-                            "$ref": "#/$defs/ProgressToken",
-                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                        }
-                    },
-                    "type": "object"
-                },
-                "uri": {
-                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ResourceTemplate": {
-            "description": "A template description for resources available on the server.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "annotations": {
-                    "$ref": "#/$defs/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "description": {
-                    "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
-                    "type": "string"
-                },
-                "icons": {
-                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
-                    "items": {
-                        "$ref": "#/$defs/Icon"
-                    },
-                    "type": "array"
-                },
-                "mimeType": {
-                    "description": "The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                },
-                "uriTemplate": {
-                    "description": "A URI template (according to RFC 6570) that can be used to construct resource URIs.",
-                    "format": "uri-template",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "uriTemplate"
-            ],
-            "type": "object"
-        },
-        "ResourceTemplateReference": {
-            "description": "A reference to a resource or resource template definition.",
-            "properties": {
-                "type": {
-                    "const": "ref/resource",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI or URI template of the resource.",
-                    "format": "uri-template",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "type",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ResourceUpdatedNotification": {
-            "description": "A notification from the server to the client, informing it that a resource has changed and may need to be read again. This should only be sent if the client previously sent a resources/subscribe request.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "notifications/resources/updated",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/ResourceUpdatedNotificationParams"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ResourceUpdatedNotificationParams": {
-            "description": "Parameters for a `notifications/resources/updated` notification.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "uri": {
-                    "description": "The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "uri"
-            ],
-            "type": "object"
-        },
-        "Result": {
-            "additionalProperties": {},
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "Role": {
-            "description": "The sender or recipient of messages and data in a conversation.",
-            "enum": [
-                "assistant",
-                "user"
-            ],
-            "type": "string"
-        },
-        "Root": {
-            "description": "Represents a root directory or file that the server can operate on.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "name": {
-                    "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI identifying the root. This *must* start with file:// for now.\nThis restriction may be relaxed in future versions of the protocol to allow\nother URI schemes.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "uri"
-            ],
-            "type": "object"
-        },
-        "RootsListChangedNotification": {
-            "description": "A notification from the client to the server, informing it that the list of roots has changed.\nThis notification should be sent whenever the client adds, removes, or modifies any root.\nThe server should then request an updated list of roots using the ListRootsRequest.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "notifications/roots/list_changed",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/NotificationParams"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "SamplingMessage": {
-            "description": "Describes a message issued to or received from an LLM API.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "content": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/$defs/TextContent"
-                        },
-                        {
-                            "$ref": "#/$defs/ImageContent"
-                        },
-                        {
-                            "$ref": "#/$defs/AudioContent"
-                        },
-                        {
-                            "$ref": "#/$defs/ToolUseContent"
-                        },
-                        {
-                            "$ref": "#/$defs/ToolResultContent"
-                        },
-                        {
-                            "items": {
-                                "$ref": "#/$defs/SamplingMessageContentBlock"
-                            },
-                            "type": "array"
-                        }
-                    ]
-                },
-                "role": {
-                    "$ref": "#/$defs/Role"
-                }
-            },
-            "required": [
-                "content",
-                "role"
-            ],
-            "type": "object"
-        },
-        "SamplingMessageContentBlock": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/TextContent"
-                },
-                {
-                    "$ref": "#/$defs/ImageContent"
-                },
-                {
-                    "$ref": "#/$defs/AudioContent"
-                },
-                {
-                    "$ref": "#/$defs/ToolUseContent"
-                },
-                {
-                    "$ref": "#/$defs/ToolResultContent"
-                }
-            ]
-        },
-        "ServerCapabilities": {
-            "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
-            "properties": {
-                "completions": {
-                    "additionalProperties": true,
-                    "description": "Present if the server supports argument autocompletion suggestions.",
-                    "properties": {},
-                    "type": "object"
-                },
-                "experimental": {
-                    "additionalProperties": {
-                        "additionalProperties": true,
-                        "properties": {},
-                        "type": "object"
-                    },
-                    "description": "Experimental, non-standard capabilities that the server supports.",
-                    "type": "object"
-                },
-                "logging": {
-                    "additionalProperties": true,
-                    "description": "Present if the server supports sending log messages to the client.",
-                    "properties": {},
-                    "type": "object"
-                },
-                "prompts": {
-                    "description": "Present if the server offers any prompt templates.",
-                    "properties": {
-                        "listChanged": {
-                            "description": "Whether this server supports notifications for changes to the prompt list.",
-                            "type": "boolean"
-                        }
-                    },
-                    "type": "object"
-                },
-                "resources": {
-                    "description": "Present if the server offers any resources to read.",
-                    "properties": {
-                        "listChanged": {
-                            "description": "Whether this server supports notifications for changes to the resource list.",
-                            "type": "boolean"
-                        },
-                        "subscribe": {
-                            "description": "Whether this server supports subscribing to resource updates.",
-                            "type": "boolean"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tasks": {
-                    "description": "Present if the server supports task-augmented requests.",
-                    "properties": {
-                        "cancel": {
-                            "additionalProperties": true,
-                            "description": "Whether this server supports tasks/cancel.",
-                            "properties": {},
-                            "type": "object"
-                        },
-                        "list": {
-                            "additionalProperties": true,
-                            "description": "Whether this server supports tasks/list.",
-                            "properties": {},
-                            "type": "object"
-                        },
-                        "requests": {
-                            "description": "Specifies which request types can be augmented with tasks.",
-                            "properties": {
-                                "tools": {
-                                    "description": "Task support for tool-related requests.",
-                                    "properties": {
-                                        "call": {
-                                            "additionalProperties": true,
-                                            "description": "Whether the server supports task-augmented tools/call requests.",
-                                            "properties": {},
-                                            "type": "object"
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            },
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": {
-                    "description": "Present if the server offers any tools to call.",
-                    "properties": {
-                        "listChanged": {
-                            "description": "Whether this server supports notifications for changes to the tool list.",
-                            "type": "boolean"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "ServerNotification": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/CancelledNotification"
-                },
-                {
-                    "$ref": "#/$defs/ProgressNotification"
-                },
-                {
-                    "$ref": "#/$defs/ResourceListChangedNotification"
-                },
-                {
-                    "$ref": "#/$defs/ResourceUpdatedNotification"
-                },
-                {
-                    "$ref": "#/$defs/PromptListChangedNotification"
-                },
-                {
-                    "$ref": "#/$defs/ToolListChangedNotification"
-                },
-                {
-                    "$ref": "#/$defs/TaskStatusNotification"
-                },
-                {
-                    "$ref": "#/$defs/LoggingMessageNotification"
-                },
-                {
-                    "$ref": "#/$defs/ElicitationCompleteNotification"
-                }
-            ]
-        },
-        "ServerRequest": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/PingRequest"
-                },
-                {
-                    "$ref": "#/$defs/GetTaskRequest"
-                },
-                {
-                    "$ref": "#/$defs/GetTaskPayloadRequest"
-                },
-                {
-                    "$ref": "#/$defs/CancelTaskRequest"
-                },
-                {
-                    "$ref": "#/$defs/ListTasksRequest"
-                },
-                {
-                    "$ref": "#/$defs/CreateMessageRequest"
-                },
-                {
-                    "$ref": "#/$defs/ListRootsRequest"
-                },
-                {
-                    "$ref": "#/$defs/ElicitRequest"
-                }
-            ]
-        },
-        "ServerResult": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/Result"
-                },
-                {
-                    "$ref": "#/$defs/InitializeResult"
-                },
-                {
-                    "$ref": "#/$defs/ListResourcesResult"
-                },
-                {
-                    "$ref": "#/$defs/ListResourceTemplatesResult"
-                },
-                {
-                    "$ref": "#/$defs/ReadResourceResult"
-                },
-                {
-                    "$ref": "#/$defs/ListPromptsResult"
-                },
-                {
-                    "$ref": "#/$defs/GetPromptResult"
-                },
-                {
-                    "$ref": "#/$defs/ListToolsResult"
-                },
-                {
-                    "$ref": "#/$defs/CallToolResult"
-                },
-                {
-                    "$ref": "#/$defs/GetTaskResult",
-                    "description": "The response to a tasks/get request."
-                },
-                {
-                    "$ref": "#/$defs/GetTaskPayloadResult"
-                },
-                {
-                    "$ref": "#/$defs/CancelTaskResult",
-                    "description": "The response to a tasks/cancel request."
-                },
-                {
-                    "$ref": "#/$defs/ListTasksResult"
-                },
-                {
-                    "$ref": "#/$defs/CompleteResult"
-                }
-            ]
-        },
-        "SetLevelRequest": {
-            "description": "A request from the client to the server, to enable or adjust logging.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "logging/setLevel",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/SetLevelRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "SetLevelRequestParams": {
-            "description": "Parameters for a `logging/setLevel` request.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "properties": {
-                        "progressToken": {
-                            "$ref": "#/$defs/ProgressToken",
-                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                        }
-                    },
-                    "type": "object"
-                },
-                "level": {
-                    "$ref": "#/$defs/LoggingLevel",
-                    "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message."
-                }
-            },
-            "required": [
-                "level"
-            ],
-            "type": "object"
-        },
-        "SingleSelectEnumSchema": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
-                },
-                {
-                    "$ref": "#/$defs/TitledSingleSelectEnumSchema"
-                }
-            ]
-        },
-        "StringSchema": {
-            "properties": {
-                "default": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "format": {
-                    "enum": [
-                        "date",
-                        "date-time",
-                        "email",
-                        "uri"
-                    ],
-                    "type": "string"
-                },
-                "maxLength": {
-                    "type": "integer"
-                },
-                "minLength": {
-                    "type": "integer"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "type": {
-                    "const": "string",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "type"
-            ],
-            "type": "object"
-        },
-        "SubscribeRequest": {
-            "description": "Sent from the client to request resources/updated notifications from the server whenever a particular resource changes.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "resources/subscribe",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/SubscribeRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "SubscribeRequestParams": {
-            "description": "Parameters for a `resources/subscribe` request.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "properties": {
-                        "progressToken": {
-                            "$ref": "#/$defs/ProgressToken",
-                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                        }
-                    },
-                    "type": "object"
-                },
-                "uri": {
-                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "uri"
-            ],
-            "type": "object"
-        },
-        "Task": {
-            "description": "Data associated with a task.",
-            "properties": {
-                "createdAt": {
-                    "description": "ISO 8601 timestamp when the task was created.",
-                    "type": "string"
-                },
-                "lastUpdatedAt": {
-                    "description": "ISO 8601 timestamp when the task was last updated.",
-                    "type": "string"
-                },
-                "pollInterval": {
-                    "description": "Suggested polling interval in milliseconds.",
-                    "type": "integer"
-                },
-                "status": {
-                    "$ref": "#/$defs/TaskStatus",
-                    "description": "Current task state."
-                },
-                "statusMessage": {
-                    "description": "Optional human-readable message describing the current task state.\nThis can provide context for any status, including:\n- Reasons for \"cancelled\" status\n- Summaries for \"completed\" status\n- Diagnostic information for \"failed\" status (e.g., error details, what went wrong)",
-                    "type": "string"
-                },
-                "taskId": {
-                    "description": "The task identifier.",
-                    "type": "string"
-                },
-                "ttl": {
-                    "description": "Actual retention duration from creation in milliseconds, null for unlimited.",
-                    "type": [
-                        "integer",
-                        "null"
-                    ]
-                }
-            },
-            "required": [
-                "createdAt",
-                "lastUpdatedAt",
-                "status",
-                "taskId",
-                "ttl"
-            ],
-            "type": "object"
-        },
-        "TaskAugmentedRequestParams": {
-            "description": "Common params for any task-augmented request.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "properties": {
-                        "progressToken": {
-                            "$ref": "#/$defs/ProgressToken",
-                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                        }
-                    },
-                    "type": "object"
-                },
-                "task": {
-                    "$ref": "#/$defs/TaskMetadata",
-                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
-                }
-            },
-            "type": "object"
-        },
-        "TaskMetadata": {
-            "description": "Metadata for augmenting a request with task execution.\nInclude this in the `task` field of the request parameters.",
-            "properties": {
-                "ttl": {
-                    "description": "Requested duration in milliseconds to retain task from creation.",
-                    "type": "integer"
-                }
-            },
-            "type": "object"
-        },
-        "TaskStatus": {
-            "description": "The status of a task.",
-            "enum": [
-                "cancelled",
-                "completed",
-                "failed",
-                "input_required",
-                "working"
-            ],
-            "type": "string"
-        },
-        "TaskStatusNotification": {
-            "description": "An optional notification from the receiver to the requestor, informing them that a task's status has changed. Receivers are not required to send these notifications.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "notifications/tasks/status",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/TaskStatusNotificationParams"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "TaskStatusNotificationParams": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/NotificationParams"
-                },
-                {
-                    "$ref": "#/$defs/Task"
-                }
-            ],
-            "description": "Parameters for a `notifications/tasks/status` notification."
-        },
-        "TextContent": {
-            "description": "Text provided to or from an LLM.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "annotations": {
-                    "$ref": "#/$defs/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "text": {
-                    "description": "The text content of the message.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "text",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "text",
-                "type"
-            ],
-            "type": "object"
-        },
-        "TextResourceContents": {
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "text": {
-                    "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "text",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "TitledMultiSelectEnumSchema": {
-            "description": "Schema for multiple-selection enumeration with display titles for each option.",
-            "properties": {
-                "default": {
-                    "description": "Optional default value.",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "description": {
-                    "description": "Optional description for the enum field.",
-                    "type": "string"
-                },
-                "items": {
-                    "description": "Schema for array items with enum options and display labels.",
-                    "properties": {
-                        "anyOf": {
-                            "description": "Array of enum options with values and display labels.",
-                            "items": {
-                                "properties": {
-                                    "const": {
-                                        "description": "The constant enum value.",
-                                        "type": "string"
-                                    },
-                                    "title": {
-                                        "description": "Display title for this option.",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "const",
-                                    "title"
-                                ],
-                                "type": "object"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "required": [
-                        "anyOf"
-                    ],
-                    "type": "object"
-                },
-                "maxItems": {
-                    "description": "Maximum number of items to select.",
-                    "type": "integer"
-                },
-                "minItems": {
-                    "description": "Minimum number of items to select.",
-                    "type": "integer"
-                },
-                "title": {
-                    "description": "Optional title for the enum field.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "array",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "items",
-                "type"
-            ],
-            "type": "object"
-        },
-        "TitledSingleSelectEnumSchema": {
-            "description": "Schema for single-selection enumeration with display titles for each option.",
-            "properties": {
-                "default": {
-                    "description": "Optional default value.",
-                    "type": "string"
-                },
-                "description": {
-                    "description": "Optional description for the enum field.",
-                    "type": "string"
-                },
-                "oneOf": {
-                    "description": "Array of enum options with values and display labels.",
-                    "items": {
-                        "properties": {
-                            "const": {
-                                "description": "The enum value.",
-                                "type": "string"
-                            },
-                            "title": {
-                                "description": "Display label for this option.",
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "const",
-                            "title"
-                        ],
-                        "type": "object"
-                    },
-                    "type": "array"
-                },
-                "title": {
-                    "description": "Optional title for the enum field.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "string",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "oneOf",
-                "type"
-            ],
-            "type": "object"
-        },
-        "Tool": {
-            "description": "Definition for a tool the client can call.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "annotations": {
-                    "$ref": "#/$defs/ToolAnnotations",
-                    "description": "Optional additional tool information.\n\nDisplay name precedence order is: title, annotations.title, then name."
-                },
-                "description": {
-                    "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
-                    "type": "string"
-                },
-                "execution": {
-                    "$ref": "#/$defs/ToolExecution",
-                    "description": "Execution-related properties for this tool."
-                },
-                "icons": {
-                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
-                    "items": {
-                        "$ref": "#/$defs/Icon"
-                    },
-                    "type": "array"
-                },
-                "inputSchema": {
-                    "description": "A JSON Schema object defining the expected parameters for the tool.",
-                    "properties": {
-                        "$schema": {
-                            "type": "string"
-                        },
-                        "properties": {
-                            "additionalProperties": {
-                                "additionalProperties": true,
-                                "properties": {},
-                                "type": "object"
-                            },
-                            "type": "object"
-                        },
-                        "required": {
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "type": {
-                            "const": "object",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "type"
-                    ],
-                    "type": "object"
-                },
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "outputSchema": {
-                    "description": "An optional JSON Schema object defining the structure of the tool's output returned in\nthe structuredContent field of a CallToolResult.\n\nDefaults to JSON Schema 2020-12 when no explicit $schema is provided.\nCurrently restricted to type: \"object\" at the root level.",
-                    "properties": {
-                        "$schema": {
-                            "type": "string"
-                        },
-                        "properties": {
-                            "additionalProperties": {
-                                "additionalProperties": true,
-                                "properties": {},
-                                "type": "object"
-                            },
-                            "type": "object"
-                        },
-                        "required": {
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "type": {
-                            "const": "object",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "type"
-                    ],
-                    "type": "object"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "inputSchema",
-                "name"
-            ],
-            "type": "object"
-        },
-        "ToolAnnotations": {
-            "description": "Additional properties describing a Tool to clients.\n\nNOTE: all properties in ToolAnnotations are **hints**.\nThey are not guaranteed to provide a faithful description of\ntool behavior (including descriptive properties like `title`).\n\nClients should never make tool use decisions based on ToolAnnotations\nreceived from untrusted servers.",
-            "properties": {
-                "destructiveHint": {
-                    "description": "If true, the tool may perform destructive updates to its environment.\nIf false, the tool performs only additive updates.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: true",
-                    "type": "boolean"
-                },
-                "idempotentHint": {
-                    "description": "If true, calling the tool repeatedly with the same arguments\nwill have no additional effect on its environment.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: false",
-                    "type": "boolean"
-                },
-                "openWorldHint": {
-                    "description": "If true, this tool may interact with an \"open world\" of external\nentities. If false, the tool's domain of interaction is closed.\nFor example, the world of a web search tool is open, whereas that\nof a memory tool is not.\n\nDefault: true",
-                    "type": "boolean"
-                },
-                "readOnlyHint": {
-                    "description": "If true, the tool does not modify its environment.\n\nDefault: false",
-                    "type": "boolean"
-                },
-                "title": {
-                    "description": "A human-readable title for the tool.",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "ToolChoice": {
-            "description": "Controls tool selection behavior for sampling requests.",
-            "properties": {
-                "mode": {
-                    "description": "Controls the tool use ability of the model:\n- \"auto\": Model decides whether to use tools (default)\n- \"required\": Model MUST use at least one tool before completing\n- \"none\": Model MUST NOT use any tools",
-                    "enum": [
-                        "auto",
-                        "none",
-                        "required"
-                    ],
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "ToolExecution": {
-            "description": "Execution-related properties for a tool.",
-            "properties": {
-                "taskSupport": {
-                    "description": "Indicates whether this tool supports task-augmented execution.\nThis allows clients to handle long-running operations through polling\nthe task system.\n\n- \"forbidden\": Tool does not support task-augmented execution (default when absent)\n- \"optional\": Tool may support task-augmented execution\n- \"required\": Tool requires task-augmented execution\n\nDefault: \"forbidden\"",
-                    "enum": [
-                        "forbidden",
-                        "optional",
-                        "required"
-                    ],
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "ToolListChangedNotification": {
-            "description": "An optional notification from the server to the client, informing it that the list of tools it offers has changed. This may be issued by servers without any previous subscription from the client.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "notifications/tools/list_changed",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/NotificationParams"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "ToolResultContent": {
-            "description": "The result of a tool use, provided by the user back to the assistant.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "Optional metadata about the tool result. Clients SHOULD preserve this field when\nincluding tool results in subsequent sampling requests to enable caching optimizations.\n\nSee [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "content": {
-                    "description": "The unstructured result content of the tool use.\n\nThis has the same format as CallToolResult.content and can include text, images,\naudio, resource links, and embedded resources.",
-                    "items": {
-                        "$ref": "#/$defs/ContentBlock"
-                    },
-                    "type": "array"
-                },
-                "isError": {
-                    "description": "Whether the tool use resulted in an error.\n\nIf true, the content typically describes the error that occurred.\nDefault: false",
-                    "type": "boolean"
-                },
-                "structuredContent": {
-                    "additionalProperties": {},
-                    "description": "An optional structured result object.\n\nIf the tool defined an outputSchema, this SHOULD conform to that schema.",
-                    "type": "object"
-                },
-                "toolUseId": {
-                    "description": "The ID of the tool use this result corresponds to.\n\nThis MUST match the ID from a previous ToolUseContent.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "tool_result",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "content",
-                "toolUseId",
-                "type"
-            ],
-            "type": "object"
-        },
-        "ToolUseContent": {
-            "description": "A request from the assistant to call a tool.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "Optional metadata about the tool use. Clients SHOULD preserve this field when\nincluding tool uses in subsequent sampling requests to enable caching optimizations.\n\nSee [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "type": "object"
-                },
-                "id": {
-                    "description": "A unique identifier for this tool use.\n\nThis ID is used to match tool results to their corresponding tool uses.",
-                    "type": "string"
-                },
-                "input": {
-                    "additionalProperties": {},
-                    "description": "The arguments to pass to the tool, conforming to the tool's input schema.",
-                    "type": "object"
-                },
-                "name": {
-                    "description": "The name of the tool to call.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "tool_use",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "id",
-                "input",
-                "name",
-                "type"
-            ],
-            "type": "object"
-        },
-        "URLElicitationRequiredError": {
-            "description": "An error response that indicates that the server requires the client to provide additional information via an elicitation request.",
-            "properties": {
-                "error": {
-                    "allOf": [
-                        {
-                            "$ref": "#/$defs/Error"
-                        },
-                        {
-                            "properties": {
-                                "code": {
-                                    "const": -32042,
-                                    "type": "integer"
-                                },
-                                "data": {
-                                    "additionalProperties": {},
-                                    "properties": {
-                                        "elicitations": {
-                                            "items": {
-                                                "$ref": "#/$defs/ElicitRequestURLParams"
-                                            },
-                                            "type": "array"
-                                        }
-                                    },
-                                    "required": [
-                                        "elicitations"
-                                    ],
-                                    "type": "object"
-                                }
-                            },
-                            "required": [
-                                "code",
-                                "data"
-                            ],
-                            "type": "object"
-                        }
-                    ]
-                },
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "error",
-                "jsonrpc"
-            ],
-            "type": "object"
-        },
-        "UnsubscribeRequest": {
-            "description": "Sent from the client to request cancellation of resources/updated notifications from the server. This should follow a previous resources/subscribe request.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "resources/unsubscribe",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/UnsubscribeRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "UnsubscribeRequestParams": {
-            "description": "Parameters for a `resources/unsubscribe` request.",
-            "properties": {
-                "_meta": {
-                    "additionalProperties": {},
-                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
-                    "properties": {
-                        "progressToken": {
-                            "$ref": "#/$defs/ProgressToken",
-                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                        }
-                    },
-                    "type": "object"
-                },
-                "uri": {
-                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "uri"
-            ],
-            "type": "object"
-        },
-        "UntitledMultiSelectEnumSchema": {
-            "description": "Schema for multiple-selection enumeration without display titles for options.",
-            "properties": {
-                "default": {
-                    "description": "Optional default value.",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "description": {
-                    "description": "Optional description for the enum field.",
-                    "type": "string"
-                },
-                "items": {
-                    "description": "Schema for the array items.",
-                    "properties": {
-                        "enum": {
-                            "description": "Array of enum values to choose from.",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "type": {
-                            "const": "string",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "enum",
-                        "type"
-                    ],
-                    "type": "object"
-                },
-                "maxItems": {
-                    "description": "Maximum number of items to select.",
-                    "type": "integer"
-                },
-                "minItems": {
-                    "description": "Minimum number of items to select.",
-                    "type": "integer"
-                },
-                "title": {
-                    "description": "Optional title for the enum field.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "array",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "items",
-                "type"
-            ],
-            "type": "object"
-        },
-        "UntitledSingleSelectEnumSchema": {
-            "description": "Schema for single-selection enumeration without display titles for options.",
-            "properties": {
-                "default": {
-                    "description": "Optional default value.",
-                    "type": "string"
-                },
-                "description": {
-                    "description": "Optional description for the enum field.",
-                    "type": "string"
-                },
-                "enum": {
-                    "description": "Array of enum values to choose from.",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "title": {
-                    "description": "Optional title for the enum field.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "string",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "enum",
-                "type"
-            ],
-            "type": "object"
         }
     }
 }
-

--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -1,62 +1,936 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$defs": {
-        "Annotations": {
-            "description": "Optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
-            "properties": {
-                "audience": {
-                    "description": "Describes who the intended audience of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+        "JSONValue": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/JSONObject"
+                },
+                {
+                    "type": "array",
                     "items": {
-                        "$ref": "#/$defs/Role"
-                    },
-                    "type": "array"
+                        "$ref": "#/$defs/JSONValue"
+                    }
                 },
-                "lastModified": {
-                    "description": "The moment the resource was last modified, as an ISO 8601 formatted string.\n\nShould be an ISO 8601 formatted string (e.g., \"2025-01-12T15:00:58Z\").\n\nExamples: last activity timestamp in an open file, timestamp when the resource\nwas attached, etc.",
-                    "type": "string"
-                },
-                "priority": {
-                    "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
+                {
+                    "type": [
+                        "string",
+                        "integer",
+                        "boolean"
+                    ]
                 }
-            },
+            ]
+        },
+        "JSONObject": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/$defs/JSONValue"
+            }
+        },
+        "JSONArray": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/JSONValue"
+            }
+        },
+        "JSONRPCMessage": {
+            "description": "Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent.",
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/JSONRPCRequest"
+                },
+                {
+                    "$ref": "#/$defs/JSONRPCNotification"
+                },
+                {
+                    "$ref": "#/$defs/JSONRPCResultResponse"
+                },
+                {
+                    "$ref": "#/$defs/JSONRPCErrorResponse"
+                }
+            ]
+        },
+        "MetaObject": {
+            "description": "Represents the contents of a `_meta` field, which clients and servers use to attach additional metadata to their interactions.\n\nCertain key names are reserved by MCP for protocol-level metadata; implementations MUST NOT make assumptions about values at these keys. Additionally, specific schema definitions may reserve particular names for purpose-specific metadata, as declared in those definitions.\n\nValid keys have two segments:\n\n**Prefix:**\n- Optional — if specified, MUST be a series of _labels_ separated by dots (`.`), followed by a slash (`/`).\n- Labels MUST start with a letter and end with a letter or digit. Interior characters may be letters, digits, or hyphens (`-`).\n- Implementations SHOULD use reverse DNS notation (e.g., `com.example/` rather than `example.com/`).\n- Any prefix where the second label is `modelcontextprotocol` or `mcp` is **reserved** for MCP use. For example: `io.modelcontextprotocol/`, `dev.mcp/`, `org.modelcontextprotocol.api/`, and `com.mcp.tools/` are all reserved. However, `com.example.mcp/` is NOT reserved, as the second label is `example`.\n\n**Name:**\n- Unless empty, MUST start and end with an alphanumeric character (`[a-z0-9A-Z]`).\n- Interior characters may be alphanumeric, hyphens (`-`), underscores (`_`), or dots (`.`).",
             "type": "object"
         },
-        "AudioContent": {
-            "description": "Audio provided to or from an LLM.",
+        "RequestMetaObject": {
+            "description": "Extends {@link MetaObject} with additional request-specific fields. All key naming rules from `MetaObject` apply.",
+            "type": "object",
+            "properties": {
+                "progressToken": {
+                    "$ref": "#/$defs/ProgressToken",
+                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by {@link ProgressNotificationnotifications/progress}). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                    "description": "The MCP Protocol Version being used for this request. Required.\n\nFor the HTTP transport, this value MUST match the `MCP-Protocol-Version`\nheader; otherwise the server MUST return a `400 Bad Request`. If the\nserver does not support the requested version, it MUST return an\n{@link UnsupportedProtocolVersionError}.",
+                    "type": "string"
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                    "$ref": "#/$defs/Implementation",
+                    "description": "Identifies the client software making the request. Clients SHOULD\ninclude this field on every request unless specifically configured not\nto do so.\n\nThe {@link Implementation} schema requires `name` and `version`; other\nfields are optional.\n\nThe value is self-reported by the client and is not verified by the\nprotocol. It is intended for display, logging, and debugging. Servers\nSHOULD NOT use it to change their behavior, and SHOULD NOT rely on it for\nsecurity decisions."
+                },
+                "io.modelcontextprotocol/clientCapabilities": {
+                    "$ref": "#/$defs/ClientCapabilities",
+                    "description": "The client's capabilities for this specific request. Required.\n\nCapabilities are declared per-request rather than once at initialization;\nan empty object means the client supports no optional capabilities.\nServers MUST NOT infer capabilities from prior requests."
+                },
+                "io.modelcontextprotocol/logLevel": {
+                    "$ref": "#/$defs/LoggingLevel",
+                    "description": "The desired log level for this request. Optional.\n\nIf absent, the server MUST NOT send any {@link LoggingMessageNotificationnotifications/message}\nnotifications for this request. The client opts in to log messages by\nexplicitly setting a level. Replaces the former `logging/setLevel` RPC."
+                }
+            },
+            "required": [
+                "io.modelcontextprotocol/clientCapabilities",
+                "io.modelcontextprotocol/protocolVersion"
+            ]
+        },
+        "NotificationMetaObject": {
+            "description": "Extends {@link MetaObject} with additional notification-specific fields. All key naming rules from `MetaObject` apply.",
+            "type": "object",
+            "properties": {
+                "io.modelcontextprotocol/subscriptionId": {
+                    "$ref": "#/$defs/RequestId",
+                    "description": "Identifies the subscription stream a notification was delivered on. The\nserver MUST include this key on every notification delivered via a\n{@link SubscriptionsListenRequestsubscriptions/listen} stream, so the\nclient can correlate the notification with the originating subscription.\nThe key is absent on notifications not delivered via a subscription\nstream (e.g. progress notifications for an in-flight request), which is\nwhy it is optional here.\n\nThe value is the JSON-RPC ID of the `subscriptions/listen` request that\nopened the stream."
+                }
+            }
+        },
+        "ResultMetaObject": {
+            "description": "Extends {@link MetaObject} with additional result-specific fields. All key naming rules from `MetaObject` apply.",
+            "type": "object",
+            "properties": {
+                "io.modelcontextprotocol/serverInfo": {
+                    "$ref": "#/$defs/Implementation",
+                    "description": "Identifies the server software producing the response. Servers SHOULD\ninclude this field on every response unless specifically configured not\nto do so.\n\nThe {@link Implementation} schema requires `name` and `version`; other\nfields are optional.\n\nThe value is self-reported by the server and is not verified by the\nprotocol. It is intended for display, logging, and debugging. Clients\nSHOULD NOT use it to change their behavior, and SHOULD NOT rely on it for\nsecurity decisions."
+                }
+            }
+        },
+        "ProgressToken": {
+            "description": "A progress token, used to associate progress notifications with the original request.",
+            "type": [
+                "string",
+                "integer"
+            ]
+        },
+        "Cursor": {
+            "description": "An opaque token used to represent a cursor for pagination.",
+            "type": "string"
+        },
+        "RequestParams": {
+            "description": "Common params for any request.",
+            "type": "object",
             "properties": {
                 "_meta": {
-                    "$ref": "#/$defs/MetaObject"
-                },
-                "annotations": {
-                    "$ref": "#/$defs/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "data": {
-                    "description": "The base64-encoded audio data.",
-                    "format": "byte",
+                    "$ref": "#/$defs/RequestMetaObject"
+                }
+            },
+            "required": [
+                "_meta"
+            ]
+        },
+        "NotificationParams": {
+            "description": "Common params for any notification.",
+            "type": "object",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/NotificationMetaObject"
+                }
+            }
+        },
+        "Notification": {
+            "type": "object",
+            "properties": {
+                "method": {
                     "type": "string"
                 },
-                "mimeType": {
-                    "description": "The MIME type of the audio. Different providers may support different audio types.",
-                    "type": "string"
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ResultType": {
+            "description": "Indicates the type of a {@link Result} object, allowing the client to\ndetermine how to parse the response.\n\ncomplete - the request completed successfully and the result contains the final content.\ninput_required - the request requires additional input and the result contains an {@link InputRequiredResult} object with instructions for the client to provide additional input before retrying the original request.",
+            "type": "string"
+        },
+        "Result": {
+            "description": "Common result fields.",
+            "type": "object",
+            "additionalProperties": {},
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/ResultMetaObject"
                 },
-                "type": {
-                    "const": "audio",
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
                     "type": "string"
                 }
             },
             "required": [
-                "data",
-                "mimeType",
-                "type"
-            ],
-            "type": "object"
+                "resultType"
+            ]
+        },
+        "Error": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "description": "The error type that occurred.",
+                    "type": "integer"
+                },
+                "message": {
+                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+                    "type": "string"
+                },
+                "data": {
+                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+                }
+            },
+            "required": [
+                "code",
+                "message"
+            ]
+        },
+        "RequestId": {
+            "description": "A uniquely identifying ID for a request in JSON-RPC.",
+            "type": [
+                "string",
+                "integer"
+            ]
+        },
+        "JSONRPCRequest": {
+            "description": "A request that expects a response.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "JSONRPCNotification": {
+            "description": "A notification which does not expect a response.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "JSONRPCResultResponse": {
+            "description": "A successful (non-error) response to a request.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "result": {
+                    "$ref": "#/$defs/Result"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ]
+        },
+        "JSONRPCErrorResponse": {
+            "description": "A response to a request that indicates an error occurred.",
+            "type": "object",
+            "properties": {
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "error": {
+                    "$ref": "#/$defs/Error"
+                }
+            },
+            "required": [
+                "error",
+                "jsonrpc"
+            ]
+        },
+        "JSONRPCResponse": {
+            "description": "A response to a request, containing either the result or error.",
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/JSONRPCResultResponse"
+                },
+                {
+                    "$ref": "#/$defs/JSONRPCErrorResponse"
+                }
+            ]
+        },
+        "ParseError": {
+            "description": "A JSON-RPC error indicating that invalid JSON was received by the server. This error is returned when the server cannot parse the JSON text of a message.",
+            "type": "object",
+            "properties": {
+                "code": {
+                    "description": "The error type that occurred.",
+                    "type": "integer",
+                    "const": -32700
+                },
+                "message": {
+                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+                    "type": "string"
+                },
+                "data": {
+                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+                }
+            },
+            "required": [
+                "code",
+                "message"
+            ]
+        },
+        "InvalidRequestError": {
+            "description": "A JSON-RPC error indicating that the request is not a valid request object. This error is returned when the message structure does not conform to the JSON-RPC 2.0 specification requirements for a request (e.g., missing required fields like `jsonrpc` or `method`, or using invalid types for these fields).",
+            "type": "object",
+            "properties": {
+                "code": {
+                    "description": "The error type that occurred.",
+                    "type": "integer",
+                    "const": -32600
+                },
+                "message": {
+                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+                    "type": "string"
+                },
+                "data": {
+                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+                }
+            },
+            "required": [
+                "code",
+                "message"
+            ]
+        },
+        "MethodNotFoundError": {
+            "description": "A JSON-RPC error indicating that the requested method does not exist or is not available.\n\nIn MCP, a server returns this error when a client invokes a method the server does not implement — either a genuinely unknown method, or one gated behind a server capability the server did not advertise (e.g., calling `prompts/list` when the `prompts` capability was not advertised).\n\nA request that requires a client capability the client did not declare is signalled instead by {@link MissingRequiredClientCapabilityError} (`-32021`).",
+            "type": "object",
+            "properties": {
+                "code": {
+                    "description": "The error type that occurred.",
+                    "type": "integer",
+                    "const": -32601
+                },
+                "message": {
+                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+                    "type": "string"
+                },
+                "data": {
+                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+                }
+            },
+            "required": [
+                "code",
+                "message"
+            ]
+        },
+        "InvalidParamsError": {
+            "description": "A JSON-RPC error indicating that the method parameters are invalid or malformed.\n\nIn MCP, this error is returned in various contexts when request parameters fail validation:\n\n- **Tools**: Unknown tool name or invalid tool arguments\n- **Prompts**: Unknown prompt name or missing required arguments\n- **Pagination**: Invalid or expired cursor values\n- **Logging**: Invalid log level\n- **Elicitation**: Server requests an elicitation mode not declared in client capabilities\n- **Sampling**: Missing tool result or tool results mixed with other content",
+            "type": "object",
+            "properties": {
+                "code": {
+                    "description": "The error type that occurred.",
+                    "type": "integer",
+                    "const": -32602
+                },
+                "message": {
+                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+                    "type": "string"
+                },
+                "data": {
+                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+                }
+            },
+            "required": [
+                "code",
+                "message"
+            ]
+        },
+        "InternalError": {
+            "description": "A JSON-RPC error indicating that an internal error occurred on the receiver. This error is returned when the receiver encounters an unexpected condition that prevents it from fulfilling the request.",
+            "type": "object",
+            "properties": {
+                "code": {
+                    "description": "The error type that occurred.",
+                    "type": "integer",
+                    "const": -32603
+                },
+                "message": {
+                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+                    "type": "string"
+                },
+                "data": {
+                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+                }
+            },
+            "required": [
+                "code",
+                "message"
+            ]
+        },
+        "HeaderMismatchError": {
+            "description": "Returned when a server rejects a request because the values in the HTTP\nheaders do not match the corresponding values in the request body, or\nbecause required headers are missing or malformed. For HTTP, the response\nstatus code MUST be `400 Bad Request`.",
+            "type": "object",
+            "properties": {
+                "error": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/Error"
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "code": {
+                                    "type": "integer",
+                                    "const": -32020
+                                }
+                            },
+                            "required": [
+                                "code"
+                            ]
+                        }
+                    ]
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "error",
+                "jsonrpc"
+            ]
+        },
+        "UnsupportedProtocolVersionError": {
+            "description": "Returned when the request's protocol version is unknown to the server or\nunsupported (e.g., a known experimental or draft version the server has\nchosen not to implement). For HTTP, the response status code MUST be\n`400 Bad Request`.",
+            "type": "object",
+            "properties": {
+                "error": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/Error"
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "code": {
+                                    "type": "integer",
+                                    "const": -32022
+                                },
+                                "data": {
+                                    "type": "object",
+                                    "properties": {
+                                        "supported": {
+                                            "description": "Protocol versions the server supports. The client should choose a\nmutually supported version from this list and retry.",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "requested": {
+                                            "description": "The protocol version that was requested by the client.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "requested",
+                                        "supported"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "code",
+                                "data"
+                            ]
+                        }
+                    ]
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "error",
+                "jsonrpc"
+            ]
+        },
+        "MissingRequiredClientCapabilityError": {
+            "description": "Returned when processing a request requires a capability the client did not\ndeclare in `clientCapabilities`. For HTTP, the response status code MUST be\n`400 Bad Request`.",
+            "type": "object",
+            "properties": {
+                "error": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/Error"
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "code": {
+                                    "type": "integer",
+                                    "const": -32021
+                                },
+                                "data": {
+                                    "type": "object",
+                                    "properties": {
+                                        "requiredCapabilities": {
+                                            "$ref": "#/$defs/ClientCapabilities",
+                                            "description": "The capabilities the server requires from the client to process this request."
+                                        }
+                                    },
+                                    "required": [
+                                        "requiredCapabilities"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "code",
+                                "data"
+                            ]
+                        }
+                    ]
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "error",
+                "jsonrpc"
+            ]
+        },
+        "EmptyResult": {
+            "$ref": "#/$defs/Result",
+            "description": "Common result fields."
+        },
+        "InputRequest": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/CreateMessageRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListRootsRequest"
+                },
+                {
+                    "$ref": "#/$defs/ElicitRequest"
+                }
+            ]
+        },
+        "InputResponse": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/CreateMessageResult"
+                },
+                {
+                    "$ref": "#/$defs/ListRootsResult"
+                },
+                {
+                    "$ref": "#/$defs/ElicitResult"
+                }
+            ]
+        },
+        "InputRequests": {
+            "description": "A map of server-initiated requests that the client must fulfill.\nKeys are server-assigned identifiers; values are the request objects.",
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/$defs/InputRequest"
+            }
+        },
+        "InputResponses": {
+            "description": "A map of client responses to server-initiated requests.\nKeys correspond to the keys in the {@link InputRequests} map;\nvalues are the client's result for each request.",
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/$defs/InputResponse"
+            }
+        },
+        "InputRequiredResult": {
+            "description": "An InputRequiredResult sent by the server to indicate that additional input is needed\nbefore the request can be completed.\n\nAt least one of `inputRequests` or `requestState` MUST be present.",
+            "type": "object",
+            "properties": {
+                "inputRequests": {
+                    "$ref": "#/$defs/InputRequests"
+                },
+                "requestState": {
+                    "type": "string"
+                },
+                "_meta": {
+                    "$ref": "#/$defs/ResultMetaObject"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "resultType"
+            ]
+        },
+        "InputResponseRequestParams": {
+            "type": "object",
+            "properties": {
+                "inputResponses": {
+                    "$ref": "#/$defs/InputResponses"
+                },
+                "requestState": {
+                    "type": "string"
+                },
+                "_meta": {
+                    "$ref": "#/$defs/RequestMetaObject"
+                }
+            },
+            "required": [
+                "_meta"
+            ]
+        },
+        "CancelledNotificationParams": {
+            "description": "Parameters for a `notifications/cancelled` notification.",
+            "type": "object",
+            "properties": {
+                "requestId": {
+                    "$ref": "#/$defs/RequestId",
+                    "description": "The ID of the request to cancel.\n\nThis MUST correspond to the ID of a request the client previously issued."
+                },
+                "reason": {
+                    "description": "An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "$ref": "#/$defs/NotificationMetaObject"
+                }
+            },
+            "required": [
+                "requestId"
+            ]
+        },
+        "CancelledNotification": {
+            "description": "This notification is sent by the client to indicate that it is cancelling a request it previously issued.\n\nOn stdio, the server also sends this notification, solely to terminate a {@link SubscriptionsListenRequestsubscriptions/listen} stream: it references the ID of the `subscriptions/listen` request that opened the stream. Servers MUST NOT use this notification to cancel any other request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/cancelled"
+                },
+                "params": {
+                    "$ref": "#/$defs/CancelledNotificationParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "DiscoverRequest": {
+            "description": "A request from the client asking the server to advertise its supported\nprotocol versions, capabilities, and other metadata. Servers **MUST**\nimplement `server/discover`. Clients **MAY** call it but are not required\nto — version negotiation can also happen inline via per-request `_meta`.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "server/discover"
+                },
+                "params": {
+                    "$ref": "#/$defs/RequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "DiscoverResult": {
+            "description": "The result returned by the server for a {@link DiscoverRequestserver/discover} request.",
+            "type": "object",
+            "properties": {
+                "supportedVersions": {
+                    "description": "MCP Protocol Versions this server supports. The client should choose a\nversion from this list for use in subsequent requests.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "capabilities": {
+                    "$ref": "#/$defs/ServerCapabilities",
+                    "description": "The capabilities of the server."
+                },
+                "instructions": {
+                    "description": "Natural-language guidance describing the server and its features.\n\nThis can be used by clients to improve an LLM's understanding of\navailable tools (e.g., by including it in a system prompt). It should\nfocus on information that helps the model use the server effectively\nand should not duplicate information already in tool descriptions.",
+                    "type": "string"
+                },
+                "ttlMs": {
+                    "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "cacheScope": {
+                    "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+                    "enum": [
+                        "private",
+                        "public"
+                    ],
+                    "type": "string"
+                },
+                "_meta": {
+                    "$ref": "#/$defs/ResultMetaObject"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "cacheScope",
+                "capabilities",
+                "resultType",
+                "supportedVersions",
+                "ttlMs"
+            ]
+        },
+        "DiscoverResultResponse": {
+            "description": "A successful response from the server for a {@link DiscoverRequestserver/discover} request.",
+            "type": "object",
+            "properties": {
+                "result": {
+                    "$ref": "#/$defs/DiscoverResult"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ]
+        },
+        "ClientCapabilities": {
+            "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
+            "type": "object",
+            "properties": {
+                "experimental": {
+                    "description": "Experimental, non-standard capabilities that the client supports.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/$defs/JSONObject"
+                    }
+                },
+                "roots": {
+                    "description": "Present if the client supports listing roots.",
+                    "type": "object",
+                    "properties": {}
+                },
+                "sampling": {
+                    "description": "Present if the client supports sampling from an LLM.",
+                    "type": "object",
+                    "properties": {
+                        "context": {
+                            "$ref": "#/$defs/JSONObject",
+                            "description": "Whether the client supports context inclusion via `includeContext` parameter.\nIf not declared, servers SHOULD only use `includeContext: \"none\"` (or omit it)."
+                        },
+                        "tools": {
+                            "$ref": "#/$defs/JSONObject",
+                            "description": "Whether the client supports tool use via `tools` and `toolChoice` parameters."
+                        }
+                    }
+                },
+                "elicitation": {
+                    "description": "Present if the client supports elicitation from the server.",
+                    "type": "object",
+                    "properties": {
+                        "form": {
+                            "$ref": "#/$defs/JSONObject"
+                        },
+                        "url": {
+                            "$ref": "#/$defs/JSONObject"
+                        }
+                    }
+                },
+                "extensions": {
+                    "description": "Optional MCP extensions that the client supports. Keys are extension identifiers\n(e.g., \"io.modelcontextprotocol/oauth-client-credentials\"), and values are\nper-extension settings objects. An empty object indicates support with no settings.\n\nKeys MUST follow the {@link MetaObject`_meta` key naming rules}, with a\nmandatory prefix.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/$defs/JSONObject"
+                    }
+                }
+            }
+        },
+        "ServerCapabilities": {
+            "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
+            "type": "object",
+            "properties": {
+                "experimental": {
+                    "description": "Experimental, non-standard capabilities that the server supports.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/$defs/JSONObject"
+                    }
+                },
+                "logging": {
+                    "$ref": "#/$defs/JSONObject",
+                    "description": "Present if the server supports sending log messages to the client."
+                },
+                "completions": {
+                    "$ref": "#/$defs/JSONObject",
+                    "description": "Present if the server supports argument autocompletion suggestions."
+                },
+                "prompts": {
+                    "description": "Present if the server offers any prompt templates.",
+                    "type": "object",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the prompt list.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "resources": {
+                    "description": "Present if the server offers any resources to read.",
+                    "type": "object",
+                    "properties": {
+                        "subscribe": {
+                            "description": "Whether this server supports subscribing to resource updates.",
+                            "type": "boolean"
+                        },
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the resource list.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "tools": {
+                    "description": "Present if the server offers any tools to call.",
+                    "type": "object",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the tool list.",
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "extensions": {
+                    "description": "Optional MCP extensions that the server supports. Keys are extension identifiers\n(e.g., \"io.modelcontextprotocol/tasks\"), and values are per-extension settings\nobjects. An empty object indicates support with no settings.\n\nKeys MUST follow the {@link MetaObject`_meta` key naming rules}, with a\nmandatory prefix.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/$defs/JSONObject"
+                    }
+                }
+            }
+        },
+        "Icon": {
+            "description": "An optionally-sized icon that can be displayed in a user interface.",
+            "type": "object",
+            "properties": {
+                "src": {
+                    "description": "A standard URI pointing to an icon resource. May be an HTTP/HTTPS URL or a\n`data:` URI with Base64-encoded image data.\n\nConsumers SHOULD take steps to ensure URLs serving icons are from the\nsame domain as the client/server or a trusted domain.\n\nConsumers SHOULD take appropriate precautions when consuming SVGs as they can contain\nexecutable JavaScript.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "Optional MIME type override if the source MIME type is missing or generic.\nFor example: `\"image/png\"`, `\"image/jpeg\"`, or `\"image/svg+xml\"`.",
+                    "type": "string"
+                },
+                "sizes": {
+                    "description": "Optional array of strings that specify sizes at which the icon can be used.\nEach string should be in WxH format (e.g., `\"48x48\"`, `\"96x96\"`) or `\"any\"` for scalable formats like SVG.\n\nIf not provided, the client should assume that the icon can be used at any size.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "theme": {
+                    "description": "Optional specifier for the theme this icon is designed for. `\"light\"` indicates\nthe icon is designed to be used with a light background, and `\"dark\"` indicates\nthe icon is designed to be used with a dark background.\n\nIf not provided, the client should assume the icon can be used with any theme.",
+                    "enum": [
+                        "dark",
+                        "light"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "src"
+            ]
+        },
+        "Icons": {
+            "description": "Base interface to add `icons` property.",
+            "type": "object",
+            "properties": {
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    }
+                }
+            }
         },
         "BaseMetadata": {
             "description": "Base interface for metadata with name (identifier) and title (display name) properties.",
+            "type": "object",
             "properties": {
                 "name": {
                     "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
@@ -69,61 +943,164 @@
             },
             "required": [
                 "name"
-            ],
-            "type": "object"
+            ]
         },
-        "BlobResourceContents": {
+        "Implementation": {
+            "description": "Describes the MCP implementation.",
+            "type": "object",
             "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/MetaObject"
-                },
-                "blob": {
-                    "description": "A base64-encoded string representing the binary data of the item.",
-                    "format": "byte",
+                "version": {
+                    "description": "The version of this implementation.",
                     "type": "string"
-                },
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "blob",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "BooleanSchema": {
-            "properties": {
-                "default": {
-                    "type": "boolean"
                 },
                 "description": {
+                    "description": "An optional human-readable description of what this implementation does.\n\nThis can be used by clients or servers to provide context about their purpose\nand capabilities. For example, a server might describe the types of resources\nor tools it provides, while a client might describe its intended use case.",
+                    "type": "string"
+                },
+                "websiteUrl": {
+                    "description": "An optional URL of the website for this implementation.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
                     "type": "string"
                 },
                 "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
                     "type": "string"
                 },
-                "type": {
-                    "const": "boolean",
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "version"
+            ]
+        },
+        "ProgressNotificationParams": {
+            "description": "Parameters for a {@link ProgressNotificationnotifications/progress} notification.",
+            "type": "object",
+            "properties": {
+                "progressToken": {
+                    "$ref": "#/$defs/ProgressToken",
+                    "description": "The progress token which was given in the initial request, used to associate this notification with the request that is proceeding."
+                },
+                "progress": {
+                    "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
+                    "type": "number"
+                },
+                "total": {
+                    "description": "Total number of items to process (or total progress required), if known.",
+                    "type": "number"
+                },
+                "message": {
+                    "description": "An optional message describing the current progress.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "$ref": "#/$defs/NotificationMetaObject"
+                }
+            },
+            "required": [
+                "progress",
+                "progressToken"
+            ]
+        },
+        "ProgressNotification": {
+            "description": "An out-of-band notification used to inform the receiver of a progress update for a long-running request.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/progress"
+                },
+                "params": {
+                    "$ref": "#/$defs/ProgressNotificationParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "PaginatedRequestParams": {
+            "description": "Common params for paginated requests.",
+            "type": "object",
+            "properties": {
+                "cursor": {
+                    "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "$ref": "#/$defs/RequestMetaObject"
+                }
+            },
+            "required": [
+                "_meta"
+            ]
+        },
+        "PaginatedRequest": {
+            "type": "object",
+            "properties": {
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "method": {
                     "type": "string"
                 }
             },
             "required": [
-                "type"
-            ],
-            "type": "object"
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "PaginatedResult": {
+            "type": "object",
+            "properties": {
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "$ref": "#/$defs/ResultMetaObject"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "resultType"
+            ]
         },
         "CacheableResult": {
             "description": "A result that supports a time-to-live (TTL) hint for client-side caching.",
+            "type": "object",
             "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/ResultMetaObject"
+                "ttlMs": {
+                    "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+                    "minimum": 0,
+                    "type": "integer"
                 },
                 "cacheScope": {
                     "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
@@ -133,6 +1110,63 @@
                     ],
                     "type": "string"
                 },
+                "_meta": {
+                    "$ref": "#/$defs/ResultMetaObject"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "cacheScope",
+                "resultType",
+                "ttlMs"
+            ]
+        },
+        "ListResourcesRequest": {
+            "description": "Sent from the client to request a list of resources the server has.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/list"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "ListResourcesResult": {
+            "description": "The result returned by the server for a {@link ListResourcesRequestresources/list} request.",
+            "type": "object",
+            "properties": {
+                "resources": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Resource"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "$ref": "#/$defs/ResultMetaObject"
+                },
                 "resultType": {
                     "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
                     "type": "string"
@@ -141,31 +1175,61 @@
                     "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
                     "minimum": 0,
                     "type": "integer"
+                },
+                "cacheScope": {
+                    "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+                    "enum": [
+                        "private",
+                        "public"
+                    ],
+                    "type": "string"
                 }
             },
             "required": [
                 "cacheScope",
+                "resources",
                 "resultType",
                 "ttlMs"
-            ],
-            "type": "object"
+            ]
         },
-        "CallToolRequest": {
-            "description": "Used by the client to invoke a tool provided by the server.",
+        "ListResourcesResultResponse": {
+            "description": "A successful response from the server for a {@link ListResourcesRequestresources/list} request.",
+            "type": "object",
             "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
+                "result": {
+                    "$ref": "#/$defs/ListResourcesResult"
                 },
                 "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
+                    "type": "string",
+                    "const": "2.0"
                 },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ]
+        },
+        "ListResourceTemplatesRequest": {
+            "description": "Sent from the client to request a list of resource templates the server has.",
+            "type": "object",
+            "properties": {
                 "method": {
-                    "const": "tools/call",
-                    "type": "string"
+                    "type": "string",
+                    "const": "resources/templates/list"
                 },
                 "params": {
-                    "$ref": "#/$defs/CallToolRequestParams"
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
                 }
             },
             "required": [
@@ -173,26 +1237,103 @@
                 "jsonrpc",
                 "method",
                 "params"
-            ],
-            "type": "object"
+            ]
         },
-        "CallToolRequestParams": {
-            "description": "Parameters for a `tools/call` request.",
+        "ListResourceTemplatesResult": {
+            "description": "The result returned by the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.",
+            "type": "object",
             "properties": {
+                "resourceTemplates": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/ResourceTemplate"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "$ref": "#/$defs/ResultMetaObject"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                },
+                "ttlMs": {
+                    "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "cacheScope": {
+                    "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+                    "enum": [
+                        "private",
+                        "public"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "cacheScope",
+                "resourceTemplates",
+                "resultType",
+                "ttlMs"
+            ]
+        },
+        "ListResourceTemplatesResultResponse": {
+            "description": "A successful response from the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.",
+            "type": "object",
+            "properties": {
+                "result": {
+                    "$ref": "#/$defs/ListResourceTemplatesResult"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ]
+        },
+        "ResourceRequestParams": {
+            "description": "Common params for resource-related requests.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "_meta": {
+                    "$ref": "#/$defs/RequestMetaObject"
+                }
+            },
+            "required": [
+                "_meta",
+                "uri"
+            ]
+        },
+        "ReadResourceRequestParams": {
+            "description": "Parameters for a `resources/read` request.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+                    "format": "uri",
+                    "type": "string"
+                },
                 "_meta": {
                     "$ref": "#/$defs/RequestMetaObject"
                 },
-                "arguments": {
-                    "additionalProperties": {},
-                    "description": "Arguments to use for the tool call.",
-                    "type": "object"
-                },
                 "inputResponses": {
                     "$ref": "#/$defs/InputResponses"
-                },
-                "name": {
-                    "description": "The name of the tool.",
-                    "type": "string"
                 },
                 "requestState": {
                     "type": "string"
@@ -200,51 +1341,942 @@
             },
             "required": [
                 "_meta",
-                "name"
-            ],
-            "type": "object"
+                "uri"
+            ]
         },
-        "CallToolResult": {
-            "description": "The result returned by the server for a {@link CallToolRequesttools/call} request.",
+        "ReadResourceRequest": {
+            "description": "Sent from the client to the server, to read a specific resource URI.",
+            "type": "object",
             "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "resources/read"
+                },
+                "params": {
+                    "$ref": "#/$defs/ReadResourceRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "ReadResourceResult": {
+            "description": "The result returned by the server for a {@link ReadResourceRequestresources/read} request.",
+            "type": "object",
+            "properties": {
+                "contents": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/$defs/TextResourceContents"
+                            },
+                            {
+                                "$ref": "#/$defs/BlobResourceContents"
+                            }
+                        ]
+                    }
+                },
+                "ttlMs": {
+                    "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "cacheScope": {
+                    "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+                    "enum": [
+                        "private",
+                        "public"
+                    ],
+                    "type": "string"
+                },
                 "_meta": {
                     "$ref": "#/$defs/ResultMetaObject"
                 },
-                "content": {
-                    "description": "A list of content objects that represent the unstructured result of the tool call.",
-                    "items": {
-                        "$ref": "#/$defs/ContentBlock"
-                    },
-                    "type": "array"
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "cacheScope",
+                "contents",
+                "resultType",
+                "ttlMs"
+            ]
+        },
+        "ReadResourceResultResponse": {
+            "description": "A successful response from the server for a {@link ReadResourceRequestresources/read} request.",
+            "type": "object",
+            "properties": {
+                "result": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/InputRequiredResult"
+                        },
+                        {
+                            "$ref": "#/$defs/ReadResourceResult"
+                        }
+                    ]
                 },
-                "isError": {
-                    "description": "Whether the tool call ended in an error.\n\nIf not set, this is assumed to be false (the call was successful).\n\nAny errors that originate from the tool SHOULD be reported inside the result\nobject, with `isError` set to true, _not_ as an MCP protocol-level error\nresponse. Otherwise, the LLM would not be able to see that an error occurred\nand self-correct.\n\nHowever, any errors in _finding_ the tool, an error indicating that the\nserver does not support tool calls, or any other exceptional conditions,\nshould be reported as an MCP error response.",
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ]
+        },
+        "ResourceListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `resourcesListChanged` filter field.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/resources/list_changed"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "SubscriptionFilter": {
+            "description": "The set of notification types a client may opt in to on a\n{@link SubscriptionsListenRequestsubscriptions/listen} request.\n\nEach notification type is **opt-in**; the server **MUST NOT** send\nnotification types the client has not explicitly requested here.",
+            "type": "object",
+            "properties": {
+                "toolsListChanged": {
+                    "description": "If true, receive {@link ToolListChangedNotificationnotifications/tools/list_changed}.",
                     "type": "boolean"
+                },
+                "promptsListChanged": {
+                    "description": "If true, receive {@link PromptListChangedNotificationnotifications/prompts/list_changed}.",
+                    "type": "boolean"
+                },
+                "resourcesListChanged": {
+                    "description": "If true, receive {@link ResourceListChangedNotificationnotifications/resources/list_changed}.",
+                    "type": "boolean"
+                },
+                "resourceSubscriptions": {
+                    "description": "Subscribe to {@link ResourceUpdatedNotificationnotifications/resources/updated} for these resource URIs.\nReplaces the former `resources/subscribe` RPC.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "SubscriptionsListenRequestParams": {
+            "description": "Parameters for a {@link SubscriptionsListenRequestsubscriptions/listen} request.",
+            "type": "object",
+            "properties": {
+                "notifications": {
+                    "$ref": "#/$defs/SubscriptionFilter",
+                    "description": "The notifications the client opts in to on this stream. The server\n**MUST NOT** send notification types the client has not explicitly\nrequested."
+                },
+                "_meta": {
+                    "$ref": "#/$defs/RequestMetaObject"
+                }
+            },
+            "required": [
+                "_meta",
+                "notifications"
+            ]
+        },
+        "SubscriptionsListenRequest": {
+            "description": "Sent from the client to open a long-lived channel for receiving notifications\noutside the context of a specific request. Replaces the previous HTTP GET\nendpoint and ensures consistent behavior between HTTP and STDIO.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "subscriptions/listen"
+                },
+                "params": {
+                    "$ref": "#/$defs/SubscriptionsListenRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "SubscriptionsListenResultMeta": {
+            "description": "Extends {@link ResultMetaObject} with the subscription-stream identifier carried by a\n{@link SubscriptionsListenResult}. All key naming rules from `MetaObject` apply.",
+            "type": "object",
+            "properties": {
+                "io.modelcontextprotocol/subscriptionId": {
+                    "$ref": "#/$defs/RequestId",
+                    "description": "Identifies the subscription stream this response closes, so the client can\ncorrelate it with the originating subscription — mirroring the same key on\nthe stream's notifications. The value is the JSON-RPC ID of the\n`subscriptions/listen` request that opened the stream (and equals this\nresponse's `id`)."
+                },
+                "io.modelcontextprotocol/serverInfo": {
+                    "$ref": "#/$defs/Implementation",
+                    "description": "Identifies the server software producing the response. Servers SHOULD\ninclude this field on every response unless specifically configured not\nto do so.\n\nThe {@link Implementation} schema requires `name` and `version`; other\nfields are optional.\n\nThe value is self-reported by the server and is not verified by the\nprotocol. It is intended for display, logging, and debugging. Clients\nSHOULD NOT use it to change their behavior, and SHOULD NOT rely on it for\nsecurity decisions."
+                }
+            },
+            "required": [
+                "io.modelcontextprotocol/subscriptionId"
+            ]
+        },
+        "SubscriptionsListenResult": {
+            "description": "The response to a {@link SubscriptionsListenRequestsubscriptions/listen}\nrequest, signalling that the subscription has ended gracefully (for example,\nduring server shutdown). Because the listen stream is long-lived, this result\nis sent only when the server tears the subscription down; an abrupt transport\nclose carries no response. The result body is otherwise empty.",
+            "type": "object",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/SubscriptionsListenResultMeta"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "_meta",
+                "resultType"
+            ]
+        },
+        "SubscriptionsAcknowledgedNotificationParams": {
+            "description": "Parameters for a {@link SubscriptionsAcknowledgedNotificationnotifications/subscriptions/acknowledged} notification.",
+            "type": "object",
+            "properties": {
+                "notifications": {
+                    "$ref": "#/$defs/SubscriptionFilter",
+                    "description": "The subset of requested notification types the server agreed to honor.\nOnly includes notification types the server actually supports; if the\nclient requested an unsupported type (e.g., `promptsListChanged` when\nthe server has no prompts), it is omitted from this set."
+                },
+                "_meta": {
+                    "$ref": "#/$defs/NotificationMetaObject"
+                }
+            },
+            "required": [
+                "notifications"
+            ]
+        },
+        "SubscriptionsAcknowledgedNotification": {
+            "description": "Sent by the server to acknowledge that a\n{@link SubscriptionsListenRequestsubscriptions/listen} subscription has been\nestablished and to report which notification types it agreed to honor.\n\nThis notification MUST be the first message the server sends carrying the\nsubscription's ID in `io.modelcontextprotocol/subscriptionId`. The server MUST\nNOT send any notification on the subscription before acknowledging it. On\nstdio, where every subscription shares one channel, this ordering is defined\nper subscription ID and not per channel: messages belonging to other\nsubscriptions MAY be interleaved before it.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/subscriptions/acknowledged"
+                },
+                "params": {
+                    "$ref": "#/$defs/SubscriptionsAcknowledgedNotificationParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "ResourceUpdatedNotificationParams": {
+            "description": "Parameters for a `notifications/resources/updated` notification.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "_meta": {
+                    "$ref": "#/$defs/NotificationMetaObject"
+                }
+            },
+            "required": [
+                "uri"
+            ]
+        },
+        "ResourceUpdatedNotification": {
+            "description": "A notification from the server to the client, informing it that a resource has changed and may need to be read again. This is only sent for resources the client opted in to via the `resourceSubscriptions` field of a {@link SubscriptionsListenRequestsubscriptions/listen} request.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/resources/updated"
+                },
+                "params": {
+                    "$ref": "#/$defs/ResourceUpdatedNotificationParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "ResourceTemplate": {
+            "description": "A template description for resources available on the server.",
+            "type": "object",
+            "properties": {
+                "uriTemplate": {
+                    "description": "A URI template (according to RFC 6570) that can be used to construct resource URIs.",
+                    "format": "uri-template",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "uriTemplate"
+            ]
+        },
+        "ResourceContents": {
+            "description": "The contents of a specific resource or sub-resource.",
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                }
+            },
+            "required": [
+                "uri"
+            ]
+        },
+        "TextResourceContents": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                }
+            },
+            "required": [
+                "text",
+                "uri"
+            ]
+        },
+        "BlobResourceContents": {
+            "type": "object",
+            "properties": {
+                "blob": {
+                    "description": "A base64-encoded string representing the binary data of the item.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                }
+            },
+            "required": [
+                "blob",
+                "uri"
+            ]
+        },
+        "ListPromptsRequest": {
+            "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "prompts/list"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "ListPromptsResult": {
+            "description": "The result returned by the server for a {@link ListPromptsRequestprompts/list} request.",
+            "type": "object",
+            "properties": {
+                "prompts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Prompt"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "$ref": "#/$defs/ResultMetaObject"
                 },
                 "resultType": {
                     "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
                     "type": "string"
                 },
+                "ttlMs": {
+                    "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "cacheScope": {
+                    "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+                    "enum": [
+                        "private",
+                        "public"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "cacheScope",
+                "prompts",
+                "resultType",
+                "ttlMs"
+            ]
+        },
+        "ListPromptsResultResponse": {
+            "description": "A successful response from the server for a {@link ListPromptsRequestprompts/list} request.",
+            "type": "object",
+            "properties": {
+                "result": {
+                    "$ref": "#/$defs/ListPromptsResult"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ]
+        },
+        "GetPromptRequestParams": {
+            "description": "Parameters for a `prompts/get` request.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The name of the prompt or prompt template.",
+                    "type": "string"
+                },
+                "arguments": {
+                    "description": "Arguments to use for templating the prompt.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "inputResponses": {
+                    "$ref": "#/$defs/InputResponses"
+                },
+                "requestState": {
+                    "type": "string"
+                },
+                "_meta": {
+                    "$ref": "#/$defs/RequestMetaObject"
+                }
+            },
+            "required": [
+                "_meta",
+                "name"
+            ]
+        },
+        "GetPromptRequest": {
+            "description": "Used by the client to get a prompt provided by the server.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "prompts/get"
+                },
+                "params": {
+                    "$ref": "#/$defs/GetPromptRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "GetPromptResult": {
+            "description": "The result returned by the server for a {@link GetPromptRequestprompts/get} request.",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "An optional description for the prompt.",
+                    "type": "string"
+                },
+                "messages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/PromptMessage"
+                    }
+                },
+                "_meta": {
+                    "$ref": "#/$defs/ResultMetaObject"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "messages",
+                "resultType"
+            ]
+        },
+        "GetPromptResultResponse": {
+            "description": "A successful response from the server for a {@link GetPromptRequestprompts/get} request.",
+            "type": "object",
+            "properties": {
+                "result": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/InputRequiredResult"
+                        },
+                        {
+                            "$ref": "#/$defs/GetPromptResult"
+                        }
+                    ]
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ]
+        },
+        "Prompt": {
+            "description": "A prompt or prompt template that the server offers.",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "An optional description of what this prompt provides",
+                    "type": "string"
+                },
+                "arguments": {
+                    "description": "A list of arguments to use for templating the prompt.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/PromptArgument"
+                    }
+                },
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    }
+                }
+            },
+            "required": [
+                "name"
+            ]
+        },
+        "PromptArgument": {
+            "description": "Describes an argument that a prompt can accept.",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "A human-readable description of the argument.",
+                    "type": "string"
+                },
+                "required": {
+                    "description": "Whether this argument must be provided.",
+                    "type": "boolean"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ]
+        },
+        "Role": {
+            "description": "The sender or recipient of messages and data in a conversation.",
+            "enum": [
+                "assistant",
+                "user"
+            ],
+            "type": "string"
+        },
+        "PromptMessage": {
+            "description": "Describes a message returned as part of a prompt.\n\nThis is similar to {@link SamplingMessage}, but also supports the embedding of\nresources from the MCP server.",
+            "type": "object",
+            "properties": {
+                "role": {
+                    "$ref": "#/$defs/Role"
+                },
+                "content": {
+                    "$ref": "#/$defs/ContentBlock"
+                }
+            },
+            "required": [
+                "content",
+                "role"
+            ]
+        },
+        "ResourceLink": {
+            "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of {@link ListResourcesRequestresources/list} requests.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "resource_link"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "size": {
+                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+                    "type": "integer"
+                },
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "type",
+                "uri"
+            ]
+        },
+        "EmbeddedResource": {
+            "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "resource"
+                },
+                "resource": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TextResourceContents"
+                        },
+                        {
+                            "$ref": "#/$defs/BlobResourceContents"
+                        }
+                    ]
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                }
+            },
+            "required": [
+                "resource",
+                "type"
+            ]
+        },
+        "PromptListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `promptsListChanged` filter field.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/prompts/list_changed"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "ListToolsRequest": {
+            "description": "Sent from the client to request a list of tools the server has.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "tools/list"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "ListToolsResult": {
+            "description": "The result returned by the server for a {@link ListToolsRequesttools/list} request.",
+            "type": "object",
+            "properties": {
+                "tools": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Tool"
+                    }
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "_meta": {
+                    "$ref": "#/$defs/ResultMetaObject"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                },
+                "ttlMs": {
+                    "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "cacheScope": {
+                    "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+                    "enum": [
+                        "private",
+                        "public"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "cacheScope",
+                "resultType",
+                "tools",
+                "ttlMs"
+            ]
+        },
+        "ListToolsResultResponse": {
+            "description": "A successful response from the server for a {@link ListToolsRequesttools/list} request.",
+            "type": "object",
+            "properties": {
+                "result": {
+                    "$ref": "#/$defs/ListToolsResult"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                }
+            },
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ]
+        },
+        "CallToolResult": {
+            "description": "The result returned by the server for a {@link CallToolRequesttools/call} request.",
+            "type": "object",
+            "properties": {
+                "content": {
+                    "description": "A list of content objects that represent the unstructured result of the tool call.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/ContentBlock"
+                    }
+                },
                 "structuredContent": {
                     "description": "An optional JSON value that represents the structured result of the tool call.\n\nThis can be any JSON value (object, array, string, number, boolean, or null)\nthat conforms to the tool's outputSchema if one is defined."
+                },
+                "isError": {
+                    "description": "Whether the tool call ended in an error.\n\nIf not set, this is assumed to be false (the call was successful).\n\nAny errors that originate from the tool SHOULD be reported inside the result\nobject, with `isError` set to true, _not_ as an MCP protocol-level error\nresponse. Otherwise, the LLM would not be able to see that an error occurred\nand self-correct.\n\nHowever, any errors in _finding_ the tool, an error indicating that the\nserver does not support tool calls, or any other exceptional conditions,\nshould be reported as an MCP error response.",
+                    "type": "boolean"
+                },
+                "_meta": {
+                    "$ref": "#/$defs/ResultMetaObject"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
                 }
             },
             "required": [
                 "content",
                 "resultType"
-            ],
-            "type": "object"
+            ]
         },
         "CallToolResultResponse": {
             "description": "A successful response from the server for a {@link CallToolRequesttools/call} request.",
+            "type": "object",
             "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
                 "result": {
                     "anyOf": [
                         {
@@ -254,310 +2286,470 @@
                             "$ref": "#/$defs/CallToolResult"
                         }
                     ]
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
                 }
             },
             "required": [
                 "id",
                 "jsonrpc",
                 "result"
-            ],
-            "type": "object"
-        },
-        "CancelledNotification": {
-            "description": "This notification is sent by the client to indicate that it is cancelling a request it previously issued.\n\nOn stdio, the server also sends this notification, solely to terminate a {@link SubscriptionsListenRequestsubscriptions/listen} stream: it references the ID of the `subscriptions/listen` request that opened the stream. Servers MUST NOT use this notification to cancel any other request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "notifications/cancelled",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/CancelledNotificationParams"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "CancelledNotificationParams": {
-            "description": "Parameters for a `notifications/cancelled` notification.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/NotificationMetaObject"
-                },
-                "reason": {
-                    "description": "An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.",
-                    "type": "string"
-                },
-                "requestId": {
-                    "$ref": "#/$defs/RequestId",
-                    "description": "The ID of the request to cancel.\n\nThis MUST correspond to the ID of a request the client previously issued."
-                }
-            },
-            "required": [
-                "requestId"
-            ],
-            "type": "object"
-        },
-        "ClientCapabilities": {
-            "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
-            "properties": {
-                "elicitation": {
-                    "description": "Present if the client supports elicitation from the server.",
-                    "properties": {
-                        "form": {
-                            "$ref": "#/$defs/JSONObject"
-                        },
-                        "url": {
-                            "$ref": "#/$defs/JSONObject"
-                        }
-                    },
-                    "type": "object"
-                },
-                "experimental": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/JSONObject"
-                    },
-                    "description": "Experimental, non-standard capabilities that the client supports.",
-                    "type": "object"
-                },
-                "extensions": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/JSONObject"
-                    },
-                    "description": "Optional MCP extensions that the client supports. Keys are extension identifiers\n(e.g., \"io.modelcontextprotocol/oauth-client-credentials\"), and values are\nper-extension settings objects. An empty object indicates support with no settings.\n\nKeys MUST follow the {@link MetaObject`_meta` key naming rules}, with a\nmandatory prefix.",
-                    "type": "object"
-                },
-                "roots": {
-                    "description": "Present if the client supports listing roots.",
-                    "properties": {},
-                    "type": "object"
-                },
-                "sampling": {
-                    "description": "Present if the client supports sampling from an LLM.",
-                    "properties": {
-                        "context": {
-                            "$ref": "#/$defs/JSONObject",
-                            "description": "Whether the client supports context inclusion via `includeContext` parameter.\nIf not declared, servers SHOULD only use `includeContext: \"none\"` (or omit it)."
-                        },
-                        "tools": {
-                            "$ref": "#/$defs/JSONObject",
-                            "description": "Whether the client supports tool use via `tools` and `toolChoice` parameters."
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
-        },
-        "ClientNotification": {
-            "description": "This notification is sent by the client to indicate that it is cancelling a request it previously issued.\n\nOn stdio, the server also sends this notification, solely to terminate a {@link SubscriptionsListenRequestsubscriptions/listen} stream: it references the ID of the `subscriptions/listen` request that opened the stream. Servers MUST NOT use this notification to cancel any other request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "notifications/cancelled",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/CancelledNotificationParams"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ClientRequest": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/DiscoverRequest"
-                },
-                {
-                    "$ref": "#/$defs/ListResourcesRequest"
-                },
-                {
-                    "$ref": "#/$defs/ListResourceTemplatesRequest"
-                },
-                {
-                    "$ref": "#/$defs/ReadResourceRequest"
-                },
-                {
-                    "$ref": "#/$defs/SubscriptionsListenRequest"
-                },
-                {
-                    "$ref": "#/$defs/ListPromptsRequest"
-                },
-                {
-                    "$ref": "#/$defs/GetPromptRequest"
-                },
-                {
-                    "$ref": "#/$defs/ListToolsRequest"
-                },
-                {
-                    "$ref": "#/$defs/CallToolRequest"
-                },
-                {
-                    "$ref": "#/$defs/CompleteRequest"
-                }
             ]
         },
-        "ClientResult": {
-            "$ref": "#/$defs/Result",
-            "description": "Common result fields."
-        },
-        "CompleteRequest": {
-            "description": "A request from the client to the server, to ask for completion options.",
+        "CallToolRequestParams": {
+            "description": "Parameters for a `tools/call` request.",
+            "type": "object",
             "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
+                "name": {
+                    "description": "The name of the tool.",
                     "type": "string"
                 },
-                "method": {
-                    "const": "completion/complete",
+                "arguments": {
+                    "description": "Arguments to use for the tool call.",
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "inputResponses": {
+                    "$ref": "#/$defs/InputResponses"
+                },
+                "requestState": {
                     "type": "string"
                 },
-                "params": {
-                    "$ref": "#/$defs/CompleteRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "CompleteRequestParams": {
-            "description": "Parameters for a `completion/complete` request.",
-            "properties": {
                 "_meta": {
                     "$ref": "#/$defs/RequestMetaObject"
-                },
-                "argument": {
-                    "description": "The argument's information",
-                    "properties": {
-                        "name": {
-                            "description": "The name of the argument",
-                            "type": "string"
-                        },
-                        "value": {
-                            "description": "The value of the argument to use for completion matching.",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "name",
-                        "value"
-                    ],
-                    "type": "object"
-                },
-                "context": {
-                    "description": "Additional, optional context for completions",
-                    "properties": {
-                        "arguments": {
-                            "additionalProperties": {
-                                "type": "string"
-                            },
-                            "description": "Previously-resolved variables in a URI template or prompt.",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                },
-                "ref": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/$defs/PromptReference"
-                        },
-                        {
-                            "$ref": "#/$defs/ResourceTemplateReference"
-                        }
-                    ]
                 }
             },
             "required": [
                 "_meta",
-                "argument",
-                "ref"
-            ],
-            "type": "object"
+                "name"
+            ]
         },
-        "CompleteResult": {
-            "description": "The result returned by the server for a {@link CompleteRequestcompletion/complete} request.",
+        "CallToolRequest": {
+            "description": "Used by the client to invoke a tool provided by the server.",
+            "type": "object",
             "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/ResultMetaObject"
+                "method": {
+                    "type": "string",
+                    "const": "tools/call"
                 },
-                "completion": {
-                    "properties": {
-                        "hasMore": {
-                            "description": "Indicates whether there are additional completion options beyond those provided in the current response, even if the exact total is unknown.",
-                            "type": "boolean"
-                        },
-                        "total": {
-                            "description": "The total number of completion options available. This can exceed the number of values actually sent in the response.",
-                            "type": "integer"
-                        },
-                        "values": {
-                            "description": "An array of completion values. Must not exceed 100 items.",
-                            "items": {
-                                "type": "string"
-                            },
-                            "maxItems": 100,
-                            "type": "array"
-                        }
-                    },
-                    "required": [
-                        "values"
-                    ],
-                    "type": "object"
-                },
-                "resultType": {
-                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "completion",
-                "resultType"
-            ],
-            "type": "object"
-        },
-        "CompleteResultResponse": {
-            "description": "A successful response from the server for a {@link CompleteRequestcompletion/complete} request.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
+                "params": {
+                    "$ref": "#/$defs/CallToolRequestParams"
                 },
                 "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
+                    "type": "string",
+                    "const": "2.0"
                 },
-                "result": {
-                    "$ref": "#/$defs/CompleteResult"
+                "id": {
+                    "$ref": "#/$defs/RequestId"
                 }
             },
             "required": [
                 "id",
                 "jsonrpc",
-                "result"
+                "method",
+                "params"
+            ]
+        },
+        "ToolListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of tools it offers has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `toolsListChanged` filter field.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/tools/list_changed"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method"
+            ]
+        },
+        "ToolAnnotations": {
+            "description": "Additional properties describing a {@link Tool} to clients.\n\nNOTE: all properties in `ToolAnnotations` are **hints**.\nThey are not guaranteed to provide a faithful description of\ntool behavior (including descriptive properties like `title`).\n\nClients should never make tool use decisions based on `ToolAnnotations`\nreceived from untrusted servers.",
+            "type": "object",
+            "properties": {
+                "title": {
+                    "description": "A human-readable title for the tool.",
+                    "type": "string"
+                },
+                "readOnlyHint": {
+                    "description": "If true, the tool does not modify its environment.\n\nDefault: false",
+                    "type": "boolean"
+                },
+                "destructiveHint": {
+                    "description": "If true, the tool may perform destructive updates to its environment.\nIf false, the tool performs only additive updates.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: true",
+                    "type": "boolean"
+                },
+                "idempotentHint": {
+                    "description": "If true, calling the tool repeatedly with the same arguments\nwill have no additional effect on its environment.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: false",
+                    "type": "boolean"
+                },
+                "openWorldHint": {
+                    "description": "If true, this tool may interact with an \"open world\" of external\nentities. If false, the tool's domain of interaction is closed.\nFor example, the world of a web search tool is open, whereas that\nof a memory tool is not.\n\nDefault: true",
+                    "type": "boolean"
+                }
+            }
+        },
+        "Tool": {
+            "description": "Definition for a tool the client can call.",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "inputSchema": {
+                    "description": "A JSON Schema object defining the expected parameters for the tool.\n\nTool arguments are always JSON objects, so `type: \"object\"` is required at the root.\nBeyond that, any JSON Schema 2020-12 keyword may appear alongside `type` — including\ncomposition keywords (`oneOf`, `anyOf`, `allOf`, `not`), conditional keywords\n(`if`/`then`/`else`), reference keywords (`$ref`, `$defs`, `$anchor`), and any other\nstandard validation or annotation keywords.\n\nProperty schemas may carry an `x-mcp-header` annotation to mirror the\nargument value into an HTTP header on the Streamable HTTP transport. See\nthe Streamable HTTP transport specification for the validity and\nextraction rules.\n\nDefaults to JSON Schema 2020-12 when no explicit `$schema` is provided.",
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "$schema": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string",
+                            "const": "object"
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ]
+                },
+                "outputSchema": {
+                    "description": "An optional JSON Schema object defining the structure of the tool's output returned in\nthe structuredContent field of a {@link CallToolResult}. This can be any valid JSON Schema 2020-12.\n\nDefaults to JSON Schema 2020-12 when no explicit `$schema` is provided.",
+                    "type": "object",
+                    "additionalProperties": {},
+                    "properties": {
+                        "$schema": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "annotations": {
+                    "$ref": "#/$defs/ToolAnnotations",
+                    "description": "Optional additional tool information.\n\nDisplay name precedence order is: `title`, `annotations.title`, then `name`."
+                },
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    }
+                }
+            },
+            "required": [
+                "inputSchema",
+                "name"
+            ]
+        },
+        "LoggingMessageNotificationParams": {
+            "description": "Parameters for a `notifications/message` notification.",
+            "type": "object",
+            "properties": {
+                "level": {
+                    "$ref": "#/$defs/LoggingLevel",
+                    "description": "The severity of this log message."
+                },
+                "logger": {
+                    "description": "An optional name of the logger issuing this message.",
+                    "type": "string"
+                },
+                "data": {
+                    "description": "The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here."
+                },
+                "_meta": {
+                    "$ref": "#/$defs/NotificationMetaObject"
+                }
+            },
+            "required": [
+                "data",
+                "level"
+            ]
+        },
+        "LoggingMessageNotification": {
+            "description": "JSONRPCNotification of a log message passed from server to client. The client opts in by setting `\"io.modelcontextprotocol/logLevel\"` in a request's `_meta`.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/message"
+                },
+                "params": {
+                    "$ref": "#/$defs/LoggingMessageNotificationParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                }
+            },
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ]
+        },
+        "LoggingLevel": {
+            "description": "The severity of a log message.\n\nThese map to syslog message severities, as specified in RFC-5424:\nhttps://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1",
+            "enum": [
+                "alert",
+                "critical",
+                "debug",
+                "emergency",
+                "error",
+                "info",
+                "notice",
+                "warning"
             ],
-            "type": "object"
+            "type": "string"
+        },
+        "CreateMessageRequestParams": {
+            "description": "Parameters for a `sampling/createMessage` request.",
+            "type": "object",
+            "properties": {
+                "messages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/SamplingMessage"
+                    }
+                },
+                "modelPreferences": {
+                    "$ref": "#/$defs/ModelPreferences",
+                    "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
+                },
+                "systemPrompt": {
+                    "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
+                    "type": "string"
+                },
+                "includeContext": {
+                    "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.\nThe client MAY ignore this request.\n\nDefault is `\"none\"`. The values `\"thisServer\"` and `\"allServers\"` are deprecated (SEP-2596): servers SHOULD\nomit this field or use `\"none\"`, and SHOULD only use the deprecated values if the client declares\n{@link ClientCapabilities.sampling.context}.",
+                    "enum": [
+                        "allServers",
+                        "none",
+                        "thisServer"
+                    ],
+                    "type": "string"
+                },
+                "temperature": {
+                    "type": "number"
+                },
+                "maxTokens": {
+                    "description": "The requested maximum number of tokens to sample (to prevent runaway completions).\n\nThe client MAY choose to sample fewer tokens than the requested maximum.",
+                    "type": "integer"
+                },
+                "stopSequences": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "metadata": {
+                    "$ref": "#/$defs/JSONObject",
+                    "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific."
+                },
+                "tools": {
+                    "description": "Tools that the model may use during generation.\nThe client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Tool"
+                    }
+                },
+                "toolChoice": {
+                    "$ref": "#/$defs/ToolChoice",
+                    "description": "Controls how the model uses tools.\nThe client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.\nDefault is `{ mode: \"auto\" }`."
+                }
+            },
+            "required": [
+                "maxTokens",
+                "messages"
+            ]
+        },
+        "ToolChoice": {
+            "description": "Controls tool selection behavior for sampling requests.",
+            "type": "object",
+            "properties": {
+                "mode": {
+                    "description": "Controls the tool use ability of the model:\n- `\"auto\"`: Model decides whether to use tools (default)\n- `\"required\"`: Model MUST use at least one tool before completing\n- `\"none\"`: Model MUST NOT use any tools",
+                    "enum": [
+                        "auto",
+                        "none",
+                        "required"
+                    ],
+                    "type": "string"
+                }
+            }
+        },
+        "CreateMessageRequest": {
+            "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "sampling/createMessage"
+                },
+                "params": {
+                    "$ref": "#/$defs/CreateMessageRequestParams"
+                }
+            },
+            "required": [
+                "method",
+                "params"
+            ]
+        },
+        "CreateMessageResult": {
+            "description": "The result returned by the client for a {@link CreateMessageRequestsampling/createMessage} request.\nThe client should inform the user before returning the sampled message, to allow them\nto inspect the response (human in the loop) and decide whether to allow the server to see it.",
+            "type": "object",
+            "properties": {
+                "model": {
+                    "description": "The name of the model that generated the message.",
+                    "type": "string"
+                },
+                "stopReason": {
+                    "description": "The reason why sampling stopped, if known.\n\nStandard values:\n- `\"endTurn\"`: Natural end of the assistant's turn\n- `\"stopSequence\"`: A stop sequence was encountered\n- `\"maxTokens\"`: Maximum token limit was reached\n- `\"toolUse\"`: The model wants to use one or more tools\n\nThis field is an open string to allow for provider-specific stop reasons.",
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/$defs/Role"
+                },
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TextContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ImageContent"
+                        },
+                        {
+                            "$ref": "#/$defs/AudioContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolUseContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolResultContent"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/SamplingMessageContentBlock"
+                            }
+                        }
+                    ]
+                },
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                }
+            },
+            "required": [
+                "content",
+                "model",
+                "role"
+            ]
+        },
+        "SamplingMessage": {
+            "description": "Describes a message issued to or received from an LLM API.",
+            "type": "object",
+            "properties": {
+                "role": {
+                    "$ref": "#/$defs/Role"
+                },
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TextContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ImageContent"
+                        },
+                        {
+                            "$ref": "#/$defs/AudioContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolUseContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolResultContent"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/SamplingMessageContentBlock"
+                            }
+                        }
+                    ]
+                },
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                }
+            },
+            "required": [
+                "content",
+                "role"
+            ]
+        },
+        "SamplingMessageContentBlock": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/TextContent"
+                },
+                {
+                    "$ref": "#/$defs/ImageContent"
+                },
+                {
+                    "$ref": "#/$defs/AudioContent"
+                },
+                {
+                    "$ref": "#/$defs/ToolUseContent"
+                },
+                {
+                    "$ref": "#/$defs/ToolResultContent"
+                }
+            ]
+        },
+        "Annotations": {
+            "description": "Optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
+            "type": "object",
+            "properties": {
+                "audience": {
+                    "description": "Describes who the intended audience of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Role"
+                    }
+                },
+                "priority": {
+                    "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "lastModified": {
+                    "description": "The moment the resource was last modified, as an ISO 8601 formatted string.\n\nShould be an ISO 8601 formatted string (e.g., \"2025-01-12T15:00:58Z\").\n\nExamples: last activity timestamp in an open file, timestamp when the resource\nwas attached, etc.",
+                    "type": "string"
+                }
+            }
         },
         "ContentBlock": {
             "anyOf": [
@@ -578,154 +2770,276 @@
                 }
             ]
         },
-        "CreateMessageRequest": {
-            "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
+        "TextContent": {
+            "description": "Text provided to or from an LLM.",
+            "type": "object",
             "properties": {
-                "method": {
-                    "const": "sampling/createMessage",
+                "type": {
+                    "type": "string",
+                    "const": "text"
+                },
+                "text": {
+                    "description": "The text content of the message.",
                     "type": "string"
                 },
-                "params": {
-                    "$ref": "#/$defs/CreateMessageRequestParams"
-                }
-            },
-            "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "CreateMessageRequestParams": {
-            "description": "Parameters for a `sampling/createMessage` request.",
-            "properties": {
-                "includeContext": {
-                    "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.\nThe client MAY ignore this request.\n\nDefault is `\"none\"`. The values `\"thisServer\"` and `\"allServers\"` are deprecated (SEP-2596): servers SHOULD\nomit this field or use `\"none\"`, and SHOULD only use the deprecated values if the client declares\n{@link ClientCapabilities.sampling.context}.",
-                    "enum": [
-                        "allServers",
-                        "none",
-                        "thisServer"
-                    ],
-                    "type": "string"
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
                 },
-                "maxTokens": {
-                    "description": "The requested maximum number of tokens to sample (to prevent runaway completions).\n\nThe client MAY choose to sample fewer tokens than the requested maximum.",
-                    "type": "integer"
-                },
-                "messages": {
-                    "items": {
-                        "$ref": "#/$defs/SamplingMessage"
-                    },
-                    "type": "array"
-                },
-                "metadata": {
-                    "$ref": "#/$defs/JSONObject",
-                    "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific."
-                },
-                "modelPreferences": {
-                    "$ref": "#/$defs/ModelPreferences",
-                    "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
-                },
-                "stopSequences": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "systemPrompt": {
-                    "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
-                    "type": "string"
-                },
-                "temperature": {
-                    "type": "number"
-                },
-                "toolChoice": {
-                    "$ref": "#/$defs/ToolChoice",
-                    "description": "Controls how the model uses tools.\nThe client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.\nDefault is `{ mode: \"auto\" }`."
-                },
-                "tools": {
-                    "description": "Tools that the model may use during generation.\nThe client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.",
-                    "items": {
-                        "$ref": "#/$defs/Tool"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "maxTokens",
-                "messages"
-            ],
-            "type": "object"
-        },
-        "CreateMessageResult": {
-            "description": "The result returned by the client for a {@link CreateMessageRequestsampling/createMessage} request.\nThe client should inform the user before returning the sampled message, to allow them\nto inspect the response (human in the loop) and decide whether to allow the server to see it.",
-            "properties": {
                 "_meta": {
                     "$ref": "#/$defs/MetaObject"
+                }
+            },
+            "required": [
+                "text",
+                "type"
+            ]
+        },
+        "ImageContent": {
+            "description": "An image provided to or from an LLM.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "image"
+                },
+                "data": {
+                    "description": "The base64-encoded image data.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of the image. Different providers may support different image types.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                }
+            },
+            "required": [
+                "data",
+                "mimeType",
+                "type"
+            ]
+        },
+        "AudioContent": {
+            "description": "Audio provided to or from an LLM.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "audio"
+                },
+                "data": {
+                    "description": "The base64-encoded audio data.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of the audio. Different providers may support different audio types.",
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                }
+            },
+            "required": [
+                "data",
+                "mimeType",
+                "type"
+            ]
+        },
+        "ToolUseContent": {
+            "description": "A request from the assistant to call a tool.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "tool_use"
+                },
+                "id": {
+                    "description": "A unique identifier for this tool use.\n\nThis ID is used to match tool results to their corresponding tool uses.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The name of the tool to call.",
+                    "type": "string"
+                },
+                "input": {
+                    "description": "The arguments to pass to the tool, conforming to the tool's input schema.",
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject",
+                    "description": "Optional metadata about the tool use. Clients SHOULD preserve this field when\nincluding tool uses in subsequent sampling requests to enable caching optimizations."
+                }
+            },
+            "required": [
+                "id",
+                "input",
+                "name",
+                "type"
+            ]
+        },
+        "ToolResultContent": {
+            "description": "The result of a tool use, provided by the user back to the assistant.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "tool_result"
+                },
+                "toolUseId": {
+                    "description": "The ID of the tool use this result corresponds to.\n\nThis MUST match the ID from a previous {@link ToolUseContent}.",
+                    "type": "string"
                 },
                 "content": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/$defs/TextContent"
-                        },
-                        {
-                            "$ref": "#/$defs/ImageContent"
-                        },
-                        {
-                            "$ref": "#/$defs/AudioContent"
-                        },
-                        {
-                            "$ref": "#/$defs/ToolUseContent"
-                        },
-                        {
-                            "$ref": "#/$defs/ToolResultContent"
-                        },
-                        {
-                            "items": {
-                                "$ref": "#/$defs/SamplingMessageContentBlock"
-                            },
-                            "type": "array"
-                        }
-                    ]
+                    "description": "The unstructured result content of the tool use.\n\nThis has the same format as {@link CallToolResult.content} and can include text, images,\naudio, resource links, and embedded resources.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/ContentBlock"
+                    }
                 },
-                "model": {
-                    "description": "The name of the model that generated the message.",
-                    "type": "string"
+                "structuredContent": {
+                    "description": "An optional structured result value.\n\nThis can be any JSON value (object, array, string, number, boolean, or null).\nIf the tool defined an {@link Tool.outputSchema}, this SHOULD conform to that schema."
                 },
-                "role": {
-                    "$ref": "#/$defs/Role"
+                "isError": {
+                    "description": "Whether the tool use resulted in an error.\n\nIf true, the content typically describes the error that occurred.\nDefault: false",
+                    "type": "boolean"
                 },
-                "stopReason": {
-                    "description": "The reason why sampling stopped, if known.\n\nStandard values:\n- `\"endTurn\"`: Natural end of the assistant's turn\n- `\"stopSequence\"`: A stop sequence was encountered\n- `\"maxTokens\"`: Maximum token limit was reached\n- `\"toolUse\"`: The model wants to use one or more tools\n\nThis field is an open string to allow for provider-specific stop reasons.",
-                    "type": "string"
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject",
+                    "description": "Optional metadata about the tool result. Clients SHOULD preserve this field when\nincluding tool results in subsequent sampling requests to enable caching optimizations."
                 }
             },
             "required": [
                 "content",
-                "model",
-                "role"
-            ],
-            "type": "object"
+                "toolUseId",
+                "type"
+            ]
         },
-        "Cursor": {
-            "description": "An opaque token used to represent a cursor for pagination.",
-            "type": "string"
-        },
-        "DiscoverRequest": {
-            "description": "A request from the client asking the server to advertise its supported\nprotocol versions, capabilities, and other metadata. Servers **MUST**\nimplement `server/discover`. Clients **MAY** call it but are not required\nto — version negotiation can also happen inline via per-request `_meta`.",
+        "ModelPreferences": {
+            "description": "The server's preferences for model selection, requested of the client during sampling.\n\nBecause LLMs can vary along multiple dimensions, choosing the \"best\" model is\nrarely straightforward.  Different models excel in different areas—some are\nfaster but less capable, others are more capable but more expensive, and so\non. This interface allows servers to express their priorities across multiple\ndimensions to help clients make an appropriate selection for their use case.\n\nThese preferences are always advisory. The client MAY ignore them. It is also\nup to the client to decide how to interpret these preferences and how to\nbalance them against other considerations.",
+            "type": "object",
             "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
+                "hints": {
+                    "description": "Optional hints to use for model selection.\n\nIf multiple hints are specified, the client MUST evaluate them in order\n(such that the first match is taken).\n\nThe client SHOULD prioritize these hints over the numeric priorities, but\nMAY still use the priorities to select from ambiguous matches.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/ModelHint"
+                    }
                 },
-                "jsonrpc": {
-                    "const": "2.0",
+                "costPriority": {
+                    "description": "How much to prioritize cost when selecting a model. A value of 0 means cost\nis not important, while a value of 1 means cost is the most important\nfactor.",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "speedPriority": {
+                    "description": "How much to prioritize sampling speed (latency) when selecting a model. A\nvalue of 0 means speed is not important, while a value of 1 means speed is\nthe most important factor.",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
+                "intelligencePriority": {
+                    "description": "How much to prioritize intelligence and capabilities when selecting a\nmodel. A value of 0 means intelligence is not important, while a value of 1\nmeans intelligence is the most important factor.",
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                }
+            }
+        },
+        "ModelHint": {
+            "description": "Hints to use for model selection.\n\nKeys not declared here are currently left unspecified by the spec and are up\nto the client to interpret.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "A hint for a model name.\n\nThe client SHOULD treat this as a substring of a model name; for example:\n - `claude-3-5-sonnet` should match `claude-3-5-sonnet-20241022`\n - `sonnet` should match `claude-3-5-sonnet-20241022`, `claude-3-sonnet-20240229`, etc.\n - `claude` should match any Claude model\n\nThe client MAY also map the string to a different provider's model name or a different model family, as long as it fills a similar niche; for example:\n - `gemini-1.5-flash` could match `claude-3-haiku-20240307`",
                     "type": "string"
+                }
+            }
+        },
+        "CompleteRequestParams": {
+            "description": "Parameters for a `completion/complete` request.",
+            "type": "object",
+            "properties": {
+                "ref": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/PromptReference"
+                        },
+                        {
+                            "$ref": "#/$defs/ResourceTemplateReference"
+                        }
+                    ]
                 },
+                "argument": {
+                    "description": "The argument's information",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "description": "The name of the argument",
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "The value of the argument to use for completion matching.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "value"
+                    ]
+                },
+                "context": {
+                    "description": "Additional, optional context for completions",
+                    "type": "object",
+                    "properties": {
+                        "arguments": {
+                            "description": "Previously-resolved variables in a URI template or prompt.",
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "_meta": {
+                    "$ref": "#/$defs/RequestMetaObject"
+                }
+            },
+            "required": [
+                "_meta",
+                "argument",
+                "ref"
+            ]
+        },
+        "CompleteRequest": {
+            "description": "A request from the client to the server, to ask for completion options.",
+            "type": "object",
+            "properties": {
                 "method": {
-                    "const": "server/discover",
-                    "type": "string"
+                    "type": "string",
+                    "const": "completion/complete"
                 },
                 "params": {
-                    "$ref": "#/$defs/RequestParams"
+                    "$ref": "#/$defs/CompleteRequestParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
                 }
             },
             "required": [
@@ -733,164 +3047,206 @@
                 "jsonrpc",
                 "method",
                 "params"
-            ],
-            "type": "object"
+            ]
         },
-        "DiscoverResult": {
-            "description": "The result returned by the server for a {@link DiscoverRequestserver/discover} request.",
+        "CompleteResult": {
+            "description": "The result returned by the server for a {@link CompleteRequestcompletion/complete} request.",
+            "type": "object",
             "properties": {
+                "completion": {
+                    "type": "object",
+                    "properties": {
+                        "values": {
+                            "description": "An array of completion values. Must not exceed 100 items.",
+                            "maxItems": 100,
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "total": {
+                            "description": "The total number of completion options available. This can exceed the number of values actually sent in the response.",
+                            "type": "integer"
+                        },
+                        "hasMore": {
+                            "description": "Indicates whether there are additional completion options beyond those provided in the current response, even if the exact total is unknown.",
+                            "type": "boolean"
+                        }
+                    },
+                    "required": [
+                        "values"
+                    ]
+                },
                 "_meta": {
                     "$ref": "#/$defs/ResultMetaObject"
-                },
-                "cacheScope": {
-                    "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
-                    "enum": [
-                        "private",
-                        "public"
-                    ],
-                    "type": "string"
-                },
-                "capabilities": {
-                    "$ref": "#/$defs/ServerCapabilities",
-                    "description": "The capabilities of the server."
-                },
-                "instructions": {
-                    "description": "Natural-language guidance describing the server and its features.\n\nThis can be used by clients to improve an LLM's understanding of\navailable tools (e.g., by including it in a system prompt). It should\nfocus on information that helps the model use the server effectively\nand should not duplicate information already in tool descriptions.",
-                    "type": "string"
                 },
                 "resultType": {
                     "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
                     "type": "string"
-                },
-                "supportedVersions": {
-                    "description": "MCP Protocol Versions this server supports. The client should choose a\nversion from this list for use in subsequent requests.",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "ttlMs": {
-                    "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
-                    "minimum": 0,
-                    "type": "integer"
                 }
             },
             "required": [
-                "cacheScope",
-                "capabilities",
-                "resultType",
-                "supportedVersions",
-                "ttlMs"
-            ],
-            "type": "object"
+                "completion",
+                "resultType"
+            ]
         },
-        "DiscoverResultResponse": {
-            "description": "A successful response from the server for a {@link DiscoverRequestserver/discover} request.",
+        "CompleteResultResponse": {
+            "description": "A successful response from the server for a {@link CompleteRequestcompletion/complete} request.",
+            "type": "object",
             "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
+                "result": {
+                    "$ref": "#/$defs/CompleteResult"
                 },
                 "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
+                    "type": "string",
+                    "const": "2.0"
                 },
-                "result": {
-                    "$ref": "#/$defs/DiscoverResult"
+                "id": {
+                    "$ref": "#/$defs/RequestId"
                 }
             },
             "required": [
                 "id",
                 "jsonrpc",
                 "result"
-            ],
-            "type": "object"
+            ]
         },
-        "ElicitRequest": {
-            "description": "A request from the server to elicit additional information from the user via the client.",
+        "ResourceTemplateReference": {
+            "description": "A reference to a resource or resource template definition.",
+            "type": "object",
             "properties": {
-                "method": {
-                    "const": "elicitation/create",
-                    "type": "string"
+                "type": {
+                    "type": "string",
+                    "const": "ref/resource"
                 },
-                "params": {
-                    "$ref": "#/$defs/ElicitRequestParams"
+                "uri": {
+                    "description": "The URI or URI template of the resource.",
+                    "format": "uri-template",
+                    "type": "string"
                 }
             },
             "required": [
-                "method",
-                "params"
-            ],
-            "type": "object"
+                "type",
+                "uri"
+            ]
+        },
+        "PromptReference": {
+            "description": "Identifies a prompt.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "ref/prompt"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "type"
+            ]
+        },
+        "ListRootsRequest": {
+            "description": "Sent from the server to request a list of root URIs from the client. Roots allow\nservers to ask for specific directories or files to operate on. A common example\nfor roots is providing a set of repositories or directories a server should operate\non.\n\nThis request is typically used when the server needs to understand the file system\nstructure or access specific locations that the client has permission to read from.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "roots/list"
+                },
+                "params": {
+                    "type": "object",
+                    "properties": {
+                        "_meta": {
+                            "$ref": "#/$defs/MetaObject"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "method"
+            ]
+        },
+        "ListRootsResult": {
+            "description": "The result returned by the client for a {@link ListRootsRequestroots/list} request.\nThis result contains an array of {@link Root} objects, each representing a root directory\nor file that the server can operate on.",
+            "type": "object",
+            "properties": {
+                "roots": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/Root"
+                    }
+                }
+            },
+            "required": [
+                "roots"
+            ]
         },
         "ElicitRequestFormParams": {
             "description": "The parameters for a request to elicit non-sensitive information from the user via a form in the client.",
+            "type": "object",
             "properties": {
+                "mode": {
+                    "description": "The elicitation mode.",
+                    "type": "string",
+                    "const": "form"
+                },
                 "message": {
                     "description": "The message to present to the user describing what information is being requested.",
                     "type": "string"
                 },
-                "mode": {
-                    "const": "form",
-                    "description": "The elicitation mode.",
-                    "type": "string"
-                },
                 "requestedSchema": {
                     "description": "A restricted subset of JSON Schema.\nOnly top-level properties are allowed, without nesting.",
+                    "type": "object",
                     "properties": {
                         "$schema": {
                             "type": "string"
                         },
+                        "type": {
+                            "type": "string",
+                            "const": "object"
+                        },
                         "properties": {
+                            "type": "object",
                             "additionalProperties": {
                                 "$ref": "#/$defs/PrimitiveSchemaDefinition"
-                            },
-                            "type": "object"
+                            }
                         },
                         "required": {
+                            "type": "array",
                             "items": {
                                 "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "type": {
-                            "const": "object",
-                            "type": "string"
+                            }
                         }
                     },
                     "required": [
                         "properties",
                         "type"
-                    ],
-                    "type": "object"
+                    ]
                 }
             },
             "required": [
                 "message",
                 "requestedSchema"
-            ],
-            "type": "object"
-        },
-        "ElicitRequestParams": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/ElicitRequestFormParams"
-                },
-                {
-                    "$ref": "#/$defs/ElicitRequestURLParams"
-                }
-            ],
-            "description": "The parameters for a request to elicit additional information from the user via the client."
+            ]
         },
         "ElicitRequestURLParams": {
             "description": "The parameters for a request to elicit information from the user via a URL in the client.",
+            "type": "object",
             "properties": {
+                "mode": {
+                    "description": "The elicitation mode.",
+                    "type": "string",
+                    "const": "url"
+                },
                 "message": {
                     "description": "The message to present to the user explaining why the interaction is needed.",
-                    "type": "string"
-                },
-                "mode": {
-                    "const": "url",
-                    "description": "The elicitation mode.",
                     "type": "string"
                 },
                 "url": {
@@ -903,1436 +3259,38 @@
                 "message",
                 "mode",
                 "url"
-            ],
-            "type": "object"
+            ]
         },
-        "ElicitResult": {
-            "description": "The result returned by the client for an {@link ElicitRequestelicitation/create} request.",
-            "properties": {
-                "action": {
-                    "description": "The user action in response to the elicitation.\n- `\"accept\"`: User submitted the form/confirmed the action\n- `\"decline\"`: User explicitly declined the action\n- `\"cancel\"`: User dismissed without making an explicit choice",
-                    "enum": [
-                        "accept",
-                        "cancel",
-                        "decline"
-                    ],
-                    "type": "string"
-                },
-                "content": {
-                    "additionalProperties": {
-                        "anyOf": [
-                            {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
-                            {
-                                "type": [
-                                    "string",
-                                    "integer",
-                                    "boolean"
-                                ]
-                            }
-                        ]
-                    },
-                    "description": "The submitted form data, only present when action is `\"accept\"` and mode was `\"form\"`.\nContains values matching the requested schema.\nOmitted for out-of-band mode responses.",
-                    "type": "object"
-                }
-            },
-            "required": [
-                "action"
-            ],
-            "type": "object"
-        },
-        "EmbeddedResource": {
-            "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/MetaObject"
-                },
-                "annotations": {
-                    "$ref": "#/$defs/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "resource": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/$defs/TextResourceContents"
-                        },
-                        {
-                            "$ref": "#/$defs/BlobResourceContents"
-                        }
-                    ]
-                },
-                "type": {
-                    "const": "resource",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "resource",
-                "type"
-            ],
-            "type": "object"
-        },
-        "EmptyResult": {
-            "$ref": "#/$defs/Result",
-            "description": "Common result fields."
-        },
-        "EnumSchema": {
+        "ElicitRequestParams": {
+            "description": "The parameters for a request to elicit additional information from the user via the client.",
             "anyOf": [
                 {
-                    "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+                    "$ref": "#/$defs/ElicitRequestFormParams"
                 },
                 {
-                    "$ref": "#/$defs/TitledSingleSelectEnumSchema"
-                },
-                {
-                    "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
-                },
-                {
-                    "$ref": "#/$defs/TitledMultiSelectEnumSchema"
-                },
-                {
-                    "$ref": "#/$defs/LegacyTitledEnumSchema"
+                    "$ref": "#/$defs/ElicitRequestURLParams"
                 }
             ]
         },
-        "Error": {
+        "ElicitRequest": {
+            "description": "A request from the server to elicit additional information from the user via the client.",
+            "type": "object",
             "properties": {
-                "code": {
-                    "description": "The error type that occurred.",
-                    "type": "integer"
-                },
-                "data": {
-                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
-                },
-                "message": {
-                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "code",
-                "message"
-            ],
-            "type": "object"
-        },
-        "GetPromptRequest": {
-            "description": "Used by the client to get a prompt provided by the server.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
                 "method": {
-                    "const": "prompts/get",
-                    "type": "string"
+                    "type": "string",
+                    "const": "elicitation/create"
                 },
                 "params": {
-                    "$ref": "#/$defs/GetPromptRequestParams"
+                    "$ref": "#/$defs/ElicitRequestParams"
                 }
             },
             "required": [
-                "id",
-                "jsonrpc",
                 "method",
                 "params"
-            ],
-            "type": "object"
-        },
-        "GetPromptRequestParams": {
-            "description": "Parameters for a `prompts/get` request.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/RequestMetaObject"
-                },
-                "arguments": {
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "description": "Arguments to use for templating the prompt.",
-                    "type": "object"
-                },
-                "inputResponses": {
-                    "$ref": "#/$defs/InputResponses"
-                },
-                "name": {
-                    "description": "The name of the prompt or prompt template.",
-                    "type": "string"
-                },
-                "requestState": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "_meta",
-                "name"
-            ],
-            "type": "object"
-        },
-        "GetPromptResult": {
-            "description": "The result returned by the server for a {@link GetPromptRequestprompts/get} request.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/ResultMetaObject"
-                },
-                "description": {
-                    "description": "An optional description for the prompt.",
-                    "type": "string"
-                },
-                "messages": {
-                    "items": {
-                        "$ref": "#/$defs/PromptMessage"
-                    },
-                    "type": "array"
-                },
-                "resultType": {
-                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "messages",
-                "resultType"
-            ],
-            "type": "object"
-        },
-        "GetPromptResultResponse": {
-            "description": "A successful response from the server for a {@link GetPromptRequestprompts/get} request.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "result": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/$defs/InputRequiredResult"
-                        },
-                        {
-                            "$ref": "#/$defs/GetPromptResult"
-                        }
-                    ]
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "result"
-            ],
-            "type": "object"
-        },
-        "HeaderMismatchError": {
-            "description": "Returned when a server rejects a request because the values in the HTTP\nheaders do not match the corresponding values in the request body, or\nbecause required headers are missing or malformed. For HTTP, the response\nstatus code MUST be `400 Bad Request`.",
-            "properties": {
-                "error": {
-                    "allOf": [
-                        {
-                            "$ref": "#/$defs/Error"
-                        },
-                        {
-                            "properties": {
-                                "code": {
-                                    "const": -32020,
-                                    "type": "integer"
-                                }
-                            },
-                            "required": [
-                                "code"
-                            ],
-                            "type": "object"
-                        }
-                    ]
-                },
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "error",
-                "jsonrpc"
-            ],
-            "type": "object"
-        },
-        "Icon": {
-            "description": "An optionally-sized icon that can be displayed in a user interface.",
-            "properties": {
-                "mimeType": {
-                    "description": "Optional MIME type override if the source MIME type is missing or generic.\nFor example: `\"image/png\"`, `\"image/jpeg\"`, or `\"image/svg+xml\"`.",
-                    "type": "string"
-                },
-                "sizes": {
-                    "description": "Optional array of strings that specify sizes at which the icon can be used.\nEach string should be in WxH format (e.g., `\"48x48\"`, `\"96x96\"`) or `\"any\"` for scalable formats like SVG.\n\nIf not provided, the client should assume that the icon can be used at any size.",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "src": {
-                    "description": "A standard URI pointing to an icon resource. May be an HTTP/HTTPS URL or a\n`data:` URI with Base64-encoded image data.\n\nConsumers SHOULD take steps to ensure URLs serving icons are from the\nsame domain as the client/server or a trusted domain.\n\nConsumers SHOULD take appropriate precautions when consuming SVGs as they can contain\nexecutable JavaScript.",
-                    "format": "uri",
-                    "type": "string"
-                },
-                "theme": {
-                    "description": "Optional specifier for the theme this icon is designed for. `\"light\"` indicates\nthe icon is designed to be used with a light background, and `\"dark\"` indicates\nthe icon is designed to be used with a dark background.\n\nIf not provided, the client should assume the icon can be used with any theme.",
-                    "enum": [
-                        "dark",
-                        "light"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "src"
-            ],
-            "type": "object"
-        },
-        "Icons": {
-            "description": "Base interface to add `icons` property.",
-            "properties": {
-                "icons": {
-                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
-                    "items": {
-                        "$ref": "#/$defs/Icon"
-                    },
-                    "type": "array"
-                }
-            },
-            "type": "object"
-        },
-        "ImageContent": {
-            "description": "An image provided to or from an LLM.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/MetaObject"
-                },
-                "annotations": {
-                    "$ref": "#/$defs/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "data": {
-                    "description": "The base64-encoded image data.",
-                    "format": "byte",
-                    "type": "string"
-                },
-                "mimeType": {
-                    "description": "The MIME type of the image. Different providers may support different image types.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "image",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "data",
-                "mimeType",
-                "type"
-            ],
-            "type": "object"
-        },
-        "Implementation": {
-            "description": "Describes the MCP implementation.",
-            "properties": {
-                "description": {
-                    "description": "An optional human-readable description of what this implementation does.\n\nThis can be used by clients or servers to provide context about their purpose\nand capabilities. For example, a server might describe the types of resources\nor tools it provides, while a client might describe its intended use case.",
-                    "type": "string"
-                },
-                "icons": {
-                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
-                    "items": {
-                        "$ref": "#/$defs/Icon"
-                    },
-                    "type": "array"
-                },
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                },
-                "version": {
-                    "description": "The version of this implementation.",
-                    "type": "string"
-                },
-                "websiteUrl": {
-                    "description": "An optional URL of the website for this implementation.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "version"
-            ],
-            "type": "object"
-        },
-        "InputRequest": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/CreateMessageRequest"
-                },
-                {
-                    "$ref": "#/$defs/ListRootsRequest"
-                },
-                {
-                    "$ref": "#/$defs/ElicitRequest"
-                }
             ]
-        },
-        "InputRequests": {
-            "additionalProperties": {
-                "$ref": "#/$defs/InputRequest"
-            },
-            "description": "A map of server-initiated requests that the client must fulfill.\nKeys are server-assigned identifiers; values are the request objects.",
-            "type": "object"
-        },
-        "InputRequiredResult": {
-            "description": "An InputRequiredResult sent by the server to indicate that additional input is needed\nbefore the request can be completed.\n\nAt least one of `inputRequests` or `requestState` MUST be present.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/ResultMetaObject"
-                },
-                "inputRequests": {
-                    "$ref": "#/$defs/InputRequests"
-                },
-                "requestState": {
-                    "type": "string"
-                },
-                "resultType": {
-                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "resultType"
-            ],
-            "type": "object"
-        },
-        "InputResponse": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/CreateMessageResult"
-                },
-                {
-                    "$ref": "#/$defs/ListRootsResult"
-                },
-                {
-                    "$ref": "#/$defs/ElicitResult"
-                }
-            ]
-        },
-        "InputResponseRequestParams": {
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/RequestMetaObject"
-                },
-                "inputResponses": {
-                    "$ref": "#/$defs/InputResponses"
-                },
-                "requestState": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "_meta"
-            ],
-            "type": "object"
-        },
-        "InputResponses": {
-            "additionalProperties": {
-                "$ref": "#/$defs/InputResponse"
-            },
-            "description": "A map of client responses to server-initiated requests.\nKeys correspond to the keys in the {@link InputRequests} map;\nvalues are the client's result for each request.",
-            "type": "object"
-        },
-        "InternalError": {
-            "description": "A JSON-RPC error indicating that an internal error occurred on the receiver. This error is returned when the receiver encounters an unexpected condition that prevents it from fulfilling the request.",
-            "properties": {
-                "code": {
-                    "const": -32603,
-                    "description": "The error type that occurred.",
-                    "type": "integer"
-                },
-                "data": {
-                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
-                },
-                "message": {
-                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "code",
-                "message"
-            ],
-            "type": "object"
-        },
-        "InvalidParamsError": {
-            "description": "A JSON-RPC error indicating that the method parameters are invalid or malformed.\n\nIn MCP, this error is returned in various contexts when request parameters fail validation:\n\n- **Tools**: Unknown tool name or invalid tool arguments\n- **Prompts**: Unknown prompt name or missing required arguments\n- **Pagination**: Invalid or expired cursor values\n- **Logging**: Invalid log level\n- **Elicitation**: Server requests an elicitation mode not declared in client capabilities\n- **Sampling**: Missing tool result or tool results mixed with other content",
-            "properties": {
-                "code": {
-                    "const": -32602,
-                    "description": "The error type that occurred.",
-                    "type": "integer"
-                },
-                "data": {
-                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
-                },
-                "message": {
-                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "code",
-                "message"
-            ],
-            "type": "object"
-        },
-        "InvalidRequestError": {
-            "description": "A JSON-RPC error indicating that the request is not a valid request object. This error is returned when the message structure does not conform to the JSON-RPC 2.0 specification requirements for a request (e.g., missing required fields like `jsonrpc` or `method`, or using invalid types for these fields).",
-            "properties": {
-                "code": {
-                    "const": -32600,
-                    "description": "The error type that occurred.",
-                    "type": "integer"
-                },
-                "data": {
-                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
-                },
-                "message": {
-                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "code",
-                "message"
-            ],
-            "type": "object"
-        },
-        "JSONArray": {
-            "items": {
-                "$ref": "#/$defs/JSONValue"
-            },
-            "type": "array"
-        },
-        "JSONObject": {
-            "additionalProperties": {
-                "$ref": "#/$defs/JSONValue"
-            },
-            "type": "object"
-        },
-        "JSONRPCErrorResponse": {
-            "description": "A response to a request that indicates an error occurred.",
-            "properties": {
-                "error": {
-                    "$ref": "#/$defs/Error"
-                },
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "error",
-                "jsonrpc"
-            ],
-            "type": "object"
-        },
-        "JSONRPCMessage": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/JSONRPCRequest"
-                },
-                {
-                    "$ref": "#/$defs/JSONRPCNotification"
-                },
-                {
-                    "$ref": "#/$defs/JSONRPCResultResponse"
-                },
-                {
-                    "$ref": "#/$defs/JSONRPCErrorResponse"
-                }
-            ],
-            "description": "Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent."
-        },
-        "JSONRPCNotification": {
-            "description": "A notification which does not expect a response.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "type": "object"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "JSONRPCRequest": {
-            "description": "A request that expects a response.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "type": "object"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "JSONRPCResponse": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/JSONRPCResultResponse"
-                },
-                {
-                    "$ref": "#/$defs/JSONRPCErrorResponse"
-                }
-            ],
-            "description": "A response to a request, containing either the result or error."
-        },
-        "JSONRPCResultResponse": {
-            "description": "A successful (non-error) response to a request.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "result": {
-                    "$ref": "#/$defs/Result"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "result"
-            ],
-            "type": "object"
-        },
-        "JSONValue": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/JSONObject"
-                },
-                {
-                    "items": {
-                        "$ref": "#/$defs/JSONValue"
-                    },
-                    "type": "array"
-                },
-                {
-                    "type": [
-                        "string",
-                        "integer",
-                        "boolean"
-                    ]
-                }
-            ]
-        },
-        "LegacyTitledEnumSchema": {
-            "description": "Use {@link TitledSingleSelectEnumSchema} instead.\nThis interface will be removed in a future version.",
-            "properties": {
-                "default": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "enum": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "enumNames": {
-                    "description": "(Legacy) Display names for enum values.\nNon-standard according to JSON schema 2020-12.",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "type": {
-                    "const": "string",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "enum",
-                "type"
-            ],
-            "type": "object"
-        },
-        "ListPromptsRequest": {
-            "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "prompts/list",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/PaginatedRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ListPromptsResult": {
-            "description": "The result returned by the server for a {@link ListPromptsRequestprompts/list} request.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/ResultMetaObject"
-                },
-                "cacheScope": {
-                    "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
-                    "enum": [
-                        "private",
-                        "public"
-                    ],
-                    "type": "string"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "prompts": {
-                    "items": {
-                        "$ref": "#/$defs/Prompt"
-                    },
-                    "type": "array"
-                },
-                "resultType": {
-                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
-                    "type": "string"
-                },
-                "ttlMs": {
-                    "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
-                    "minimum": 0,
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "cacheScope",
-                "prompts",
-                "resultType",
-                "ttlMs"
-            ],
-            "type": "object"
-        },
-        "ListPromptsResultResponse": {
-            "description": "A successful response from the server for a {@link ListPromptsRequestprompts/list} request.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "result": {
-                    "$ref": "#/$defs/ListPromptsResult"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "result"
-            ],
-            "type": "object"
-        },
-        "ListResourceTemplatesRequest": {
-            "description": "Sent from the client to request a list of resource templates the server has.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "resources/templates/list",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/PaginatedRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ListResourceTemplatesResult": {
-            "description": "The result returned by the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/ResultMetaObject"
-                },
-                "cacheScope": {
-                    "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
-                    "enum": [
-                        "private",
-                        "public"
-                    ],
-                    "type": "string"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "resourceTemplates": {
-                    "items": {
-                        "$ref": "#/$defs/ResourceTemplate"
-                    },
-                    "type": "array"
-                },
-                "resultType": {
-                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
-                    "type": "string"
-                },
-                "ttlMs": {
-                    "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
-                    "minimum": 0,
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "cacheScope",
-                "resourceTemplates",
-                "resultType",
-                "ttlMs"
-            ],
-            "type": "object"
-        },
-        "ListResourceTemplatesResultResponse": {
-            "description": "A successful response from the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "result": {
-                    "$ref": "#/$defs/ListResourceTemplatesResult"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "result"
-            ],
-            "type": "object"
-        },
-        "ListResourcesRequest": {
-            "description": "Sent from the client to request a list of resources the server has.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "resources/list",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/PaginatedRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ListResourcesResult": {
-            "description": "The result returned by the server for a {@link ListResourcesRequestresources/list} request.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/ResultMetaObject"
-                },
-                "cacheScope": {
-                    "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
-                    "enum": [
-                        "private",
-                        "public"
-                    ],
-                    "type": "string"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "resources": {
-                    "items": {
-                        "$ref": "#/$defs/Resource"
-                    },
-                    "type": "array"
-                },
-                "resultType": {
-                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
-                    "type": "string"
-                },
-                "ttlMs": {
-                    "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
-                    "minimum": 0,
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "cacheScope",
-                "resources",
-                "resultType",
-                "ttlMs"
-            ],
-            "type": "object"
-        },
-        "ListResourcesResultResponse": {
-            "description": "A successful response from the server for a {@link ListResourcesRequestresources/list} request.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "result": {
-                    "$ref": "#/$defs/ListResourcesResult"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "result"
-            ],
-            "type": "object"
-        },
-        "ListRootsRequest": {
-            "description": "Sent from the server to request a list of root URIs from the client. Roots allow\nservers to ask for specific directories or files to operate on. A common example\nfor roots is providing a set of repositories or directories a server should operate\non.\n\nThis request is typically used when the server needs to understand the file system\nstructure or access specific locations that the client has permission to read from.",
-            "properties": {
-                "method": {
-                    "const": "roots/list",
-                    "type": "string"
-                },
-                "params": {
-                    "properties": {
-                        "_meta": {
-                            "$ref": "#/$defs/MetaObject"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "ListRootsResult": {
-            "description": "The result returned by the client for a {@link ListRootsRequestroots/list} request.\nThis result contains an array of {@link Root} objects, each representing a root directory\nor file that the server can operate on.",
-            "properties": {
-                "roots": {
-                    "items": {
-                        "$ref": "#/$defs/Root"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "roots"
-            ],
-            "type": "object"
-        },
-        "ListToolsRequest": {
-            "description": "Sent from the client to request a list of tools the server has.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "tools/list",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/PaginatedRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ListToolsResult": {
-            "description": "The result returned by the server for a {@link ListToolsRequesttools/list} request.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/ResultMetaObject"
-                },
-                "cacheScope": {
-                    "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
-                    "enum": [
-                        "private",
-                        "public"
-                    ],
-                    "type": "string"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "resultType": {
-                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
-                    "type": "string"
-                },
-                "tools": {
-                    "items": {
-                        "$ref": "#/$defs/Tool"
-                    },
-                    "type": "array"
-                },
-                "ttlMs": {
-                    "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
-                    "minimum": 0,
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "cacheScope",
-                "resultType",
-                "tools",
-                "ttlMs"
-            ],
-            "type": "object"
-        },
-        "ListToolsResultResponse": {
-            "description": "A successful response from the server for a {@link ListToolsRequesttools/list} request.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "result": {
-                    "$ref": "#/$defs/ListToolsResult"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "result"
-            ],
-            "type": "object"
-        },
-        "LoggingLevel": {
-            "description": "The severity of a log message.\n\nThese map to syslog message severities, as specified in RFC-5424:\nhttps://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1",
-            "enum": [
-                "alert",
-                "critical",
-                "debug",
-                "emergency",
-                "error",
-                "info",
-                "notice",
-                "warning"
-            ],
-            "type": "string"
-        },
-        "LoggingMessageNotification": {
-            "description": "JSONRPCNotification of a log message passed from server to client. The client opts in by setting `\"io.modelcontextprotocol/logLevel\"` in a request's `_meta`.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "notifications/message",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/LoggingMessageNotificationParams"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "LoggingMessageNotificationParams": {
-            "description": "Parameters for a `notifications/message` notification.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/NotificationMetaObject"
-                },
-                "data": {
-                    "description": "The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here."
-                },
-                "level": {
-                    "$ref": "#/$defs/LoggingLevel",
-                    "description": "The severity of this log message."
-                },
-                "logger": {
-                    "description": "An optional name of the logger issuing this message.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "data",
-                "level"
-            ],
-            "type": "object"
-        },
-        "MetaObject": {
-            "description": "Represents the contents of a `_meta` field, which clients and servers use to attach additional metadata to their interactions.\n\nCertain key names are reserved by MCP for protocol-level metadata; implementations MUST NOT make assumptions about values at these keys. Additionally, specific schema definitions may reserve particular names for purpose-specific metadata, as declared in those definitions.\n\nValid keys have two segments:\n\n**Prefix:**\n- Optional — if specified, MUST be a series of _labels_ separated by dots (`.`), followed by a slash (`/`).\n- Labels MUST start with a letter and end with a letter or digit. Interior characters may be letters, digits, or hyphens (`-`).\n- Implementations SHOULD use reverse DNS notation (e.g., `com.example/` rather than `example.com/`).\n- Any prefix where the second label is `modelcontextprotocol` or `mcp` is **reserved** for MCP use. For example: `io.modelcontextprotocol/`, `dev.mcp/`, `org.modelcontextprotocol.api/`, and `com.mcp.tools/` are all reserved. However, `com.example.mcp/` is NOT reserved, as the second label is `example`.\n\n**Name:**\n- Unless empty, MUST start and end with an alphanumeric character (`[a-z0-9A-Z]`).\n- Interior characters may be alphanumeric, hyphens (`-`), underscores (`_`), or dots (`.`).",
-            "type": "object"
-        },
-        "MethodNotFoundError": {
-            "description": "A JSON-RPC error indicating that the requested method does not exist or is not available.\n\nIn MCP, a server returns this error when a client invokes a method the server does not implement — either a genuinely unknown method, or one gated behind a server capability the server did not advertise (e.g., calling `prompts/list` when the `prompts` capability was not advertised).\n\nA request that requires a client capability the client did not declare is signalled instead by {@link MissingRequiredClientCapabilityError} (`-32021`).",
-            "properties": {
-                "code": {
-                    "const": -32601,
-                    "description": "The error type that occurred.",
-                    "type": "integer"
-                },
-                "data": {
-                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
-                },
-                "message": {
-                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "code",
-                "message"
-            ],
-            "type": "object"
-        },
-        "MissingRequiredClientCapabilityError": {
-            "description": "Returned when processing a request requires a capability the client did not\ndeclare in `clientCapabilities`. For HTTP, the response status code MUST be\n`400 Bad Request`.",
-            "properties": {
-                "error": {
-                    "allOf": [
-                        {
-                            "$ref": "#/$defs/Error"
-                        },
-                        {
-                            "properties": {
-                                "code": {
-                                    "const": -32021,
-                                    "type": "integer"
-                                },
-                                "data": {
-                                    "properties": {
-                                        "requiredCapabilities": {
-                                            "$ref": "#/$defs/ClientCapabilities",
-                                            "description": "The capabilities the server requires from the client to process this request."
-                                        }
-                                    },
-                                    "required": [
-                                        "requiredCapabilities"
-                                    ],
-                                    "type": "object"
-                                }
-                            },
-                            "required": [
-                                "code",
-                                "data"
-                            ],
-                            "type": "object"
-                        }
-                    ]
-                },
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "error",
-                "jsonrpc"
-            ],
-            "type": "object"
-        },
-        "ModelHint": {
-            "description": "Hints to use for model selection.\n\nKeys not declared here are currently left unspecified by the spec and are up\nto the client to interpret.",
-            "properties": {
-                "name": {
-                    "description": "A hint for a model name.\n\nThe client SHOULD treat this as a substring of a model name; for example:\n - `claude-3-5-sonnet` should match `claude-3-5-sonnet-20241022`\n - `sonnet` should match `claude-3-5-sonnet-20241022`, `claude-3-sonnet-20240229`, etc.\n - `claude` should match any Claude model\n\nThe client MAY also map the string to a different provider's model name or a different model family, as long as it fills a similar niche; for example:\n - `gemini-1.5-flash` could match `claude-3-haiku-20240307`",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "ModelPreferences": {
-            "description": "The server's preferences for model selection, requested of the client during sampling.\n\nBecause LLMs can vary along multiple dimensions, choosing the \"best\" model is\nrarely straightforward.  Different models excel in different areas—some are\nfaster but less capable, others are more capable but more expensive, and so\non. This interface allows servers to express their priorities across multiple\ndimensions to help clients make an appropriate selection for their use case.\n\nThese preferences are always advisory. The client MAY ignore them. It is also\nup to the client to decide how to interpret these preferences and how to\nbalance them against other considerations.",
-            "properties": {
-                "costPriority": {
-                    "description": "How much to prioritize cost when selecting a model. A value of 0 means cost\nis not important, while a value of 1 means cost is the most important\nfactor.",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "hints": {
-                    "description": "Optional hints to use for model selection.\n\nIf multiple hints are specified, the client MUST evaluate them in order\n(such that the first match is taken).\n\nThe client SHOULD prioritize these hints over the numeric priorities, but\nMAY still use the priorities to select from ambiguous matches.",
-                    "items": {
-                        "$ref": "#/$defs/ModelHint"
-                    },
-                    "type": "array"
-                },
-                "intelligencePriority": {
-                    "description": "How much to prioritize intelligence and capabilities when selecting a\nmodel. A value of 0 means intelligence is not important, while a value of 1\nmeans intelligence is the most important factor.",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "speedPriority": {
-                    "description": "How much to prioritize sampling speed (latency) when selecting a model. A\nvalue of 0 means speed is not important, while a value of 1 means speed is\nthe most important factor.",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
-                }
-            },
-            "type": "object"
-        },
-        "MultiSelectEnumSchema": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
-                },
-                {
-                    "$ref": "#/$defs/TitledMultiSelectEnumSchema"
-                }
-            ]
-        },
-        "Notification": {
-            "properties": {
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "NotificationMetaObject": {
-            "description": "Extends {@link MetaObject} with additional notification-specific fields. All key naming rules from `MetaObject` apply.",
-            "properties": {
-                "io.modelcontextprotocol/subscriptionId": {
-                    "$ref": "#/$defs/RequestId",
-                    "description": "Identifies the subscription stream a notification was delivered on. The\nserver MUST include this key on every notification delivered via a\n{@link SubscriptionsListenRequestsubscriptions/listen} stream, so the\nclient can correlate the notification with the originating subscription.\nThe key is absent on notifications not delivered via a subscription\nstream (e.g. progress notifications for an in-flight request), which is\nwhy it is optional here.\n\nThe value is the JSON-RPC ID of the `subscriptions/listen` request that\nopened the stream."
-                }
-            },
-            "type": "object"
-        },
-        "NotificationParams": {
-            "description": "Common params for any notification.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/NotificationMetaObject"
-                }
-            },
-            "type": "object"
-        },
-        "NumberSchema": {
-            "properties": {
-                "default": {
-                    "type": "number"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "maximum": {
-                    "type": "number"
-                },
-                "minimum": {
-                    "type": "number"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "type": {
-                    "enum": [
-                        "integer",
-                        "number"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "type"
-            ],
-            "type": "object"
-        },
-        "PaginatedRequest": {
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/PaginatedRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "PaginatedRequestParams": {
-            "description": "Common params for paginated requests.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/RequestMetaObject"
-                },
-                "cursor": {
-                    "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "_meta"
-            ],
-            "type": "object"
-        },
-        "PaginatedResult": {
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/ResultMetaObject"
-                },
-                "nextCursor": {
-                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
-                    "type": "string"
-                },
-                "resultType": {
-                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "resultType"
-            ],
-            "type": "object"
-        },
-        "ParseError": {
-            "description": "A JSON-RPC error indicating that invalid JSON was received by the server. This error is returned when the server cannot parse the JSON text of a message.",
-            "properties": {
-                "code": {
-                    "const": -32700,
-                    "description": "The error type that occurred.",
-                    "type": "integer"
-                },
-                "data": {
-                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
-                },
-                "message": {
-                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "code",
-                "message"
-            ],
-            "type": "object"
         },
         "PrimitiveSchemaDefinition": {
+            "description": "Restricted schema definitions that only allow primitive types\nwithout nested objects or arrays.",
             "anyOf": [
                 {
                     "$ref": "#/$defs/StringSchema"
@@ -2358,823 +3316,439 @@
                 {
                     "$ref": "#/$defs/LegacyTitledEnumSchema"
                 }
-            ],
-            "description": "Restricted schema definitions that only allow primitive types\nwithout nested objects or arrays."
-        },
-        "ProgressNotification": {
-            "description": "An out-of-band notification used to inform the receiver of a progress update for a long-running request.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "notifications/progress",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/ProgressNotificationParams"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ProgressNotificationParams": {
-            "description": "Parameters for a {@link ProgressNotificationnotifications/progress} notification.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/NotificationMetaObject"
-                },
-                "message": {
-                    "description": "An optional message describing the current progress.",
-                    "type": "string"
-                },
-                "progress": {
-                    "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
-                    "type": "number"
-                },
-                "progressToken": {
-                    "$ref": "#/$defs/ProgressToken",
-                    "description": "The progress token which was given in the initial request, used to associate this notification with the request that is proceeding."
-                },
-                "total": {
-                    "description": "Total number of items to process (or total progress required), if known.",
-                    "type": "number"
-                }
-            },
-            "required": [
-                "progress",
-                "progressToken"
-            ],
-            "type": "object"
-        },
-        "ProgressToken": {
-            "description": "A progress token, used to associate progress notifications with the original request.",
-            "type": [
-                "string",
-                "integer"
             ]
         },
-        "Prompt": {
-            "description": "A prompt or prompt template that the server offers.",
+        "StringSchema": {
+            "type": "object",
             "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/MetaObject"
-                },
-                "arguments": {
-                    "description": "A list of arguments to use for templating the prompt.",
-                    "items": {
-                        "$ref": "#/$defs/PromptArgument"
-                    },
-                    "type": "array"
-                },
-                "description": {
-                    "description": "An optional description of what this prompt provides",
-                    "type": "string"
-                },
-                "icons": {
-                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
-                    "items": {
-                        "$ref": "#/$defs/Icon"
-                    },
-                    "type": "array"
-                },
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "type": "object"
-        },
-        "PromptArgument": {
-            "description": "Describes an argument that a prompt can accept.",
-            "properties": {
-                "description": {
-                    "description": "A human-readable description of the argument.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "required": {
-                    "description": "Whether this argument must be provided.",
-                    "type": "boolean"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "type": "object"
-        },
-        "PromptListChangedNotification": {
-            "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `promptsListChanged` filter field.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "notifications/prompts/list_changed",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/NotificationParams"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "PromptMessage": {
-            "description": "Describes a message returned as part of a prompt.\n\nThis is similar to {@link SamplingMessage}, but also supports the embedding of\nresources from the MCP server.",
-            "properties": {
-                "content": {
-                    "$ref": "#/$defs/ContentBlock"
-                },
-                "role": {
-                    "$ref": "#/$defs/Role"
-                }
-            },
-            "required": [
-                "content",
-                "role"
-            ],
-            "type": "object"
-        },
-        "PromptReference": {
-            "description": "Identifies a prompt.",
-            "properties": {
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                },
                 "type": {
-                    "const": "ref/prompt",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "type"
-            ],
-            "type": "object"
-        },
-        "ReadResourceRequest": {
-            "description": "Sent from the client to the server, to read a specific resource URI.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
+                    "type": "string",
+                    "const": "string"
                 },
-                "jsonrpc": {
-                    "const": "2.0",
+                "title": {
                     "type": "string"
                 },
-                "method": {
-                    "const": "resources/read",
+                "description": {
                     "type": "string"
                 },
-                "params": {
-                    "$ref": "#/$defs/ReadResourceRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "ReadResourceRequestParams": {
-            "description": "Parameters for a `resources/read` request.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/RequestMetaObject"
+                "minLength": {
+                    "type": "integer"
                 },
-                "inputResponses": {
-                    "$ref": "#/$defs/InputResponses"
+                "maxLength": {
+                    "type": "integer"
                 },
-                "requestState": {
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "_meta",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ReadResourceResult": {
-            "description": "The result returned by the server for a {@link ReadResourceRequestresources/read} request.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/ResultMetaObject"
-                },
-                "cacheScope": {
-                    "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+                "format": {
                     "enum": [
-                        "private",
-                        "public"
+                        "date",
+                        "date-time",
+                        "email",
+                        "uri"
                     ],
                     "type": "string"
                 },
-                "contents": {
-                    "items": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/$defs/TextResourceContents"
-                            },
-                            {
-                                "$ref": "#/$defs/BlobResourceContents"
-                            }
-                        ]
-                    },
-                    "type": "array"
-                },
-                "resultType": {
-                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                "default": {
                     "type": "string"
-                },
-                "ttlMs": {
-                    "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
-                    "minimum": 0,
-                    "type": "integer"
                 }
             },
             "required": [
-                "cacheScope",
-                "contents",
-                "resultType",
-                "ttlMs"
-            ],
-            "type": "object"
-        },
-        "ReadResourceResultResponse": {
-            "description": "A successful response from the server for a {@link ReadResourceRequestresources/read} request.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "result": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/$defs/InputRequiredResult"
-                        },
-                        {
-                            "$ref": "#/$defs/ReadResourceResult"
-                        }
-                    ]
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "result"
-            ],
-            "type": "object"
-        },
-        "Request": {
-            "properties": {
-                "method": {
-                    "type": "string"
-                },
-                "params": {
-                    "additionalProperties": {},
-                    "type": "object"
-                }
-            },
-            "required": [
-                "method"
-            ],
-            "type": "object"
-        },
-        "RequestId": {
-            "description": "A uniquely identifying ID for a request in JSON-RPC.",
-            "type": [
-                "string",
-                "integer"
+                "type"
             ]
         },
-        "RequestMetaObject": {
-            "description": "Extends {@link MetaObject} with additional request-specific fields. All key naming rules from `MetaObject` apply.",
-            "properties": {
-                "io.modelcontextprotocol/clientCapabilities": {
-                    "$ref": "#/$defs/ClientCapabilities",
-                    "description": "The client's capabilities for this specific request. Required.\n\nCapabilities are declared per-request rather than once at initialization;\nan empty object means the client supports no optional capabilities.\nServers MUST NOT infer capabilities from prior requests."
-                },
-                "io.modelcontextprotocol/clientInfo": {
-                    "$ref": "#/$defs/Implementation",
-                    "description": "Identifies the client software making the request. Clients SHOULD\ninclude this field on every request unless specifically configured not\nto do so.\n\nThe {@link Implementation} schema requires `name` and `version`; other\nfields are optional.\n\nThe value is self-reported by the client and is not verified by the\nprotocol. It is intended for display, logging, and debugging. Servers\nSHOULD NOT use it to change their behavior, and SHOULD NOT rely on it for\nsecurity decisions."
-                },
-                "io.modelcontextprotocol/logLevel": {
-                    "$ref": "#/$defs/LoggingLevel",
-                    "description": "The desired log level for this request. Optional.\n\nIf absent, the server MUST NOT send any {@link LoggingMessageNotificationnotifications/message}\nnotifications for this request. The client opts in to log messages by\nexplicitly setting a level. Replaces the former `logging/setLevel` RPC."
-                },
-                "io.modelcontextprotocol/protocolVersion": {
-                    "description": "The MCP Protocol Version being used for this request. Required.\n\nFor the HTTP transport, this value MUST match the `MCP-Protocol-Version`\nheader; otherwise the server MUST return a `400 Bad Request`. If the\nserver does not support the requested version, it MUST return an\n{@link UnsupportedProtocolVersionError}.",
-                    "type": "string"
-                },
-                "progressToken": {
-                    "$ref": "#/$defs/ProgressToken",
-                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by {@link ProgressNotificationnotifications/progress}). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                }
-            },
-            "required": [
-                "io.modelcontextprotocol/clientCapabilities",
-                "io.modelcontextprotocol/protocolVersion"
-            ],
-            "type": "object"
-        },
-        "RequestParams": {
-            "description": "Common params for any request.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/RequestMetaObject"
-                }
-            },
-            "required": [
-                "_meta"
-            ],
-            "type": "object"
-        },
-        "Resource": {
-            "description": "A known resource that the server is capable of reading.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/MetaObject"
-                },
-                "annotations": {
-                    "$ref": "#/$defs/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "description": {
-                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
-                    "type": "string"
-                },
-                "icons": {
-                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
-                    "items": {
-                        "$ref": "#/$defs/Icon"
-                    },
-                    "type": "array"
-                },
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "size": {
-                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
-                    "type": "integer"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ResourceContents": {
-            "description": "The contents of a specific resource or sub-resource.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/MetaObject"
-                },
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ResourceLink": {
-            "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of {@link ListResourcesRequestresources/list} requests.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/MetaObject"
-                },
-                "annotations": {
-                    "$ref": "#/$defs/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "description": {
-                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
-                    "type": "string"
-                },
-                "icons": {
-                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
-                    "items": {
-                        "$ref": "#/$defs/Icon"
-                    },
-                    "type": "array"
-                },
-                "mimeType": {
-                    "description": "The MIME type of this resource, if known.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "size": {
-                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
-                    "type": "integer"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "resource_link",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "type",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ResourceListChangedNotification": {
-            "description": "An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `resourcesListChanged` filter field.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "notifications/resources/list_changed",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/NotificationParams"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "ResourceRequestParams": {
-            "description": "Common params for resource-related requests.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/RequestMetaObject"
-                },
-                "uri": {
-                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "_meta",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "ResourceTemplate": {
-            "description": "A template description for resources available on the server.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/MetaObject"
-                },
-                "annotations": {
-                    "$ref": "#/$defs/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "description": {
-                    "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
-                    "type": "string"
-                },
-                "icons": {
-                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
-                    "items": {
-                        "$ref": "#/$defs/Icon"
-                    },
-                    "type": "array"
-                },
-                "mimeType": {
-                    "description": "The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
-                    "type": "string"
-                },
-                "title": {
-                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
-                    "type": "string"
-                },
-                "uriTemplate": {
-                    "description": "A URI template (according to RFC 6570) that can be used to construct resource URIs.",
-                    "format": "uri-template",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "name",
-                "uriTemplate"
-            ],
-            "type": "object"
-        },
-        "ResourceTemplateReference": {
-            "description": "A reference to a resource or resource template definition.",
+        "NumberSchema": {
+            "type": "object",
             "properties": {
                 "type": {
-                    "const": "ref/resource",
+                    "enum": [
+                        "integer",
+                        "number"
+                    ],
                     "type": "string"
                 },
-                "uri": {
-                    "description": "The URI or URI template of the resource.",
-                    "format": "uri-template",
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "minimum": {
+                    "type": "number"
+                },
+                "maximum": {
+                    "type": "number"
+                },
+                "default": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "type"
+            ]
+        },
+        "BooleanSchema": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "boolean"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "default": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "type"
+            ]
+        },
+        "UntitledSingleSelectEnumSchema": {
+            "description": "Schema for single-selection enumeration without display titles for options.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "string"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Optional description for the enum field.",
+                    "type": "string"
+                },
+                "enum": {
+                    "description": "Array of enum values to choose from.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "default": {
+                    "description": "Optional default value.",
                     "type": "string"
                 }
             },
             "required": [
-                "type",
-                "uri"
-            ],
-            "type": "object"
+                "enum",
+                "type"
+            ]
         },
-        "ResourceUpdatedNotification": {
-            "description": "A notification from the server to the client, informing it that a resource has changed and may need to be read again. This is only sent for resources the client opted in to via the `resourceSubscriptions` field of a {@link SubscriptionsListenRequestsubscriptions/listen} request.",
+        "TitledSingleSelectEnumSchema": {
+            "description": "Schema for single-selection enumeration with display titles for each option.",
+            "type": "object",
             "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
+                "type": {
+                    "type": "string",
+                    "const": "string"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
                     "type": "string"
                 },
-                "method": {
-                    "const": "notifications/resources/updated",
+                "description": {
+                    "description": "Optional description for the enum field.",
                     "type": "string"
+                },
+                "oneOf": {
+                    "description": "Array of enum options with values and display labels.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "const": {
+                                "description": "The enum value.",
+                                "type": "string"
+                            },
+                            "title": {
+                                "description": "Display label for this option.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "const",
+                            "title"
+                        ]
+                    }
+                },
+                "default": {
+                    "description": "Optional default value.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "oneOf",
+                "type"
+            ]
+        },
+        "SingleSelectEnumSchema": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+                }
+            ]
+        },
+        "UntitledMultiSelectEnumSchema": {
+            "description": "Schema for multiple-selection enumeration without display titles for options.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "array"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Optional description for the enum field.",
+                    "type": "string"
+                },
+                "minItems": {
+                    "description": "Minimum number of items to select.",
+                    "type": "integer"
+                },
+                "maxItems": {
+                    "description": "Maximum number of items to select.",
+                    "type": "integer"
+                },
+                "items": {
+                    "description": "Schema for the array items.",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "const": "string"
+                        },
+                        "enum": {
+                            "description": "Array of enum values to choose from.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "enum",
+                        "type"
+                    ]
+                },
+                "default": {
+                    "description": "Optional default value.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "items",
+                "type"
+            ]
+        },
+        "TitledMultiSelectEnumSchema": {
+            "description": "Schema for multiple-selection enumeration with display titles for each option.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "array"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Optional description for the enum field.",
+                    "type": "string"
+                },
+                "minItems": {
+                    "description": "Minimum number of items to select.",
+                    "type": "integer"
+                },
+                "maxItems": {
+                    "description": "Maximum number of items to select.",
+                    "type": "integer"
+                },
+                "items": {
+                    "description": "Schema for array items with enum options and display labels.",
+                    "type": "object",
+                    "properties": {
+                        "anyOf": {
+                            "description": "Array of enum options with values and display labels.",
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "const": {
+                                        "description": "The constant enum value.",
+                                        "type": "string"
+                                    },
+                                    "title": {
+                                        "description": "Display title for this option.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "const",
+                                    "title"
+                                ]
+                            }
+                        }
+                    },
+                    "required": [
+                        "anyOf"
+                    ]
+                },
+                "default": {
+                    "description": "Optional default value.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "items",
+                "type"
+            ]
+        },
+        "MultiSelectEnumSchema": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+                }
+            ]
+        },
+        "LegacyTitledEnumSchema": {
+            "description": "Use {@link TitledSingleSelectEnumSchema} instead.\nThis interface will be removed in a future version.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "const": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "enum": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "enumNames": {
+                    "description": "(Legacy) Display names for enum values.\nNon-standard according to JSON schema 2020-12.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "default": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "enum",
+                "type"
+            ]
+        },
+        "EnumSchema": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/LegacyTitledEnumSchema"
+                }
+            ]
+        },
+        "ElicitResult": {
+            "description": "The result returned by the client for an {@link ElicitRequestelicitation/create} request.",
+            "type": "object",
+            "properties": {
+                "action": {
+                    "description": "The user action in response to the elicitation.\n- `\"accept\"`: User submitted the form/confirmed the action\n- `\"decline\"`: User explicitly declined the action\n- `\"cancel\"`: User dismissed without making an explicit choice",
+                    "enum": [
+                        "accept",
+                        "cancel",
+                        "decline"
+                    ],
+                    "type": "string"
+                },
+                "content": {
+                    "description": "The submitted form data, only present when action is `\"accept\"` and mode was `\"form\"`.\nContains values matching the requested schema.\nOmitted for out-of-band mode responses.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "anyOf": [
+                            {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            {
+                                "type": [
+                                    "string",
+                                    "integer",
+                                    "boolean"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "required": [
+                "action"
+            ]
+        },
+        "ClientNotification": {
+            "description": "This notification is sent by the client to indicate that it is cancelling a request it previously issued.\n\nOn stdio, the server also sends this notification, solely to terminate a {@link SubscriptionsListenRequestsubscriptions/listen} stream: it references the ID of the `subscriptions/listen` request that opened the stream. Servers MUST NOT use this notification to cancel any other request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.",
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string",
+                    "const": "notifications/cancelled"
                 },
                 "params": {
-                    "$ref": "#/$defs/ResourceUpdatedNotificationParams"
+                    "$ref": "#/$defs/CancelledNotificationParams"
+                },
+                "jsonrpc": {
+                    "type": "string",
+                    "const": "2.0"
                 }
             },
             "required": [
                 "jsonrpc",
                 "method",
                 "params"
-            ],
-            "type": "object"
-        },
-        "ResourceUpdatedNotificationParams": {
-            "description": "Parameters for a `notifications/resources/updated` notification.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/NotificationMetaObject"
-                },
-                "uri": {
-                    "description": "The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "uri"
-            ],
-            "type": "object"
-        },
-        "Result": {
-            "additionalProperties": {},
-            "description": "Common result fields.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/ResultMetaObject"
-                },
-                "resultType": {
-                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "resultType"
-            ],
-            "type": "object"
-        },
-        "ResultMetaObject": {
-            "description": "Extends {@link MetaObject} with additional result-specific fields. All key naming rules from `MetaObject` apply.",
-            "properties": {
-                "io.modelcontextprotocol/serverInfo": {
-                    "$ref": "#/$defs/Implementation",
-                    "description": "Identifies the server software producing the response. Servers SHOULD\ninclude this field on every response unless specifically configured not\nto do so.\n\nThe {@link Implementation} schema requires `name` and `version`; other\nfields are optional.\n\nThe value is self-reported by the server and is not verified by the\nprotocol. It is intended for display, logging, and debugging. Clients\nSHOULD NOT use it to change their behavior, and SHOULD NOT rely on it for\nsecurity decisions."
-                }
-            },
-            "type": "object"
-        },
-        "ResultType": {
-            "description": "Indicates the type of a {@link Result} object, allowing the client to\ndetermine how to parse the response.\n\ncomplete - the request completed successfully and the result contains the final content.\ninput_required - the request requires additional input and the result contains an {@link InputRequiredResult} object with instructions for the client to provide additional input before retrying the original request.",
-            "type": "string"
-        },
-        "Role": {
-            "description": "The sender or recipient of messages and data in a conversation.",
-            "enum": [
-                "assistant",
-                "user"
-            ],
-            "type": "string"
-        },
-        "Root": {
-            "description": "Represents a root directory or file that the server can operate on.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/MetaObject"
-                },
-                "name": {
-                    "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
-                    "type": "string"
-                },
-                "uri": {
-                    "description": "The URI identifying the root. This *must* start with `file://` for now.\nThis restriction may be relaxed in future versions of the protocol to allow\nother URI schemes.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "uri"
-            ],
-            "type": "object"
-        },
-        "SamplingMessage": {
-            "description": "Describes a message issued to or received from an LLM API.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/MetaObject"
-                },
-                "content": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/$defs/TextContent"
-                        },
-                        {
-                            "$ref": "#/$defs/ImageContent"
-                        },
-                        {
-                            "$ref": "#/$defs/AudioContent"
-                        },
-                        {
-                            "$ref": "#/$defs/ToolUseContent"
-                        },
-                        {
-                            "$ref": "#/$defs/ToolResultContent"
-                        },
-                        {
-                            "items": {
-                                "$ref": "#/$defs/SamplingMessageContentBlock"
-                            },
-                            "type": "array"
-                        }
-                    ]
-                },
-                "role": {
-                    "$ref": "#/$defs/Role"
-                }
-            },
-            "required": [
-                "content",
-                "role"
-            ],
-            "type": "object"
-        },
-        "SamplingMessageContentBlock": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/TextContent"
-                },
-                {
-                    "$ref": "#/$defs/ImageContent"
-                },
-                {
-                    "$ref": "#/$defs/AudioContent"
-                },
-                {
-                    "$ref": "#/$defs/ToolUseContent"
-                },
-                {
-                    "$ref": "#/$defs/ToolResultContent"
-                }
             ]
         },
-        "ServerCapabilities": {
-            "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
-            "properties": {
-                "completions": {
-                    "$ref": "#/$defs/JSONObject",
-                    "description": "Present if the server supports argument autocompletion suggestions."
-                },
-                "experimental": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/JSONObject"
-                    },
-                    "description": "Experimental, non-standard capabilities that the server supports.",
-                    "type": "object"
-                },
-                "extensions": {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/JSONObject"
-                    },
-                    "description": "Optional MCP extensions that the server supports. Keys are extension identifiers\n(e.g., \"io.modelcontextprotocol/tasks\"), and values are per-extension settings\nobjects. An empty object indicates support with no settings.\n\nKeys MUST follow the {@link MetaObject`_meta` key naming rules}, with a\nmandatory prefix.",
-                    "type": "object"
-                },
-                "logging": {
-                    "$ref": "#/$defs/JSONObject",
-                    "description": "Present if the server supports sending log messages to the client."
-                },
-                "prompts": {
-                    "description": "Present if the server offers any prompt templates.",
-                    "properties": {
-                        "listChanged": {
-                            "description": "Whether this server supports notifications for changes to the prompt list.",
-                            "type": "boolean"
-                        }
-                    },
-                    "type": "object"
-                },
-                "resources": {
-                    "description": "Present if the server offers any resources to read.",
-                    "properties": {
-                        "listChanged": {
-                            "description": "Whether this server supports notifications for changes to the resource list.",
-                            "type": "boolean"
-                        },
-                        "subscribe": {
-                            "description": "Whether this server supports subscribing to resource updates.",
-                            "type": "boolean"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": {
-                    "description": "Present if the server offers any tools to call.",
-                    "properties": {
-                        "listChanged": {
-                            "description": "Whether this server supports notifications for changes to the tool list.",
-                            "type": "boolean"
-                        }
-                    },
-                    "type": "object"
-                }
-            },
-            "type": "object"
+        "ClientResult": {
+            "$ref": "#/$defs/Result",
+            "description": "Common result fields."
         },
         "ServerNotification": {
             "anyOf": [
@@ -3244,699 +3818,124 @@
                 }
             ]
         },
-        "SingleSelectEnumSchema": {
-            "anyOf": [
-                {
-                    "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+        "Request": {
+            "type": "object",
+            "properties": {
+                "method": {
+                    "type": "string"
                 },
-                {
-                    "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+                "params": {
+                    "type": "object",
+                    "additionalProperties": {}
                 }
+            },
+            "required": [
+                "method"
             ]
         },
-        "StringSchema": {
+        "Resource": {
+            "description": "A known resource that the server is capable of reading.",
+            "type": "object",
             "properties": {
-                "default": {
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
                     "type": "string"
                 },
                 "description": {
+                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
                     "type": "string"
-                },
-                "format": {
-                    "enum": [
-                        "date",
-                        "date-time",
-                        "email",
-                        "uri"
-                    ],
-                    "type": "string"
-                },
-                "maxLength": {
-                    "type": "integer"
-                },
-                "minLength": {
-                    "type": "integer"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "type": {
-                    "const": "string",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "type"
-            ],
-            "type": "object"
-        },
-        "SubscriptionFilter": {
-            "description": "The set of notification types a client may opt in to on a\n{@link SubscriptionsListenRequestsubscriptions/listen} request.\n\nEach notification type is **opt-in**; the server **MUST NOT** send\nnotification types the client has not explicitly requested here.",
-            "properties": {
-                "promptsListChanged": {
-                    "description": "If true, receive {@link PromptListChangedNotificationnotifications/prompts/list_changed}.",
-                    "type": "boolean"
-                },
-                "resourceSubscriptions": {
-                    "description": "Subscribe to {@link ResourceUpdatedNotificationnotifications/resources/updated} for these resource URIs.\nReplaces the former `resources/subscribe` RPC.",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "resourcesListChanged": {
-                    "description": "If true, receive {@link ResourceListChangedNotificationnotifications/resources/list_changed}.",
-                    "type": "boolean"
-                },
-                "toolsListChanged": {
-                    "description": "If true, receive {@link ToolListChangedNotificationnotifications/tools/list_changed}.",
-                    "type": "boolean"
-                }
-            },
-            "type": "object"
-        },
-        "SubscriptionsAcknowledgedNotification": {
-            "description": "Sent by the server to acknowledge that a\n{@link SubscriptionsListenRequestsubscriptions/listen} subscription has been\nestablished and to report which notification types it agreed to honor.\n\nThis notification MUST be the first message the server sends carrying the\nsubscription's ID in `io.modelcontextprotocol/subscriptionId`. The server MUST\nNOT send any notification on the subscription before acknowledging it. On\nstdio, where every subscription shares one channel, this ordering is defined\nper subscription ID and not per channel: messages belonging to other\nsubscriptions MAY be interleaved before it.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "notifications/subscriptions/acknowledged",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/SubscriptionsAcknowledgedNotificationParams"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "SubscriptionsAcknowledgedNotificationParams": {
-            "description": "Parameters for a {@link SubscriptionsAcknowledgedNotificationnotifications/subscriptions/acknowledged} notification.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/NotificationMetaObject"
-                },
-                "notifications": {
-                    "$ref": "#/$defs/SubscriptionFilter",
-                    "description": "The subset of requested notification types the server agreed to honor.\nOnly includes notification types the server actually supports; if the\nclient requested an unsupported type (e.g., `promptsListChanged` when\nthe server has no prompts), it is omitted from this set."
-                }
-            },
-            "required": [
-                "notifications"
-            ],
-            "type": "object"
-        },
-        "SubscriptionsListenRequest": {
-            "description": "Sent from the client to open a long-lived channel for receiving notifications\noutside the context of a specific request. Replaces the previous HTTP GET\nendpoint and ensures consistent behavior between HTTP and STDIO.",
-            "properties": {
-                "id": {
-                    "$ref": "#/$defs/RequestId"
-                },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "subscriptions/listen",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/SubscriptionsListenRequestParams"
-                }
-            },
-            "required": [
-                "id",
-                "jsonrpc",
-                "method",
-                "params"
-            ],
-            "type": "object"
-        },
-        "SubscriptionsListenRequestParams": {
-            "description": "Parameters for a {@link SubscriptionsListenRequestsubscriptions/listen} request.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/RequestMetaObject"
-                },
-                "notifications": {
-                    "$ref": "#/$defs/SubscriptionFilter",
-                    "description": "The notifications the client opts in to on this stream. The server\n**MUST NOT** send notification types the client has not explicitly\nrequested."
-                }
-            },
-            "required": [
-                "_meta",
-                "notifications"
-            ],
-            "type": "object"
-        },
-        "SubscriptionsListenResult": {
-            "description": "The response to a {@link SubscriptionsListenRequestsubscriptions/listen}\nrequest, signalling that the subscription has ended gracefully (for example,\nduring server shutdown). Because the listen stream is long-lived, this result\nis sent only when the server tears the subscription down; an abrupt transport\nclose carries no response. The result body is otherwise empty.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/SubscriptionsListenResultMeta"
-                },
-                "resultType": {
-                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "_meta",
-                "resultType"
-            ],
-            "type": "object"
-        },
-        "SubscriptionsListenResultMeta": {
-            "description": "Extends {@link ResultMetaObject} with the subscription-stream identifier carried by a\n{@link SubscriptionsListenResult}. All key naming rules from `MetaObject` apply.",
-            "properties": {
-                "io.modelcontextprotocol/serverInfo": {
-                    "$ref": "#/$defs/Implementation",
-                    "description": "Identifies the server software producing the response. Servers SHOULD\ninclude this field on every response unless specifically configured not\nto do so.\n\nThe {@link Implementation} schema requires `name` and `version`; other\nfields are optional.\n\nThe value is self-reported by the server and is not verified by the\nprotocol. It is intended for display, logging, and debugging. Clients\nSHOULD NOT use it to change their behavior, and SHOULD NOT rely on it for\nsecurity decisions."
-                },
-                "io.modelcontextprotocol/subscriptionId": {
-                    "$ref": "#/$defs/RequestId",
-                    "description": "Identifies the subscription stream this response closes, so the client can\ncorrelate it with the originating subscription — mirroring the same key on\nthe stream's notifications. The value is the JSON-RPC ID of the\n`subscriptions/listen` request that opened the stream (and equals this\nresponse's `id`)."
-                }
-            },
-            "required": [
-                "io.modelcontextprotocol/subscriptionId"
-            ],
-            "type": "object"
-        },
-        "TextContent": {
-            "description": "Text provided to or from an LLM.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/MetaObject"
-                },
-                "annotations": {
-                    "$ref": "#/$defs/Annotations",
-                    "description": "Optional annotations for the client."
-                },
-                "text": {
-                    "description": "The text content of the message.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "text",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "text",
-                "type"
-            ],
-            "type": "object"
-        },
-        "TextResourceContents": {
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/MetaObject"
                 },
                 "mimeType": {
                     "description": "The MIME type of this resource, if known.",
                     "type": "string"
                 },
-                "text": {
-                    "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
-                    "type": "string"
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
                 },
-                "uri": {
-                    "description": "The URI of this resource.",
-                    "format": "uri",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "text",
-                "uri"
-            ],
-            "type": "object"
-        },
-        "TitledMultiSelectEnumSchema": {
-            "description": "Schema for multiple-selection enumeration with display titles for each option.",
-            "properties": {
-                "default": {
-                    "description": "Optional default value.",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "description": {
-                    "description": "Optional description for the enum field.",
-                    "type": "string"
-                },
-                "items": {
-                    "description": "Schema for array items with enum options and display labels.",
-                    "properties": {
-                        "anyOf": {
-                            "description": "Array of enum options with values and display labels.",
-                            "items": {
-                                "properties": {
-                                    "const": {
-                                        "description": "The constant enum value.",
-                                        "type": "string"
-                                    },
-                                    "title": {
-                                        "description": "Display title for this option.",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "const",
-                                    "title"
-                                ],
-                                "type": "object"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "required": [
-                        "anyOf"
-                    ],
-                    "type": "object"
-                },
-                "maxItems": {
-                    "description": "Maximum number of items to select.",
+                "size": {
+                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
                     "type": "integer"
                 },
-                "minItems": {
-                    "description": "Minimum number of items to select.",
-                    "type": "integer"
-                },
-                "title": {
-                    "description": "Optional title for the enum field.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "array",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "items",
-                "type"
-            ],
-            "type": "object"
-        },
-        "TitledSingleSelectEnumSchema": {
-            "description": "Schema for single-selection enumeration with display titles for each option.",
-            "properties": {
-                "default": {
-                    "description": "Optional default value.",
-                    "type": "string"
-                },
-                "description": {
-                    "description": "Optional description for the enum field.",
-                    "type": "string"
-                },
-                "oneOf": {
-                    "description": "Array of enum options with values and display labels.",
-                    "items": {
-                        "properties": {
-                            "const": {
-                                "description": "The enum value.",
-                                "type": "string"
-                            },
-                            "title": {
-                                "description": "Display label for this option.",
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "const",
-                            "title"
-                        ],
-                        "type": "object"
-                    },
-                    "type": "array"
-                },
-                "title": {
-                    "description": "Optional title for the enum field.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "string",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "oneOf",
-                "type"
-            ],
-            "type": "object"
-        },
-        "Tool": {
-            "description": "Definition for a tool the client can call.",
-            "properties": {
                 "_meta": {
                     "$ref": "#/$defs/MetaObject"
-                },
-                "annotations": {
-                    "$ref": "#/$defs/ToolAnnotations",
-                    "description": "Optional additional tool information.\n\nDisplay name precedence order is: `title`, `annotations.title`, then `name`."
-                },
-                "description": {
-                    "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
-                    "type": "string"
-                },
-                "icons": {
-                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
-                    "items": {
-                        "$ref": "#/$defs/Icon"
-                    },
-                    "type": "array"
-                },
-                "inputSchema": {
-                    "additionalProperties": {},
-                    "description": "A JSON Schema object defining the expected parameters for the tool.\n\nTool arguments are always JSON objects, so `type: \"object\"` is required at the root.\nBeyond that, any JSON Schema 2020-12 keyword may appear alongside `type` — including\ncomposition keywords (`oneOf`, `anyOf`, `allOf`, `not`), conditional keywords\n(`if`/`then`/`else`), reference keywords (`$ref`, `$defs`, `$anchor`), and any other\nstandard validation or annotation keywords.\n\nProperty schemas may carry an `x-mcp-header` annotation to mirror the\nargument value into an HTTP header on the Streamable HTTP transport. See\nthe Streamable HTTP transport specification for the validity and\nextraction rules.\n\nDefaults to JSON Schema 2020-12 when no explicit `$schema` is provided.",
-                    "properties": {
-                        "$schema": {
-                            "type": "string"
-                        },
-                        "type": {
-                            "const": "object",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "type"
-                    ],
-                    "type": "object"
                 },
                 "name": {
                     "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
                     "type": "string"
                 },
-                "outputSchema": {
-                    "additionalProperties": {},
-                    "description": "An optional JSON Schema object defining the structure of the tool's output returned in\nthe structuredContent field of a {@link CallToolResult}. This can be any valid JSON Schema 2020-12.\n\nDefaults to JSON Schema 2020-12 when no explicit `$schema` is provided.",
-                    "properties": {
-                        "$schema": {
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
                 "title": {
                     "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
                     "type": "string"
-                }
-            },
-            "required": [
-                "inputSchema",
-                "name"
-            ],
-            "type": "object"
-        },
-        "ToolAnnotations": {
-            "description": "Additional properties describing a {@link Tool} to clients.\n\nNOTE: all properties in `ToolAnnotations` are **hints**.\nThey are not guaranteed to provide a faithful description of\ntool behavior (including descriptive properties like `title`).\n\nClients should never make tool use decisions based on `ToolAnnotations`\nreceived from untrusted servers.",
-            "properties": {
-                "destructiveHint": {
-                    "description": "If true, the tool may perform destructive updates to its environment.\nIf false, the tool performs only additive updates.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: true",
-                    "type": "boolean"
                 },
-                "idempotentHint": {
-                    "description": "If true, calling the tool repeatedly with the same arguments\nwill have no additional effect on its environment.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: false",
-                    "type": "boolean"
-                },
-                "openWorldHint": {
-                    "description": "If true, this tool may interact with an \"open world\" of external\nentities. If false, the tool's domain of interaction is closed.\nFor example, the world of a web search tool is open, whereas that\nof a memory tool is not.\n\nDefault: true",
-                    "type": "boolean"
-                },
-                "readOnlyHint": {
-                    "description": "If true, the tool does not modify its environment.\n\nDefault: false",
-                    "type": "boolean"
-                },
-                "title": {
-                    "description": "A human-readable title for the tool.",
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "ToolChoice": {
-            "description": "Controls tool selection behavior for sampling requests.",
-            "properties": {
-                "mode": {
-                    "description": "Controls the tool use ability of the model:\n- `\"auto\"`: Model decides whether to use tools (default)\n- `\"required\"`: Model MUST use at least one tool before completing\n- `\"none\"`: Model MUST NOT use any tools",
-                    "enum": [
-                        "auto",
-                        "none",
-                        "required"
-                    ],
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "ToolListChangedNotification": {
-            "description": "An optional notification from the server to the client, informing it that the list of tools it offers has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `toolsListChanged` filter field.",
-            "properties": {
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
-                },
-                "method": {
-                    "const": "notifications/tools/list_changed",
-                    "type": "string"
-                },
-                "params": {
-                    "$ref": "#/$defs/NotificationParams"
-                }
-            },
-            "required": [
-                "jsonrpc",
-                "method"
-            ],
-            "type": "object"
-        },
-        "ToolResultContent": {
-            "description": "The result of a tool use, provided by the user back to the assistant.",
-            "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/MetaObject",
-                    "description": "Optional metadata about the tool result. Clients SHOULD preserve this field when\nincluding tool results in subsequent sampling requests to enable caching optimizations."
-                },
-                "content": {
-                    "description": "The unstructured result content of the tool use.\n\nThis has the same format as {@link CallToolResult.content} and can include text, images,\naudio, resource links, and embedded resources.",
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "type": "array",
                     "items": {
-                        "$ref": "#/$defs/ContentBlock"
-                    },
-                    "type": "array"
-                },
-                "isError": {
-                    "description": "Whether the tool use resulted in an error.\n\nIf true, the content typically describes the error that occurred.\nDefault: false",
-                    "type": "boolean"
-                },
-                "structuredContent": {
-                    "description": "An optional structured result value.\n\nThis can be any JSON value (object, array, string, number, boolean, or null).\nIf the tool defined an {@link Tool.outputSchema}, this SHOULD conform to that schema."
-                },
-                "toolUseId": {
-                    "description": "The ID of the tool use this result corresponds to.\n\nThis MUST match the ID from a previous {@link ToolUseContent}.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "tool_result",
-                    "type": "string"
+                        "$ref": "#/$defs/Icon"
+                    }
                 }
             },
             "required": [
-                "content",
-                "toolUseId",
-                "type"
-            ],
-            "type": "object"
+                "name",
+                "uri"
+            ]
         },
-        "ToolUseContent": {
-            "description": "A request from the assistant to call a tool.",
+        "Root": {
+            "description": "Represents a root directory or file that the server can operate on.",
+            "type": "object",
             "properties": {
-                "_meta": {
-                    "$ref": "#/$defs/MetaObject",
-                    "description": "Optional metadata about the tool use. Clients SHOULD preserve this field when\nincluding tool uses in subsequent sampling requests to enable caching optimizations."
-                },
-                "id": {
-                    "description": "A unique identifier for this tool use.\n\nThis ID is used to match tool results to their corresponding tool uses.",
+                "uri": {
+                    "description": "The URI identifying the root. This *must* start with `file://` for now.\nThis restriction may be relaxed in future versions of the protocol to allow\nother URI schemes.",
+                    "format": "uri",
                     "type": "string"
-                },
-                "input": {
-                    "additionalProperties": {},
-                    "description": "The arguments to pass to the tool, conforming to the tool's input schema.",
-                    "type": "object"
                 },
                 "name": {
-                    "description": "The name of the tool to call.",
+                    "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
                     "type": "string"
                 },
-                "type": {
-                    "const": "tool_use",
-                    "type": "string"
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
                 }
             },
             "required": [
-                "id",
-                "input",
-                "name",
-                "type"
-            ],
-            "type": "object"
+                "uri"
+            ]
         },
-        "UnsupportedProtocolVersionError": {
-            "description": "Returned when the request's protocol version is unknown to the server or\nunsupported (e.g., a known experimental or draft version the server has\nchosen not to implement). For HTTP, the response status code MUST be\n`400 Bad Request`.",
-            "properties": {
-                "error": {
-                    "allOf": [
-                        {
-                            "$ref": "#/$defs/Error"
-                        },
-                        {
-                            "properties": {
-                                "code": {
-                                    "const": -32022,
-                                    "type": "integer"
-                                },
-                                "data": {
-                                    "properties": {
-                                        "requested": {
-                                            "description": "The protocol version that was requested by the client.",
-                                            "type": "string"
-                                        },
-                                        "supported": {
-                                            "description": "Protocol versions the server supports. The client should choose a\nmutually supported version from this list and retry.",
-                                            "items": {
-                                                "type": "string"
-                                            },
-                                            "type": "array"
-                                        }
-                                    },
-                                    "required": [
-                                        "requested",
-                                        "supported"
-                                    ],
-                                    "type": "object"
-                                }
-                            },
-                            "required": [
-                                "code",
-                                "data"
-                            ],
-                            "type": "object"
-                        }
-                    ]
+        "ClientRequest": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/DiscoverRequest"
                 },
-                "id": {
-                    "$ref": "#/$defs/RequestId"
+                {
+                    "$ref": "#/$defs/ListResourcesRequest"
                 },
-                "jsonrpc": {
-                    "const": "2.0",
-                    "type": "string"
+                {
+                    "$ref": "#/$defs/ListResourceTemplatesRequest"
+                },
+                {
+                    "$ref": "#/$defs/ReadResourceRequest"
+                },
+                {
+                    "$ref": "#/$defs/SubscriptionsListenRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListPromptsRequest"
+                },
+                {
+                    "$ref": "#/$defs/GetPromptRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListToolsRequest"
+                },
+                {
+                    "$ref": "#/$defs/CallToolRequest"
+                },
+                {
+                    "$ref": "#/$defs/CompleteRequest"
                 }
-            },
-            "required": [
-                "error",
-                "jsonrpc"
-            ],
-            "type": "object"
-        },
-        "UntitledMultiSelectEnumSchema": {
-            "description": "Schema for multiple-selection enumeration without display titles for options.",
-            "properties": {
-                "default": {
-                    "description": "Optional default value.",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "description": {
-                    "description": "Optional description for the enum field.",
-                    "type": "string"
-                },
-                "items": {
-                    "description": "Schema for the array items.",
-                    "properties": {
-                        "enum": {
-                            "description": "Array of enum values to choose from.",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "type": {
-                            "const": "string",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "enum",
-                        "type"
-                    ],
-                    "type": "object"
-                },
-                "maxItems": {
-                    "description": "Maximum number of items to select.",
-                    "type": "integer"
-                },
-                "minItems": {
-                    "description": "Minimum number of items to select.",
-                    "type": "integer"
-                },
-                "title": {
-                    "description": "Optional title for the enum field.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "array",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "items",
-                "type"
-            ],
-            "type": "object"
-        },
-        "UntitledSingleSelectEnumSchema": {
-            "description": "Schema for single-selection enumeration without display titles for options.",
-            "properties": {
-                "default": {
-                    "description": "Optional default value.",
-                    "type": "string"
-                },
-                "description": {
-                    "description": "Optional description for the enum field.",
-                    "type": "string"
-                },
-                "enum": {
-                    "description": "Array of enum values to choose from.",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "title": {
-                    "description": "Optional title for the enum field.",
-                    "type": "string"
-                },
-                "type": {
-                    "const": "string",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "enum",
-                "type"
-            ],
-            "type": "object"
+            ]
         }
     }
 }
-

--- a/scripts/generate-schemas.ts
+++ b/scripts/generate-schemas.ts
@@ -1,11 +1,9 @@
 #!/usr/bin/env tsx
 
-import { exec } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
-import { promisify } from 'util';
-
-const execAsync = promisify(exec);
+import { join, resolve } from 'path';
+import * as TJS from 'typescript-json-schema';
+import * as ts from 'typescript';
 
 // Legacy schema versions that should remain as JSON Schema draft-07
 const LEGACY_SCHEMAS = ['2024-11-05', '2025-03-26', '2025-06-18'];
@@ -19,91 +17,137 @@ const ALL_SCHEMAS = [...LEGACY_SCHEMAS, ...MODERN_SCHEMAS];
 // Check if we're in check mode (validate existing schemas match generated ones)
 const CHECK_MODE = process.argv.includes('--check');
 
+// typescript-json-schema settings matching the original CLI flags
+const TJS_SETTINGS: TJS.PartialArgs = {
+  defaultNumberType: 'integer',
+  required: true,
+  skipLibCheck: true,
+};
+
 /**
- * Apply JSON Schema 2020-12 transformations to a schema file
+ * Enumerate all exported type and interface names from a TypeScript source file.
+ *
+ * `generator.getMainFileSymbols()` misses exported types whose names collide
+ * with DOM/built-in types (e.g. Request, Resource, Root, ClientRequest).
+ * This function walks the AST to find those missing types so they can be
+ * merged back into the symbol list.
  */
-function applyJsonSchema202012Transformations(schemaPath: string): void {
-  let content = readFileSync(schemaPath, 'utf-8');
+function getExportedTypeNames(
+  program: ts.Program,
+  sourceFilePath: string,
+  generator: TJS.JsonSchemaGenerator,
+): string[] {
+  const sourceFile = program.getSourceFile(sourceFilePath);
+  if (!sourceFile) {
+    throw new Error(`Source file not found: ${sourceFilePath}`);
+  }
 
-  // Replace $schema URL
-  content = content.replace(
-    /http:\/\/json-schema\.org\/draft-07\/schema#/g,
-    'https://json-schema.org/draft/2020-12/schema'
-  );
+  const userSymbols = new Set(generator.getUserSymbols());
+  const exportedNames: string[] = [];
 
-  // Replace "definitions": with "$defs":
-  content = content.replace(
-    /"definitions":/g,
-    '"$defs":'
-  );
+  ts.forEachChild(sourceFile, (node) => {
+    const modifiers = ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined;
+    if (!modifiers?.some(m => m.kind === ts.SyntaxKind.ExportKeyword)) {
+      return;
+    }
 
-  // Replace #/definitions/ with #/$defs/
-  content = content.replace(
-    /#\/definitions\//g,
-    '#/$defs/'
-  );
+    if (ts.isTypeAliasDeclaration(node) || ts.isInterfaceDeclaration(node) || ts.isEnumDeclaration(node)) {
+      const name = node.name.text;
+      if (userSymbols.has(name)) {
+        exportedNames.push(name);
+      }
+    }
+    // Intentionally skip VariableStatements (export const) — they are runtime
+    // values (e.g. LATEST_PROTOCOL_VERSION), not schema types.
+  });
 
-  writeFileSync(schemaPath, content, 'utf-8');
+  return exportedNames;
 }
 
 /**
- * Generate JSON schema for a specific version
+ * Apply JSON Schema 2020-12 transformations to a schema string
  */
-async function generateSchema(version: string, check: boolean = false): Promise<boolean> {
+function applyJsonSchema202012Transformations(schema: string): string {
+  return schema
+    .replace(
+      /http:\/\/json-schema\.org\/draft-07\/schema#/g,
+      'https://json-schema.org/draft/2020-12/schema',
+    )
+    .replace(/"definitions":/g, '"$defs":')
+    .replace(/#\/definitions\//g, '#/$defs/');
+}
+
+/**
+ * Generate the JSON schema string for a given schema version using the
+ * typescript-json-schema programmatic API.
+ */
+function generateSchemaString(version: string): string {
   const schemaDir = join('schema', version);
-  const schemaTs = join(schemaDir, 'schema.ts');
+  const schemaTs = resolve(join(schemaDir, 'schema.ts'));
+
+  // Pass empty compiler options to match the CLI's default behavior.
+  // Explicit options (e.g. strict, target) alter how typescript-json-schema
+  // resolves $ref entries, producing schemas that differ from the CLI output.
+  const program = TJS.getProgramFromFiles([schemaTs], {});
+  const generator = TJS.buildGenerator(program, TJS_SETTINGS);
+  if (!generator) {
+    throw new Error(`Failed to build schema generator for ${version}`);
+  }
+
+  // Use getMainFileSymbols() as the primary source (matches CLI wildcard
+  // behavior), then merge in any AST-discovered types that were missed
+  // due to name collisions with DOM/built-in types.
+  const mainSymbols = generator.getMainFileSymbols(program);
+  const mainSet = new Set(mainSymbols);
+  const astSymbols = getExportedTypeNames(program, schemaTs, generator);
+  const symbols = [...mainSymbols];
+  for (const name of astSymbols) {
+    if (!mainSet.has(name)) {
+      symbols.push(name);
+    }
+  }
+
+  if (symbols.length === 0) {
+    throw new Error(`No exported types found in ${schemaTs}`);
+  }
+
+  const schema = generator.getSchemaForSymbols(symbols);
+  let output = JSON.stringify(schema, null, 4) + '\n';
+
+  // Apply transformations for non-legacy schemas
+  if (!LEGACY_SCHEMAS.includes(version)) {
+    output = applyJsonSchema202012Transformations(output);
+  }
+
+  return output;
+}
+
+/**
+ * Generate or check JSON schema for a specific version
+ */
+function processSchema(version: string, check: boolean): boolean {
+  const schemaDir = join('schema', version);
   const schemaJson = join(schemaDir, 'schema.json');
 
   if (check) {
-    // Read existing schema
     const existingSchema = readFileSync(schemaJson, 'utf-8');
+    const generatedSchema = generateSchemaString(version);
 
-    // Generate schema to stdout and capture it
-    try {
-      const { stdout: generated } = await execAsync(
-        `npx typescript-json-schema --defaultNumberType integer --required --skipLibCheck "${schemaTs}" "*"`
-      );
+    // Use semantic comparison (parsed JSON deep equality) so that
+    // insignificant whitespace or property-ordering differences are ignored.
+    const existingParsed = JSON.parse(existingSchema);
+    const generatedParsed = JSON.parse(generatedSchema);
 
-      let expectedSchema = generated;
-
-      // Apply transformations for non-legacy schemas
-      if (!LEGACY_SCHEMAS.includes(version)) {
-        expectedSchema = expectedSchema.replace(
-          /http:\/\/json-schema\.org\/draft-07\/schema#/g,
-          'https://json-schema.org/draft/2020-12/schema'
-        );
-        expectedSchema = expectedSchema.replace(/"definitions":/g, '"$defs":');
-        expectedSchema = expectedSchema.replace(/#\/definitions\//g, '#/$defs/');
-      }
-
-      // Compare
-      if (existingSchema.trim() !== expectedSchema.trim()) {
-        console.error(`  ✗ Schema ${version} is out of date!`);
-        return false;
-      }
-
-      console.log(`  ✓ Schema ${version} is up to date`);
-      return true;
-    } catch (error) {
-      console.error(`Failed to check schema for ${version}`);
-      throw error;
+    if (JSON.stringify(existingParsed) !== JSON.stringify(generatedParsed)) {
+      console.error(`  ✗ Schema ${version} is out of date!`);
+      return false;
     }
+
+    console.log(`  ✓ Schema ${version} is up to date`);
+    return true;
   } else {
-    // Run typescript-json-schema
-    try {
-      await execAsync(
-        `npx typescript-json-schema --defaultNumberType integer --required --skipLibCheck "${schemaTs}" "*" -o "${schemaJson}"`
-      );
-    } catch (error) {
-      console.error(`Failed to generate schema for ${version}`);
-      throw error;
-    }
-
-    // Apply transformations for non-legacy schemas
-    if (!LEGACY_SCHEMAS.includes(version)) {
-      applyJsonSchema202012Transformations(schemaJson);
-    }
-
+    const generatedSchema = generateSchemaString(version);
+    writeFileSync(schemaJson, generatedSchema, 'utf-8');
     console.log(`  ✓ Generated schema for ${version}`);
     return true;
   }
@@ -112,14 +156,11 @@ async function generateSchema(version: string, check: boolean = false): Promise<
 /**
  * Main function
  */
-async function main(): Promise<void> {
+function main(): void {
   if (CHECK_MODE) {
-    console.log('Checking JSON schemas in parallel...\n');
+    console.log('Checking JSON schemas...\n');
 
-    const results = await Promise.all(
-      ALL_SCHEMAS.map(version => generateSchema(version, true))
-    );
-
+    const results = ALL_SCHEMAS.map(version => processSchema(version, true));
     const allValid = results.every(valid => valid);
 
     console.log();
@@ -130,11 +171,9 @@ async function main(): Promise<void> {
       console.log('All schemas are up to date!');
     }
   } else {
-    console.log('Generating JSON schemas in parallel...\n');
+    console.log('Generating JSON schemas...\n');
 
-    await Promise.all(
-      ALL_SCHEMAS.map(version => generateSchema(version, false))
-    );
+    ALL_SCHEMAS.forEach(version => processSchema(version, false));
 
     console.log('\nSchema generation complete!');
     console.log(`- (draft-07): ${LEGACY_SCHEMAS.join(', ')}`);
@@ -142,7 +181,4 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch(error => {
-  console.error('Schema generation failed:', error);
-  process.exit(1);
-});
+main();


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Replaces the CLI-based `npx typescript-json-schema ... "*"` invocation in `scripts/generate-schemas.ts` with the library's programmatic API (`TJS.buildGenerator` + `getSchemaForSymbols`).

Fixes #3114 

## Motivation and Context
The `typescript-json-schema` CLI's wildcard `"*"` type argument silently produces empty schemas on Node.js 24+ with TypeScript 6+. On a clean checkout:

- `npm run generate:schema:json` overwrites all five schema files with
  near-empty JSON (~85 bytes each, zero definitions).

- `npm run check:schema:examples` then reports **0 passed, 128 failed**.

Generating a single named type (e.g. `"AudioContent"`) still works, so the regression is isolated to wildcard type discovery inside the library's CLI entry-point.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

After the change, on the same Node.js 24 + TypeScript 6 environment that was
previously broken:
| Command                           | Before         | After                  |
|-----------------------------------|----------------|------------------------|
| `npm run generate:schema:json`    | 5 empty files  |  all 5 schemas valid  |
| `npm run check:schema:json`       | out of date  |  all 5 up to date     |
| `npm run check:schema:examples`   | 0/128 passed   |  128/128 passed       |

Generated schema definition counts per version:

| Version    | Definitions | JSON Schema dialect |
|------------|-------------|---------------------|
| 2024-11-05 | 79          | draft-07            |
| 2025-03-26 | 83          | draft-07            |
| 2025-06-18 | 91          | draft-07            |
| 2025-11-25 | 145         | 2020-12             |
| draft      | 154         | 2020-12             |

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
### AI Disclosure
This fix was developed with AI assistance. Specifically:
- **Investigation & root-cause analysis**: AI reproduced the bug, tested the
  programmatic API as a workaround, identified the `getMainFileSymbols()`
  gap (4 missing symbols due to DOM name collisions), and validated the fix
  produces all 154 expected definitions for the draft schema.
- **Code generation**: The rewritten `generate-schemas.ts` was authored by AI
  based on the investigation findings.
- **Testing & verification**: AI ran `generate:schema:json`,
  `check:schema:json`, and `check:schema:examples` to confirm the fix.
I reviewed the changes, understood the root cause, and verified the results
independently.
