### PR TITLE
Move Nick Aldridge to Core Maintainer Emeritus

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,7 +2,7 @@
 
 This document lists current maintainers in the Model Context Protocol project.
 
-**Last updated:** May 1, 2026
+**Last updated:** August 5, 2026
 
 ## Lead Maintainers
 
@@ -14,7 +14,6 @@ This document lists current maintainers in the Model Context Protocol project.
 - [Caitie McCaffrey](https://github.com/CaitieM20)
 - [Clare Liguori](https://github.com/clareliguori)
 - [Kurtis Van Gent](https://github.com/kurtisvg)
-- [Nick Aldridge](https://github.com/000-000-000-000-000)
 - [Nick Cooper](https://github.com/nickcoai)
 - [Paul Carleton](https://github.com/pcarleton)
 - [Peter Alexander](https://github.com/pja-ant)
@@ -24,6 +23,7 @@ This document lists current maintainers in the Model Context Protocol project.
 - [Justin Spahr-Summers](https://github.com/jspahrsummers) (Co-Inventor, Lead Maintainer Emeritus)
 - [Basil Hosmer](https://github.com/bhosmer-ant) (Core Maintainer Emeritus)
 - [Che Liu](https://github.com/pwwpche) (Core Maintainer Emeritus)
+- [Nick Aldridge](https://github.com/000-000-000-000-000) (Core Maintainer Emeritus)
 
 ## SDK Maintainers
 

--- a/docs/community/governance.mdx
+++ b/docs/community/governance.mdx
@@ -115,13 +115,13 @@ The nomination process, sponsorship requirements, review timeline, and inactivit
 - Clare Liguori
 - Paul Carleton
 - Nick Cooper
-- Nick Aldridge
 
 ## Emeritus
 
 - Justin Spahr-Summers (Co-Inventor, Lead Maintainer Emeritus)
 - Basil Hosmer (Core Maintainer Emeritus)
 - Che Liu (Core Maintainer Emeritus)
+- Nick Aldridge (Core Maintainer Emeritus)
 
 ## Current Maintainers and Working Groups
 


### PR DESCRIPTION
## Summary
Nick Aldridge is stepping back from the Core Maintainer role. This moves him from the Core Maintainers list to the Emeritus section in MAINTAINERS.md and in the governance page, and bumps the last-updated date.

## Test plan
Ran `npm run prep` (check, generate, format) — completed with no warnings or errors and no additional file changes.