### PR TITLE
Fix typo in 2025-11-25 authorization spec

### DIFF
--- a/docs/specification/2025-11-25/basic/authorization.mdx
+++ b/docs/specification/2025-11-25/basic/authorization.mdx
@@ -643,7 +643,7 @@ Authorization servers fetching metadata documents **SHOULD** consider
 Client ID Metadata Documents cannot prevent `localhost` URL impersonation by themselves. An attacker can claim to be any client by:
 
 1. Providing the legitimate client's metadata URL as their `client_id`
-2. Binding to the any `localhost` port, and providing that address as the redirect_uri
+2. Binding to any `localhost` port, and providing that address as the redirect_uri
 3. Receiving the authorization code via the redirect when the user approves
 
 The server will see the legitimate client's metadata document and the user will see the legitimate client's name, making attack detection difficult.


### PR DESCRIPTION
One-word fix: "Binding to the any `localhost` port" becomes "Binding to any `localhost` port" in the localhost redirect URI attack steps. This matches the wording the draft and 2026-07-28 copies of this page already use.

Merging this also re-triggers the Mintlify deploy for the site.