### PR TITLE
Update Ruby MCP client example

### DIFF
--- a/docs/docs/draft/develop/build-client.mdx
+++ b/docs/docs/draft/develop/build-client.mdx
@@ -1702,7 +1702,7 @@ cd mcp-client
 bundle init
 
 # Add required dependencies
-bundle add anthropic base64 dotenv mcp
+bundle add anthropic dotenv mcp
 
 # Create our main file
 touch client.rb


### PR DESCRIPTION
Follow-up to https://github.com/modelcontextprotocol/quickstart-resources/pull/177.

This PR removes the `base64` dependency from the `bundle add` arguments, as it became a runtime dependency of Claude SDK for Ruby v1.60.0+.
https://github.com/anthropics/anthropic-sdk-ruby/pull/161#issuecomment-5221400980

At least when this draft of `build-client.mdx` was written, `bundle add ...` was expected to install a recent version of the Claude SDK for Ruby that already includes `base64` as a runtime dependency.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
