### PR TITLE
fix: correct typos in SEP documents

### DIFF
--- a/docs/seps/1577--sampling-with-tools.mdx
+++ b/docs/seps/1577--sampling-with-tools.mdx
@@ -288,7 +288,7 @@ In the "Possible Follow ups" Section below, we give examples of features that we
 
 ## Possible Follow ups
 
-Theses are out of scope for this SEP, but care was taken not to preclude them, so where appropriate we give examples of how they could be implemented on top of / after this SEP.
+These are out of scope for this SEP, but care was taken not to preclude them, so where appropriate we give examples of how they could be implemented on top of / after this SEP.
 
 ### Streaming support
 

--- a/docs/seps/2260-Require-Server-requests-to-be-associated-with-Client-requests.mdx
+++ b/docs/seps/2260-Require-Server-requests-to-be-associated-with-Client-requests.mdx
@@ -265,7 +265,7 @@ Implementers **MUST** ensure that:
 
 **No changes required** - Clients should already handle sampling/elicitation requests in the context of their own outbound requests. Potential to simplify implementations if out-of-band is currently supported.
 
-Clients recieving server-to-client requests with no associated outbound request **SHOULD** respond with a `-32602` (Invalid Params) error.
+Clients receiving server-to-client requests with no associated outbound request **SHOULD** respond with a `-32602` (Invalid Params) error.
 
 ### For Transport Implementers
 

--- a/docs/seps/2322-MRTR.mdx
+++ b/docs/seps/2322-MRTR.mdx
@@ -1275,7 +1275,7 @@ In the ephemeral workflow, this would look like the following:
 }
 ```
 
-2. The Server responds wit an incomplete response, indicating that the client needs to provide missing information for the request to succeed.
+2. The Server responds with an incomplete response, indicating that the client needs to provide missing information for the request to succeed.
 
 In the persistent workflow, this would look like the following:
 Step 7 from above: <b>Client Request</b> The client mistakenly or maliciously sends unexpected, but well-formed data to the server in response to the input request.
@@ -1303,7 +1303,7 @@ Step 7 from above: <b>Client Request</b> The client mistakenly or maliciously se
 }
 ```
 
-Step 8 from above. <b>Server Response</b> Server acknowledges the receipt of the response by sending a `JSONRPCResultResponse`. However, since the response is missing required information, the server does not proceed with processing the taks and leaves the Task status as `input_required`. The next time the client calls `tasks/result`, the server responds with a new `inputRequest` requesting the necessary information again.
+Step 8 from above. <b>Server Response</b> Server acknowledges the receipt of the response by sending a `JSONRPCResultResponse`. However, since the response is missing required information, the server does not proceed with processing the task and leaves the Task status as `input_required`. The next time the client calls `tasks/result`, the server responds with a new `inputRequest` requesting the necessary information again.
 
 ```json
 {

--- a/docs/seps/991-enable-url-based-client-registration-using-oauth-c.mdx
+++ b/docs/seps/991-enable-url-based-client-registration-using-oauth-c.mdx
@@ -240,9 +240,9 @@ There is not any additional amplification for the fetch request (i.e. the bandwi
 
 The RFC for Client ID Metadata documents is still a draft. It has been implemented by the platform Bluesky, but has not been ratified or very widely adopted outside of that, and may evolve over time. Our intention is to evolve and align with subsequent drafts and any final standard, while minimizing disruption and breakage with existing implementations.
 
-This approach has the risk that there are implementation challenges or flaws in the protocol that have not surfaced yet. However, even though DCR has been ratified, and it also has a number of implementation challenges that developers are facing when trying to use it in an open ecosystem context like MCP. Those challenges are the motiviation behind this proposal.
+This approach has the risk that there are implementation challenges or flaws in the protocol that have not surfaced yet. However, even though DCR has been ratified, and it also has a number of implementation challenges that developers are facing when trying to use it in an open ecosystem context like MCP. Those challenges are the motivation behind this proposal.
 
-#### Risk: Client implementation burden, espcially local clients
+#### Risk: Client implementation burden, especially local clients
 
 This specification requires an additional piece of infrastructure for clients, since they need to host a metadata file behind an HTTPS url. Without this specification, a client could be strictly a desktop application for example.
 

--- a/seps/1577--sampling-with-tools.md
+++ b/seps/1577--sampling-with-tools.md
@@ -27,7 +27,7 @@
 - _Nov 5_:
   - kept `stopReason` as open string but w/ redundant explicit enums for visibility
   - removed requirement to throw when `includeContext` not matching advertised `ClientCapabilities.sampling.context`
-  - mitigates backwards compatibility issue of `CreateMessageResult.content` being an array of contents OR a single content by saying sampling _MUST NOT_ return an array in earlier spec versions (+ ackowledging SDK updates of code w/ sampling will need small code changes)
+  - mitigates backwards compatibility issue of `CreateMessageResult.content` being an array of contents OR a single content by saying sampling _MUST NOT_ return an array in earlier spec versions (+ acknowledging SDK updates of code w/ sampling will need small code changes)
 - _Nov 7_: renamed type `ToolCallContent` to `ToolUseContent` (to match its `tool_use` type & the `toolUse` `stopReason`). SEP was approved!
 - _Nov 10_: removing `disable_parallel_tool_use` / keeping for a later update as the Gemini API has no way to implement this for now.
 - _Nov 11_: added extra notes about Gemini API's function calling modes & roles; requiring SamplingMessage w/ tool result contents not be mixed w/ other content types
@@ -286,7 +286,7 @@ In the "Possible Follow ups" Section below, we give examples of features that we
 
 ## Possible Follow ups
 
-Theses are out of scope for this SEP, but care was taken not to preclude them, so where appropriate we give examples of how they could be implemented on top of / after this SEP.
+These are out of scope for this SEP, but care was taken not to preclude them, so where appropriate we give examples of how they could be implemented on top of / after this SEP.
 
 ### Streaming support
 

--- a/seps/2260-Require-Server-requests-to-be-associated-with-Client-requests.md
+++ b/seps/2260-Require-Server-requests-to-be-associated-with-Client-requests.md
@@ -238,7 +238,7 @@ Implementers **MUST** ensure that:
 
 **No changes required** - Clients should already handle sampling/elicitation requests in the context of their own outbound requests. Potential to simplify implementations if out-of-band is currently supported.
 
-Clients recieving server-to-client requests with no associated outbound request **SHOULD** respond with a `-32602` (Invalid Params) error.
+Clients receiving server-to-client requests with no associated outbound request **SHOULD** respond with a `-32602` (Invalid Params) error.
 
 ### For Transport Implementers
 

--- a/seps/2322-MRTR.md
+++ b/seps/2322-MRTR.md
@@ -1239,7 +1239,7 @@ In the ephemeral workflow, this would look like the following:
 }
 ```
 
-2. The Server responds wit an incomplete response, indicating that the client needs to provide missing information for the request to succeed.
+2. The Server responds with an incomplete response, indicating that the client needs to provide missing information for the request to succeed.
 
 In the persistent workflow, this would look like the following:
 Step 7 from above: <b>Client Request</b> The client mistakenly or maliciously sends unexpected, but well-formed data to the server in response to the input request.
@@ -1267,7 +1267,7 @@ Step 7 from above: <b>Client Request</b> The client mistakenly or maliciously se
 }
 ```
 
-Step 8 from above. <b>Server Response</b> Server acknowledges the receipt of the response by sending a `JSONRPCResultResponse`. However, since the response is missing required information, the server does not proceed with processing the taks and leaves the Task status as `input_required`. The next time the client calls `tasks/result`, the server responds with a new `inputRequest` requesting the necessary information again.
+Step 8 from above. <b>Server Response</b> Server acknowledges the receipt of the response by sending a `JSONRPCResultResponse`. However, since the response is missing required information, the server does not proceed with processing the task and leaves the Task status as `input_required`. The next time the client calls `tasks/result`, the server responds with a new `inputRequest` requesting the necessary information again.
 
 ```json
 {

--- a/seps/991-enable-url-based-client-registration-using-oauth-c.md
+++ b/seps/991-enable-url-based-client-registration-using-oauth-c.md
@@ -214,9 +214,9 @@ There is not any additional amplification for the fetch request (i.e. the bandwi
 
 The RFC for Client ID Metadata documents is still a draft. It has been implemented by the platform Bluesky, but has not been ratified or very widely adopted outside of that, and may evolve over time. Our intention is to evolve and align with subsequent drafts and any final standard, while minimizing disruption and breakage with existing implementations.
 
-This approach has the risk that there are implementation challenges or flaws in the protocol that have not surfaced yet. However, even though DCR has been ratified, and it also has a number of implementation challenges that developers are facing when trying to use it in an open ecosystem context like MCP. Those challenges are the motiviation behind this proposal.
+This approach has the risk that there are implementation challenges or flaws in the protocol that have not surfaced yet. However, even though DCR has been ratified, and it also has a number of implementation challenges that developers are facing when trying to use it in an open ecosystem context like MCP. Those challenges are the motivation behind this proposal.
 
-#### Risk: Client implementation burden, espcially local clients
+#### Risk: Client implementation burden, especially local clients
 
 This specification requires an additional piece of infrastructure for clients, since they need to host a metadata file behind an HTTPS url. Without this specification, a client could be strictly a desktop application for example.
 


### PR DESCRIPTION
Fix misspellings in SEP sources 
## Motivation and Context
A few SEP documents had small spelling mistakes (`motiviation`, `espcially`, `ackowledging`, `Theses`, `recieving`, `wit`, `taks`). This cleans those up so the published SEP docs read correctly.

## How Has This Been Tested?
- Confirmed misspellings are gone from `seps/` and regenerated `docs/seps/`
- Ran `npm run check:seps` (docs are up to date)

## Breaking Changes
None

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
