### PR TITLE
Align safe-integer-range wording with server/tools.mdx

### DIFF
--- a/docs/specification/draft/basic/transports/streamable-http.mdx
+++ b/docs/specification/draft/basic/transports/streamable-http.mdx
@@ -383,7 +383,8 @@ the header name `Mcp-Param-{name}`.
   the `inputSchema`
 - **MUST** only be applied to parameters with primitive types (integer,
   string, boolean). Parameters with type `number` are not permitted.
-  Integer values **MUST** be within the safe range for JavaScript
+  Integer values **MUST** be within the safe range for integers represented
+  using IEEE754 double-precision floating point numbers
   (−2<sup>53</sup>+1 to 2<sup>53</sup>−1)
 - **MUST** only be applied to properties that are _statically reachable_
   from the schema root: reachable via a chain consisting solely of


### PR DESCRIPTION
`server/tools.mdx` and `basic/transports/streamable-http.mdx` state the same `x-mcp-header` constraint with two different justifications:

- `tools.mdx` — "the safe range for integers represented using IEEE754 double-precision floating point numbers (−2<sup>53</sup>+1 to 2<sup>53</sup>−1)"
- `streamable-http.mdx` — "the safe range for JavaScript (−2<sup>53</sup>+1 to 2<sup>53</sup>−1)"

The IEEE754 wording came out of review on #2772, where @pja-ant noted that "even in languages that have native integers, sometimes JSON parsing libraries will parse to `double` by default" and @mikekistler replied "Fair point. I will revise." That revision landed in `tools.mdx` only, and both files shipped in `2026-07-28` with the difference still present.

This applies the same wording in `draft`. The bound itself is unchanged.

Noticed while reading modelcontextprotocol/conformance#445.
