### PR TITLE
docs: add Maxi Boch to Tool Annotations IG membership

### DIFF
--- a/docs/community/interest-groups/tool-annotations.mdx
+++ b/docs/community/interest-groups/tool-annotations.mdx
@@ -42,16 +42,17 @@ The Tool Annotations Interest Group explores the role of tool annotations in ena
 
 ## Membership
 
-| Name                    | Organization | GitHub                                               | Discord | Level       |
-| ----------------------- | ------------ | ---------------------------------------------------- | ------- | ----------- |
-| Sam Morrow              | GitHub       | [@SamMorrowDrums](https://github.com/SamMorrowDrums) |         | Facilitator |
-| Robert Reichel          | OpenAI       | [@rreichel3](https://github.com/rreichel3)           |         | Facilitator |
-| Matt Carey              | Cloudflare   | [@mattzcarey](https://github.com/mattzcarey)         |         | Participant |
-| Kapil Sharma            | Microsoft    | [@kapil8811](https://github.com/kapil8811)           |         | Participant |
-| Connor Peet             | Microsoft    | [@connor4312](https://github.com/connor4312)         |         | Participant |
-| Ola Hungerford          | Nordstrom    | [@olaservo](https://github.com/olaservo)             |         | Participant |
-| Gökhan Arkan            | GitHub       | [@gokhanarkan](https://github.com/gokhanarkan)       |         | Participant |
-| Joanna Krzek-Lubowiecka | GitHub       | [@joannakl](https://github.com/joannakl)             |         | Participant |
+| Name                    | Organization | GitHub                                               | Discord  | Level       |
+| ----------------------- | ------------ | ---------------------------------------------------- | -------- | ----------- |
+| Sam Morrow              | GitHub       | [@SamMorrowDrums](https://github.com/SamMorrowDrums) |          | Facilitator |
+| Robert Reichel          | OpenAI       | [@rreichel3](https://github.com/rreichel3)           |          | Facilitator |
+| Matt Carey              | Cloudflare   | [@mattzcarey](https://github.com/mattzcarey)         |          | Participant |
+| Kapil Sharma            | Microsoft    | [@kapil8811](https://github.com/kapil8811)           |          | Participant |
+| Connor Peet             | Microsoft    | [@connor4312](https://github.com/connor4312)         |          | Participant |
+| Ola Hungerford          | Nordstrom    | [@olaservo](https://github.com/olaservo)             |          | Participant |
+| Gökhan Arkan            | GitHub       | [@gokhanarkan](https://github.com/gokhanarkan)       |          | Participant |
+| Joanna Krzek-Lubowiecka | GitHub       | [@joannakl](https://github.com/joannakl)             |          | Participant |
+| Maxi Boch               | Independent  | [@maxiboch](https://github.com/maxiboch)             | maxiboch | Participant |
 
 ## Operations
 


### PR DESCRIPTION
Adds myself to the Tool Annotations IG membership table as a Participant, per the onboarding step in the [May 28 meeting notes](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/2820): "New participants are invited to open a PR adding themselves to the membership table."

Context for the affiliation: I've proposed the `io.modelcontextprotocol/display-templates` extension in [experimental-ext-tool-annotations#7](https://github.com/modelcontextprotocol/experimental-ext-tool-annotations/pull/7) - call-side display templates on `Tool` `_meta` and result-side rendered text, with a reference implementation running on the stock Python SDK.

Note on the diff size: the Discord column grew by one character, so the table padding on the existing rows shifted to match. The only content change is the added row.