### PR TITLE
Mark 2026-07-28 as the default docs version

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -80,7 +80,8 @@
                   "examples"
                 ]
               }
-            ]
+            ],
+            "default": true
           },
           {
             "version": "Version 2025-11-25",
@@ -441,7 +442,8 @@
                 ]
               },
               "specification/2026-07-28/schema"
-            ]
+            ],
+            "default": true
           },
           {
             "version": "Version 2025-11-25",


### PR DESCRIPTION
The published site is showing the outdated-version banner on the `2026-07-28` pages ("View the latest version (2025-11-25)") for both docs and spec, even though `2026-07-28` is first in each `versions` array. No version entry sets `default`, so Mintlify is inferring the latest version and resolving `2025-11-25`.

This sets `default: true` on the `Version 2026-07-28 (latest)` entry in both the Documentation and Specification tabs, which is Mintlify's explicit control for the default version and stops the inference. No other config changes.