### PR TITLE
Skip existing redirect sources when cutting a release

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -164,13 +164,19 @@ jobs:
           }
           // Draft-source redirects (pages that moved out of the draft tree)
           // get a dated sibling so the promoted version's URLs resolve too.
+          // Skip any dated source already present: main may carry pre-cut
+          // <version>/ redirects, and Mintlify rejects duplicate sources.
           const draftRedirects = (j.redirects ?? []).filter((r) =>
             r.source.startsWith('/specification/draft/'),
           );
+          const sources = new Set((j.redirects ?? []).map((r) => r.source));
           for (const r of draftRedirects) {
+            const source = r.source.replace('/specification/draft/', `/specification/${V}/`);
+            if (sources.has(source)) continue;
+            sources.add(source);
             j.redirects.push({
               ...r,
-              source: r.source.replace('/specification/draft/', `/specification/${V}/`),
+              source,
               destination: r.destination
                 .replaceAll('/specification/draft', `/specification/${V}`)
                 .replaceAll('/docs/draft', `/docs/${V}`),


### PR DESCRIPTION
The 2026-07-28 release PR (#3154) failed Mintlify's config validation with "Each source path can only be used once". The cause is the nav patch step in `cut-release.yml`: it appends a dated sibling redirect for every `/specification/draft/...` entry, but never checked whether that dated source already existed. `main` already carried the five `2026-07-28` redirects for the restructured lifecycle and utilities pages, so the loop wrote each of those sources a second time.

This tracks the existing sources in a set and skips any collision, which makes the step idempotent no matter what `main` already contains. I checked it by pulling the script out of the workflow and running it against `main`'s real `docs.json`: the current logic reproduces the five duplicates (78 redirects), the patched logic yields 73 with none, and a second run over its own output is a no-op.

The duplicate entries already in #3154 are removed in a separate commit on that branch, so this only prevents the next release from tripping the same wire.