### PR TITLE
Publish the 2026-07-28 specification post

### DIFF
--- a/blog/content/posts/2026-07-28-spec-ga/index.md
+++ b/blog/content/posts/2026-07-28-spec-ga/index.md
@@ -3,7 +3,6 @@ title: "The 2026-07-28 Specification"
 date: "2026-07-28T09:00:00+00:00"
 publishDate: "2026-07-28T09:00:00+00:00"
 slug: 2026-07-28
-draft: true
 description: "The 2026-07-28 Model Context Protocol specification is out, bringing a stateless protocol core, Multi Round-Trip Requests, header-based routing, cacheable list results, authorization hardening, a formal extensions framework, and updated Tier 1 SDKs."
 author:
   - David Soria Parra (Lead Maintainer)


### PR DESCRIPTION
Removes the `draft: true` flag from the 2026-07-28 GA announcement so Hugo publishes it, now that the specification, docs, and GitHub release are all live.