### PR TITLE
Patch two high-severity advisories in dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1239,9 +1239,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1898,9 +1898,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Motivation and Context

Two high-severity advisories, both transitive dev dependencies. Lockfile-only; each new version is within the range its parent already declares.

- **`fast-uri` 3.1.4 → 3.1.5** — [CVE-2026-18446](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7), host confusion via backslash authority introducer. Via `ajv` (`^3.0.1`). This is Dependabot alert #90, open since 2026-08-04.
- **`brace-expansion` 5.0.8 → 5.0.9** — [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895), DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation. Via `eslint` → `minimatch`. Not reported by Dependabot — `npm audit` catches it but the alerts API lists only #90, so it would otherwise sit unnoticed.

## How Has This Been Tested?

- `npm audit` → 0 vulnerabilities (was 2 high).
- `npx eslint schema/` clean (brace-expansion consumer).
- `npx tsx scripts/validate-examples.ts` → 258 passed, 0 failed (ajv consumer).

## Breaking Changes

None. Two patch bumps; no direct dependency moves.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Other (please describe): dependency security patch

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

Branched from `main`. If these should also reach `docs/2026-07-28-release` before it merges, that needs a separate cherry-pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)