### PR TITLE
docs: remove experimental term from Task docs

### DIFF
--- a/docs/extensions/tasks/overview.mdx
+++ b/docs/extensions/tasks/overview.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Overview
 description: Asynchronous task execution for long-running MCP operations
 ---
 
-The [experimental-ext-tasks repository](https://github.com/modelcontextprotocol/experimental-ext-tasks) contains the full specification and documentation for MCP Tasks.
+The [ext-tasks repository](https://github.com/modelcontextprotocol/ext-tasks) contains the full specification and documentation for MCP Tasks.
 
 <Card
   title="modelcontextprotocol/ext-tasks"
@@ -275,4 +275,4 @@ clients. Task support requires explicit opt-in from both client and server.
 
 ## Specification
 
-The Tasks extension is specified in the [experimental-ext-tasks repository](https://github.com/modelcontextprotocol/experimental-ext-tasks). It uses the standard MCP [extension negotiation](/extensions/overview#negotiation) mechanism: clients declare support in the `extensions` field of the `io.modelcontextprotocol/clientCapabilities` they send in each request's `_meta`, and servers advertise theirs in the capabilities returned by [`server/discover`](/specification/draft/server/discover).
+The Tasks extension is specified in the [ext-tasks repository](https://github.com/modelcontextprotocol/ext-tasks). It uses the standard MCP [extension negotiation](/extensions/overview#negotiation) mechanism: clients declare support in the `extensions` field of the `io.modelcontextprotocol/clientCapabilities` they send in each request's `_meta`, and servers advertise theirs in the capabilities returned by [`server/discover`](/specification/draft/server/discover).


### PR DESCRIPTION
Task is now an official MCP extension with 7-28 release; hence, this PR updates the Task docs to remove the experimental term.

## Motivation and Context
With the 7-28 release, the Task extension has become an official extension, and the documentation should be updated accordingly. 

## How Has This Been Tested?
Followed the contributor guide to test the doc changes locally.

## Breaking Changes
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
No.