### PR TITLE
Move the Node floor off EOL 20 to 24

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
 
       - name: Validate version

--- a/.github/workflows/sep-lifecycle-manual.yml
+++ b/.github/workflows/sep-lifecycle-manual.yml
@@ -13,7 +13,7 @@ on:
         default: true
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '24'
 
 jobs:
   run-automation:

--- a/.github/workflows/sep-lifecycle.yml
+++ b/.github/workflows/sep-lifecycle.yml
@@ -12,7 +12,7 @@ on:
     - cron: '0 9 * * 1'  # Every Monday at 9 AM UTC
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '24'
 
 jobs:
   check-sep:

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "unified": "^11.0.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=24"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://modelcontextprotocol.io",
   "bugs": "https://github.com/modelcontextprotocol/specification/issues",
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "prettier": {
     "overrides": [


### PR DESCRIPTION
## Motivation and Context

`CONTRIBUTING.md` already states **"Node.js 24 or above"** and `.nvmrc` pins `v24.2.0`, but `package.json` still declared `engines.node: ">=20"` and three workflow entries still provisioned Node 20.

Node 20 ("Iron") reached end of life on **2026-04-30** ([nodejs/Release schedule](https://github.com/nodejs/Release/blob/main/schedule.json)) — about three months ago — so it no longer receives security patches. The most notable case is `cut-release.yml`, where the job that promotes the draft spec and cuts a release was provisioning an unsupported runtime.

## How Has This Been Tested?

- `npx tsc --noEmit` passes clean.
- The lockfile was refreshed with `npm install --package-lock-only`; the resulting diff is the root `engines` field only, with no dependency versions moving.
- Changed workflows were reviewed for other Node assumptions; the version string is the only thing touched.

## Breaking Changes

None

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Other (please describe): repository tooling / CI maintenance

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

Files deliberately left alone: `main.yml`, `markdown-format.yml`, and `render-seps.yml` were already on 24.

Two pre-existing local check failures are worth noting so they aren't attributed to this change — `npm run check:schema:ts` (prettier) and `npm run check:schema:json` both fail identically on a pristine `main` checkout on Windows, because `core.autocrlf=true` gives the schema files CRLF terminators. They are a Windows-checkout artifact, not a regression here, and CI on Linux is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)