### PR TITLE
docs: record post-final SEP-2575 changes

### DIFF
--- a/docs/seps/2575-stateless-mcp.mdx
+++ b/docs/seps/2575-stateless-mcp.mdx
@@ -814,6 +814,12 @@ authoritative, up-to-date requirements.
   the top-level `DiscoverResult.serverInfo` field to avoid duplicate
   representations. Servers **SHOULD** include this metadata on every result
   unless specifically configured not to do so.
+- **Subscriptions gained a graceful completion result.**
+  [#2953](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2953)
+  defined a `subscriptions/listen` result for server-initiated graceful
+  closure, replacing the SEP's statement that a subscription has no natural
+  completion result. Servers **SHOULD** send this result before closing the
+  stream.
 
 [SEP-2127]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127
 [SEP-2243]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2243

--- a/docs/seps/2575-stateless-mcp.mdx
+++ b/docs/seps/2575-stateless-mcp.mdx
@@ -796,6 +796,25 @@ negotiation). Should `clientInfo` be folded into `ClientCapabilities`, remain a
 separate per-request `_meta` field, or be handled through a different mechanism
 entirely (e.g., only sent via `subscriptions/listen`)?
 
+## Changes since SEP became Final
+
+This SEP is preserved as a historical record of what was accepted. The list
+below tracks changes made to the specification after this SEP reached Final
+status. Refer to the current
+[specification](https://modelcontextprotocol.io/specification) for the
+authoritative, up-to-date requirements.
+
+- **Client identity became optional request metadata.**
+  [#3002](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/3002)
+  made `io.modelcontextprotocol/clientInfo` optional. Clients **SHOULD** include
+  it on every request unless specifically configured not to do so.
+- **Server identity moved to optional result metadata.**
+  [#3002](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/3002)
+  introduced `io.modelcontextprotocol/serverInfo` in result `_meta` and removed
+  the top-level `DiscoverResult.serverInfo` field to avoid duplicate
+  representations. Servers **SHOULD** include this metadata on every result
+  unless specifically configured not to do so.
+
 [SEP-2127]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127
 [SEP-2243]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2243
 [SEP-2260]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2260

--- a/seps/2575-stateless-mcp.md
+++ b/seps/2575-stateless-mcp.md
@@ -796,6 +796,12 @@ authoritative, up-to-date requirements.
   the top-level `DiscoverResult.serverInfo` field to avoid duplicate
   representations. Servers **SHOULD** include this metadata on every result
   unless specifically configured not to do so.
+- **Subscriptions gained a graceful completion result.**
+  [#2953](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2953)
+  defined a `subscriptions/listen` result for server-initiated graceful
+  closure, replacing the SEP's statement that a subscription has no natural
+  completion result. Servers **SHOULD** send this result before closing the
+  stream.
 
 [SEP-2127]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127
 [SEP-2243]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2243

--- a/seps/2575-stateless-mcp.md
+++ b/seps/2575-stateless-mcp.md
@@ -778,6 +778,25 @@ negotiation). Should `clientInfo` be folded into `ClientCapabilities`, remain a
 separate per-request `_meta` field, or be handled through a different mechanism
 entirely (e.g., only sent via `subscriptions/listen`)?
 
+## Changes since SEP became Final
+
+This SEP is preserved as a historical record of what was accepted. The list
+below tracks changes made to the specification after this SEP reached Final
+status. Refer to the current
+[specification](https://modelcontextprotocol.io/specification) for the
+authoritative, up-to-date requirements.
+
+- **Client identity became optional request metadata.**
+  [#3002](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/3002)
+  made `io.modelcontextprotocol/clientInfo` optional. Clients **SHOULD** include
+  it on every request unless specifically configured not to do so.
+- **Server identity moved to optional result metadata.**
+  [#3002](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/3002)
+  introduced `io.modelcontextprotocol/serverInfo` in result `_meta` and removed
+  the top-level `DiscoverResult.serverInfo` field to avoid duplicate
+  representations. Servers **SHOULD** include this metadata on every result
+  unless specifically configured not to do so.
+
 [SEP-2127]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127
 [SEP-2243]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2243
 [SEP-2260]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2260


### PR DESCRIPTION
Follow-up to #2953 and #3002.

## Motivation and Context

SEP-2575 remains the historical record of the accepted proposal. However, several protocol details changed after it became Final.

PR #3002 made `io.modelcontextprotocol/clientInfo` optional. It also moved the server identity from the top-level `DiscoverResult.serverInfo` field to the optional `_meta["io.modelcontextprotocol/serverInfo"]` field.

PR #2953 added a `subscriptions/listen` result for graceful, server-initiated closure. This replaced the SEP's statement that subscriptions have no natural completion result.

As a result, readers implementing the SEP may reach conclusions that conflict with the current schema. This adds a "Changes since SEP became Final" section to document these updates without rewriting the accepted proposal.

## How Has This Been Tested?

`npm run prep`

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

This came up while reviewing modelcontextprotocol/rust-sdk#1078 against
modelcontextprotocol/rust-sdk#1065.
