### PR TITLE
docs(registry-wg): remove @tadasant from Registry WG Leads

### DIFF
--- a/docs/community/working-groups/registry.mdx
+++ b/docs/community/working-groups/registry.mdx
@@ -37,10 +37,9 @@ The Registry Working Group exists to build and maintain the official MCP Registr
 
 ## Leadership
 
-| Role | Name               | Organization | GitHub                                     | Term    |
-| ---- | ------------------ | ------------ | ------------------------------------------ | ------- |
-| Lead | Tadas Antanavicius | PulseMCP     | [@tadasant](https://github.com/tadasant)   | Initial |
-| Lead | Radoslav Dimitrov  | Stacklok     | [@rdimitrov](https://github.com/rdimitrov) | Initial |
+| Role | Name              | Organization | GitHub                                     | Term    |
+| ---- | ----------------- | ------------ | ------------------------------------------ | ------- |
+| Lead | Radoslav Dimitrov | Stacklok     | [@rdimitrov](https://github.com/rdimitrov) | Initial |
 
 ## Authority & Decision Rights
 
@@ -59,7 +58,7 @@ The Registry Working Group exists to build and maintain the official MCP Registr
 
 | Name               | Organization | GitHub                                           | Discord    | Level     | Maintainer? |
 | ------------------ | ------------ | ------------------------------------------------ | ---------- | --------- | ----------- |
-| Tadas Antanavicius | PulseMCP     | [@tadasant](https://github.com/tadasant)         | tadasant\_ | Lead      | Yes         |
+| Tadas Antanavicius | PulseMCP     | [@tadasant](https://github.com/tadasant)         | tadasant\_ | WG Member | Yes         |
 | Radoslav Dimitrov  | Stacklok     | [@rdimitrov](https://github.com/rdimitrov)       | dimitrovr  | Lead      | Yes         |
 | Bob Dickinson      | TeamSpark    | [@BobDickinson](https://github.com/BobDickinson) | rddthree   | WG Member | Yes         |
 | Preeti Dewani      | Ravenmail    | [@pree-dew](https://github.com/pree-dew)         | pree_dew   | WG Member | No          |
@@ -108,6 +107,7 @@ Discord: `#registry-dev`
 
 ## Changelog
 
-| Date       | Change          |
-| ---------- | --------------- |
-| 2026-04-08 | Initial charter |
+| Date       | Change                                                                                      |
+| ---------- | ------------------------------------------------------------------------------------------- |
+| 2026-07-30 | @tadasant stepped down as Lead; @rdimitrov is now sole Lead (@tadasant remains a WG Member) |
+| 2026-04-08 | Initial charter                                                                             |

--- a/docs/community/working-groups/registry.mdx
+++ b/docs/community/working-groups/registry.mdx
@@ -58,8 +58,8 @@ The Registry Working Group exists to build and maintain the official MCP Registr
 
 | Name               | Organization | GitHub                                           | Discord    | Level     | Maintainer? |
 | ------------------ | ------------ | ------------------------------------------------ | ---------- | --------- | ----------- |
-| Tadas Antanavicius | PulseMCP     | [@tadasant](https://github.com/tadasant)         | tadasant\_ | WG Member | Yes         |
 | Radoslav Dimitrov  | Stacklok     | [@rdimitrov](https://github.com/rdimitrov)       | dimitrovr  | Lead      | Yes         |
+| Tadas Antanavicius | PulseMCP     | [@tadasant](https://github.com/tadasant)         | tadasant\_ | WG Member | Yes         |
 | Bob Dickinson      | TeamSpark    | [@BobDickinson](https://github.com/BobDickinson) | rddthree   | WG Member | Yes         |
 | Preeti Dewani      | Ravenmail    | [@pree-dew](https://github.com/pree-dew)         | pree_dew   | WG Member | No          |
 


### PR DESCRIPTION
Per discussions with @rdimitrov and @dsp-ant, removing myself from WG Leads of Registry so I can free up some time to keep working on [AI Catalog](https://github.com/Agent-Card/ai-catalog) and [Server Cards](https://github.com/modelcontextprotocol/experimental-ext-server-card).