### PR TITLE
Add Credential Destination Injection section to security best practices

### DIFF
--- a/docs/docs/draft/tutorials/security/security_best_practices.mdx
+++ b/docs/docs/draft/tutorials/security/security_best_practices.mdx
@@ -513,6 +513,118 @@ in MCP clients.
   SSRF in the context of the most critical web application security
   risks
 
+### Credential Destination Injection
+
+A separate risk, related to but distinct from the SSRF risks described
+above: an MCP server's tool implementation frequently holds its own
+credential for a backing service it wraps, for example a database
+password, a cloud API access token, or a bearer token for a
+third-party API. If a tool attaches that credential to an outbound
+request whose destination is determined, even in part, by
+caller-influenced input, without validating the destination against a
+trusted allowlist first, the server's own credential can be delivered
+to a destination the caller chose rather than the service the
+credential was issued for.
+
+This differs from the SSRF risks described above in what is exposed
+and to whom. The SSRF attacks above concern an MCP _client_ being
+tricked by a malicious _server_ into fetching URLs during OAuth
+discovery, exposing the client's own network position. Credential
+Destination Injection concerns an MCP _server's own tool_ attaching a
+credential _it holds_ to a request whose destination was influenced by
+a tool argument — a value that, in practice, is frequently chosen by
+the model based on untrusted content it has processed, not typed
+directly by the end user. Blocking private IP ranges, the primary
+SSRF mitigation, does not address this: the caller-chosen destination
+in this pattern is frequently an ordinary public host under the
+attacker's control, not an internal address.
+
+#### Attack Description
+
+1. An MCP tool holds a credential for a specific backing service, for
+   example a database connection string, a cloud API token, or a
+   bearer token issued for a specific third-party API.
+2. The tool accepts an argument that influences the destination of the
+   request the tool makes, directly or indirectly (for example, a
+   hostname embedded in a resource identifier).
+3. The tool attaches the credential to the outbound request without
+   first validating the destination against a trusted allowlist, or
+   validates only the initial request and does not re-validate the
+   destination if a redirect changes it.
+4. A caller — potentially the model itself, acting on content it has
+   read such as a document or a prior tool result — supplies a
+   destination the attacker controls.
+5. The server sends its own credential to the attacker's destination.
+6. The attacker replays the credential against the legitimate service,
+   or exfiltrates it directly if the response is returned to the
+   model.
+
+```mermaid
+sequenceDiagram
+    participant Content as Untrusted Content
+    participant Client as MCP Client / Model
+    participant MCP as MCP Server (holds credential)
+    participant Attacker as Attacker-Controlled Host
+
+    Content->>Client: Content containing an injected destination
+    Client->>MCP: Tool call with attacker-chosen destination
+    Note over MCP: Credential attached without allowlist check
+    MCP->>Attacker: Request to attacker's host, credential attached
+    Attacker-->>MCP: Attacker's server logs the credential
+    Note over MCP: Credential is now known to the attacker
+```
+
+#### Risks
+
+- **Credential exfiltration**. The server's own credential, valid
+  against the backing service it wraps, is delivered intact to an
+  attacker-controlled destination.
+- **Replay**. Because the credential is transmitted correctly (over
+  TLS, not logged, not exposed in a response), standard
+  credential-hygiene controls do not detect or prevent this; the
+  attacker can replay it against the legitimate service until it is
+  rotated or expires.
+- **Redirect bypass**. Validating only the initial destination is
+  insufficient. A destination that passes an initial check can still
+  be redirected to an attacker-controlled host on a later hop, and any
+  custom transport or interceptor that re-applies the credential on
+  every hop defeats the redirect protections an HTTP client library
+  may already provide by default.
+
+#### Mitigation
+
+MCP servers that attach a held credential to an outbound request
+**MUST** validate the request's destination against a trusted
+allowlist, using exact host or exact domain-suffix comparison, before
+attaching the credential. Substring or "contains" checks are
+insufficient.
+
+MCP servers **MUST** re-validate the destination on every redirect
+hop, not only the initial request, and **MUST NOT** re-attach the
+credential to a destination that fails the allowlist check on any hop.
+
+Where a tool must be able to reach a caller-chosen destination that
+cannot be enumerated in advance, such as a general-purpose fetch tool,
+the server **SHOULD** withhold its own credential from the request
+entirely rather than attach it to an unvalidated destination. A
+general-purpose fetch tool has no legitimate reason to carry the
+server's own backing-service credential to a caller-chosen
+destination.
+
+MCP server developers **SHOULD** verify that no custom HTTP transport,
+interceptor, or retry wrapper in their implementation re-applies a
+credential on every hop in a way that bypasses the redirect
+protections their language runtime or HTTP client library provides by
+default.
+
+#### Resources and Tools
+
+This pattern is the mechanism behind a publicly disclosed
+vulnerability in an official cloud vendor's MCP server for database
+access, in which a redirect carried a credentialed request to a cloud
+instance metadata endpoint
+([CVE-2026-14540](https://nvd.nist.gov/vuln/detail/CVE-2026-14540)).
+
 ### State Handle Hijacking
 
 MCP is [stateless](/specification/draft/basic/index#statelessness) and


### PR DESCRIPTION
## AI disclosure

This PR was written primarily by Claude Code. I (the submitter) directed the scope, provided the underlying technical grounding (the CVE below, which I found and reported, and a static analysis tool I maintain that detects this exact pattern), reviewed the full text, and take responsibility for its accuracy. The prose, structure, and Mermaid diagram were drafted by Claude Code to match this document's existing house style.

## Summary

Adds a new **Credential Destination Injection** section to `security_best_practices.mdx`, positioned after the existing SSRF section.

## Rationale

The existing **Server-Side Request Forgery (SSRF)** section thoroughly covers a malicious *MCP server* tricking an MCP *client* into fetching attacker-controlled URLs during OAuth discovery (`resource_metadata`, `authorization_servers`, `token_endpoint`). That's a distinct threat model from the one this PR addresses: an MCP *server's own tool* holding its own backing-service credential (a DB password, a cloud API token, a third-party bearer token) and attaching that credential to a request whose *destination* is influenced by a tool argument, without validating the destination first.

The distinction matters for mitigation, not just taxonomy: private-IP blocking, the SSRF section's primary countermeasure, does not help here, because the attacker-chosen destination in this pattern is typically an ordinary public host, not an internal address. The credential itself is what's at risk, not access to an internal network.

## Concrete evidence

This is not a hypothetical pattern. It's the mechanism behind [CVE-2026-14540](https://nvd.nist.gov/vuln/detail/CVE-2026-14540), a real, publicly disclosed SSRF in an official cloud vendor's MCP database toolbox, where a redirect carried a credentialed request to a cloud instance metadata endpoint. I found and reported that vulnerability, and separately maintain an open-source static analysis tool (`mcp-safeguard`) built around detecting this exact pattern, which I measured against 14 official vendor MCP servers.

I also have a related, already-open PR to semgrep/semgrep-rules ([semgrep/semgrep-rules#4043](https://github.com/semgrep/semgrep-rules/pull/4043)) adding a detection rule for this same pattern to Semgrep's existing `ai/ai-best-practices/mcp-*` rule category, whose own rules already cite this document's security_best_practices page as their reference.

## My own analysis

I checked this document's existing MCP-specific rules and sections carefully before drafting anything, specifically to confirm this wasn't already covered under a different name. It isn't: neither the SSRF section (client-side, OAuth-discovery-focused) nor the Confused Deputy or Token Passthrough sections (both about authorization-code/token boundaries, not credential-destination binding) cover a server attaching its own credential to a caller-chosen destination. I tried to match this document's existing tone and rigor as closely as I could — RFC 2119 language in the mitigation, an Attack Description numbered list, a Mermaid sequence diagram, and a Risks/Mitigation split — rather than writing in a different register from the rest of the page.

## Test plan

- [x] `npm run check:docs:format` (prettier) passes
- [x] `npm run check:docs:js-comments` passes
- [ ] `npm run check:docs:links` could not run in my environment (the bundled `mint` CLI doesn't support Node 25; needs an LTS version) — the only link added in this change is the external NVD citation, no internal cross-links, so I don't expect this to surface anything, but flagging that I couldn't run it end-to-end myself.