### PR TITLE
docs:add Linux support to build-server tutorial

### DIFF
--- a/docs/docs/2026-07-28/develop/build-server.mdx
+++ b/docs/docs/2026-07-28/develop/build-server.mdx
@@ -744,7 +744,6 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
 
-
 First, make sure you have Claude for Desktop installed. [You can install the latest version
 here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 
@@ -978,7 +977,6 @@ This will generate an `mcp-weather-stdio-server-0.0.1-SNAPSHOT.jar` file within 
 Let's now test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
-
 
 First, make sure you have Claude for Desktop installed.
 [You can install the latest version here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
@@ -1695,7 +1693,6 @@ This will start the server and listen for incoming requests on standard input/ou
 
 ## Testing your server with Claude for Desktop
 
-
 First, make sure you have Claude for Desktop installed. [You can install the latest version
 here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 We'll need to configure Claude for Desktop for whichever MCP servers you want to use. To do this, open your Claude for Desktop App configuration at `~/Library/Application Support/Claude/claude_desktop_config.json` in a text editor. Make sure to create the file if it doesn't exist.
@@ -2003,7 +2000,6 @@ Your server is complete! Run `bundle exec ruby weather.rb` to start the MCP serv
 Let's now test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
-
 
 First, make sure you have Claude for Desktop installed. [You can install the latest version here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 
@@ -2440,7 +2436,6 @@ The compiled binary will be in `target/release/weather`.
 Let's now test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
-
 
 First, make sure you have Claude for Desktop installed. [You can install the latest version here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 
@@ -2884,7 +2879,6 @@ The compiled binary will be in `./weather`.
 Let's now test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
-
 
 First, make sure you have Claude for Desktop installed. [You can install the latest version here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 

--- a/docs/docs/2026-07-28/develop/build-server.mdx
+++ b/docs/docs/2026-07-28/develop/build-server.mdx
@@ -261,12 +261,6 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
 
-<Note>
-
-Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/docs/2026-07-28/develop/build-client) tutorial to build an MCP client that connects to the server we just built.
-
-</Note>
-
 First, make sure you have Claude for Desktop installed. [You can install the latest version
 here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 
@@ -276,7 +270,11 @@ For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
 <CodeGroup>
 
-```bash macOS/Linux
+```bash Linux
+code ~/.config/Claude/claude_desktop_config.json
+```
+
+```bash macOS
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
@@ -746,11 +744,6 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
 
-<Note>
-
-Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/docs/2026-07-28/develop/build-client) tutorial to build an MCP client that connects to the server we just built.
-
-</Note>
 
 First, make sure you have Claude for Desktop installed. [You can install the latest version
 here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
@@ -761,7 +754,11 @@ For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
 <CodeGroup>
 
-```bash macOS/Linux
+```bash Linux
+code ~/.config/Claude/claude_desktop_config.json
+```
+
+```bash macOS
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
@@ -982,11 +979,6 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
 
-<Note>
-
-Claude for Desktop is not yet available on Linux.
-
-</Note>
 
 First, make sure you have Claude for Desktop installed.
 [You can install the latest version here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
@@ -999,7 +991,11 @@ For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
 <CodeGroup>
 
-```bash macOS/Linux
+```bash Linux
+code ~/.config/Claude/claude_desktop_config.json
+```
+
+```bash macOS
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
@@ -1427,12 +1423,6 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
 
-<Note>
-
-Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/docs/2026-07-28/develop/build-client) tutorial to build an MCP client that connects to the server we just built.
-
-</Note>
-
 First, make sure you have Claude for Desktop installed. [You can install the latest version
 here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 
@@ -1444,7 +1434,11 @@ For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
 <CodeGroup>
 
-```bash macOS/Linux
+```bash Linux
+code ~/.config/Claude/claude_desktop_config.json
+```
+
+```bash macOS
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
@@ -1701,11 +1695,6 @@ This will start the server and listen for incoming requests on standard input/ou
 
 ## Testing your server with Claude for Desktop
 
-<Note>
-
-Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/docs/2026-07-28/develop/build-client) tutorial to build an MCP client that connects to the server we just built.
-
-</Note>
 
 First, make sure you have Claude for Desktop installed. [You can install the latest version
 here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
@@ -1714,7 +1703,11 @@ For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
 <CodeGroup>
 
-```bash macOS/Linux
+```bash Linux
+code ~/.config/Claude/claude_desktop_config.json
+```
+
+```bash macOS
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
@@ -2011,11 +2004,6 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
 
-<Note>
-
-Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/docs/2026-07-28/develop/build-client) tutorial to build an MCP client that connects to the server we just built.
-
-</Note>
 
 First, make sure you have Claude for Desktop installed. [You can install the latest version here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 
@@ -2025,7 +2013,11 @@ For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
 <CodeGroup>
 
-```bash macOS/Linux
+```bash Linux
+code ~/.config/Claude/claude_desktop_config.json
+```
+
+```bash macOS
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
@@ -2449,11 +2441,6 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
 
-<Note>
-
-Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/docs/2026-07-28/develop/build-client) tutorial to build an MCP client that connects to the server we just built.
-
-</Note>
 
 First, make sure you have Claude for Desktop installed. [You can install the latest version here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 
@@ -2463,7 +2450,11 @@ For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
 <CodeGroup>
 
-```bash macOS/Linux
+```bash Linux
+code ~/.config/Claude/claude_desktop_config.json
+```
+
+```bash macOS
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
@@ -2894,11 +2885,6 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
 
-<Note>
-
-Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/docs/2026-07-28/develop/build-client) tutorial to build an MCP client that connects to the server we just built.
-
-</Note>
 
 First, make sure you have Claude for Desktop installed. [You can install the latest version here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 
@@ -2908,7 +2894,11 @@ For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
 <CodeGroup>
 
-```bash macOS/Linux
+```bash Linux
+code ~/.config/Claude/claude_desktop_config.json
+```
+
+```bash macOS
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
@@ -3014,16 +3004,21 @@ When you ask a question:
 
 **Getting logs from Claude for Desktop**
 
-Claude.app logging related to MCP is written to log files in `~/Library/Logs/Claude`:
+Claude.app logging related to MCP is written to log files in `~/Library/Logs/Claude` (macOS) or `~/.config/Claude/logs/` (Linux):
 
 - `mcp.log` will contain general logging about MCP connections and connection failures.
 - Files named `mcp-server-SERVERNAME.log` will contain the stderr output from the named server. Stdio servers may use stderr for all their logging, so these files are not limited to errors.
 
 You can run the following command to list recent logs and follow along with any new ones:
 
-```bash
+```bash macOS
 # Check Claude's logs for errors
 tail -n 20 -f ~/Library/Logs/Claude/mcp*.log
+```
+
+```bash Linux
+# Check Claude's logs for errors
+tail -n 20 -f ~/.config/Claude/logs/mcp*.log
 ```
 
 **Server not showing up in Claude**
@@ -3038,6 +3033,7 @@ To properly restart Claude for Desktop, you must fully quit the application:
 
 - **Windows**: Right-click the Claude icon in the system tray (which may be hidden in the "hidden icons" menu) and select "Quit" or "Exit".
 - **macOS**: Use Cmd+Q or select "Quit Claude" from the menu bar.
+- **Linux**: Right-click the Claude icon in the system tray and select "Quit", or run `pkill -f claude-desktop` from a terminal.
 
 Simply closing the window does not fully quit the application, and your MCP server configuration changes will not take effect.
 

--- a/docs/docs/draft/develop/build-server.mdx
+++ b/docs/docs/draft/develop/build-server.mdx
@@ -261,12 +261,6 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
 
-<Note>
-
-Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/docs/draft/develop/build-client) tutorial to build an MCP client that connects to the server we just built.
-
-</Note>
-
 First, make sure you have Claude for Desktop installed. [You can install the latest version
 here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 
@@ -276,7 +270,11 @@ For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
 <CodeGroup>
 
-```bash macOS/Linux
+```bash Linux
+code ~/.config/Claude/claude_desktop_config.json
+```
+
+```bash macOS
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
@@ -746,12 +744,6 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
 
-<Note>
-
-Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/docs/draft/develop/build-client) tutorial to build an MCP client that connects to the server we just built.
-
-</Note>
-
 First, make sure you have Claude for Desktop installed. [You can install the latest version
 here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 
@@ -761,7 +753,11 @@ For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
 <CodeGroup>
 
-```bash macOS/Linux
+```bash Linux
+code ~/.config/Claude/claude_desktop_config.json
+```
+
+```bash macOS
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
@@ -982,12 +978,6 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
 
-<Note>
-
-Claude for Desktop is not yet available on Linux.
-
-</Note>
-
 First, make sure you have Claude for Desktop installed.
 [You can install the latest version here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 
@@ -999,7 +989,11 @@ For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
 <CodeGroup>
 
-```bash macOS/Linux
+```bash Linux
+code ~/.config/Claude/claude_desktop_config.json
+```
+
+```bash macOS
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
@@ -1427,12 +1421,6 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
 
-<Note>
-
-Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/docs/draft/develop/build-client) tutorial to build an MCP client that connects to the server we just built.
-
-</Note>
-
 First, make sure you have Claude for Desktop installed. [You can install the latest version
 here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 
@@ -1444,7 +1432,11 @@ For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
 <CodeGroup>
 
-```bash macOS/Linux
+```bash Linux
+code ~/.config/Claude/claude_desktop_config.json
+```
+
+```bash macOS
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
@@ -1701,12 +1693,6 @@ This will start the server and listen for incoming requests on standard input/ou
 
 ## Testing your server with Claude for Desktop
 
-<Note>
-
-Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/docs/draft/develop/build-client) tutorial to build an MCP client that connects to the server we just built.
-
-</Note>
-
 First, make sure you have Claude for Desktop installed. [You can install the latest version
 here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 We'll need to configure Claude for Desktop for whichever MCP servers you want to use. To do this, open your Claude for Desktop App configuration at `~/Library/Application Support/Claude/claude_desktop_config.json` in a text editor. Make sure to create the file if it doesn't exist.
@@ -1714,7 +1700,11 @@ For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
 <CodeGroup>
 
-```bash macOS/Linux
+```bash Linux
+code ~/.config/Claude/claude_desktop_config.json
+```
+
+```bash macOS
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
@@ -2011,12 +2001,6 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
 
-<Note>
-
-Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/docs/draft/develop/build-client) tutorial to build an MCP client that connects to the server we just built.
-
-</Note>
-
 First, make sure you have Claude for Desktop installed. [You can install the latest version here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 
 We'll need to configure Claude for Desktop for whichever MCP servers you want to use. To do this, open your Claude for Desktop App configuration at `~/Library/Application Support/Claude/claude_desktop_config.json` in a text editor. Make sure to create the file if it doesn't exist.
@@ -2025,7 +2009,11 @@ For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
 <CodeGroup>
 
-```bash macOS/Linux
+```bash Linux
+code ~/.config/Claude/claude_desktop_config.json
+```
+
+```bash macOS
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
@@ -2449,12 +2437,6 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
 
-<Note>
-
-Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/docs/draft/develop/build-client) tutorial to build an MCP client that connects to the server we just built.
-
-</Note>
-
 First, make sure you have Claude for Desktop installed. [You can install the latest version here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 
 We'll need to configure Claude for Desktop for whichever MCP servers you want to use. To do this, open your Claude for Desktop App configuration at `~/Library/Application Support/Claude/claude_desktop_config.json` in a text editor. Make sure to create the file if it doesn't exist.
@@ -2463,7 +2445,11 @@ For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
 <CodeGroup>
 
-```bash macOS/Linux
+```bash Linux
+code ~/.config/Claude/claude_desktop_config.json
+```
+
+```bash macOS
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
@@ -2894,12 +2880,6 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 
 ## Testing your server with Claude for Desktop
 
-<Note>
-
-Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/docs/draft/develop/build-client) tutorial to build an MCP client that connects to the server we just built.
-
-</Note>
-
 First, make sure you have Claude for Desktop installed. [You can install the latest version here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 
 We'll need to configure Claude for Desktop for whichever MCP servers you want to use. To do this, open your Claude for Desktop App configuration at `~/Library/Application Support/Claude/claude_desktop_config.json` in a text editor. Make sure to create the file if it doesn't exist.
@@ -2908,7 +2888,11 @@ For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 
 <CodeGroup>
 
-```bash macOS/Linux
+```bash Linux
+code ~/.config/Claude/claude_desktop_config.json
+```
+
+```bash macOS
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
@@ -3014,17 +2998,26 @@ When you ask a question:
 
 **Getting logs from Claude for Desktop**
 
-Claude.app logging related to MCP is written to log files in `~/Library/Logs/Claude`:
+Claude.app logging related to MCP is written to log files in `~/Library/Logs/Claude` (macOS) or `~/.config/Claude/logs/` (Linux):
 
 - `mcp.log` will contain general logging about MCP connections and connection failures.
 - Files named `mcp-server-SERVERNAME.log` will contain the stderr output from the named server. Stdio servers may use stderr for all their logging, so these files are not limited to errors.
 
 You can run the following command to list recent logs and follow along with any new ones:
 
-```bash
+<CodeGroup>
+
+```bash macOS
 # Check Claude's logs for errors
 tail -n 20 -f ~/Library/Logs/Claude/mcp*.log
 ```
+
+```bash Linux
+# Check Claude's logs for errors
+tail -n 20 -f ~/.config/Claude/logs/mcp*.log
+```
+
+</CodeGroup>
 
 **Server not showing up in Claude**
 
@@ -3038,6 +3031,7 @@ To properly restart Claude for Desktop, you must fully quit the application:
 
 - **Windows**: Right-click the Claude icon in the system tray (which may be hidden in the "hidden icons" menu) and select "Quit" or "Exit".
 - **macOS**: Use Cmd+Q or select "Quit Claude" from the menu bar.
+- **Linux**: Right-click the Claude icon in the system tray and select "Quit", or run `pkill -f claude-desktop` from a terminal.
 
 Simply closing the window does not fully quit the application, and your MCP server configuration changes will not take effect.
 


### PR DESCRIPTION
Build Server docs said Claude Desktop for Linux is not available, but it is now available. Removed note about Linux availability for Claude for Desktop in multiple sections and updated configuration instructions for Linux users.

## Motivation and Context
Build Server docs said Claude Desktop for Linux is not available

## How Has This Been Tested?
I checked it in the browser since this is a smaller change. 

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ x] I have added or updated documentation as needed

## Additional context
None
