### PR TITLE
docs: align the safe-integer justification in streamable-http with tools.mdx

### DIFF
--- a/docs/specification/draft/basic/transports/streamable-http.mdx
+++ b/docs/specification/draft/basic/transports/streamable-http.mdx
@@ -383,7 +383,8 @@ the header name `Mcp-Param-{name}`.
   the `inputSchema`
 - **MUST** only be applied to parameters with primitive types (integer,
   string, boolean). Parameters with type `number` are not permitted.
-  Integer values **MUST** be within the safe range for JavaScript
+  Integer values **MUST** be within the safe range for integers
+  represented using IEEE754 double-precision floating point numbers
   (−2<sup>53</sup>+1 to 2<sup>53</sup>−1)
 - **MUST** only be applied to properties that are _statically reachable_
   from the schema root: reachable via a chain consisting solely of


### PR DESCRIPTION
`draft/basic/transports/streamable-http.mdx` still describes the `x-mcp-header` integer bound as "the safe range for JavaScript", while `draft/server/tools.mdx` describes the same bound as "the safe range for integers represented using IEEE754 double-precision floating point numbers". Same constraint, same numeric range, two different justifications in one normative document.

The IEEE754 phrasing is the one already settled. In the review of #2772, @pja-ant pushed back on the JavaScript framing — "Even in languages that have native integers, sometimes JSON parsing libraries will parse to `double` by default" — and @mikekistler replied "Fair point. I will revise." That revision landed in `tools.mdx` but not in `streamable-http.mdx`. This completes it.

**Not a normative change.** The bound `(−2^53+1 to 2^53−1)` is untouched; only the justifying clause changes. Only `draft` is edited — the released `2026-07-28` copy is deliberately left frozen.

I noticed this via the "Aside" section of modelcontextprotocol/conformance#445, which flagged it as "probably a one-line upstream fix". I am not taking on the check described in the body of that issue — as its author notes, the normative question there needs settling first, since asserting either behaviour makes one SDK fail.

**Why this matters to me:** the divergence I care about is the one downstream of this wording. The C# SDK throws on an out-of-range integer; the TypeScript SDK drops the header silently and lets the call proceed. Precise, consistently-stated normative text is what keeps two SDKs from reading one MUST two ways — and silent omission is the failure mode I find hardest to catch in my own systems, because nothing downstream reports anything wrong.

**AI disclosure:** This was found and drafted with Claude Code — it located the inconsistency, traced it to the #2772 discussion, and wrote this description. I directed that work and had the change and its rationale explained to me before submitting; it is a one-clause wording swap that I understand and can defend. Per AI_POLICY.md, stating the extent rather than just the fact.