### PR TITLE
Add blog post announcing the new roadmap

### DIFF
--- a/blog/content/posts/2026-08-22-mcp-roadmap.md
+++ b/blog/content/posts/2026-08-22-mcp-roadmap.md
@@ -1,0 +1,70 @@
+---
+title: "The New MCP Roadmap"
+date: "2026-08-22T09:00:00+00:00"
+publishDate: "2026-08-22T09:00:00+00:00"
+slug: mcp-roadmap
+description: "An update on the Model Context Protocol roadmap and focus areas for upcoming specification releases."
+author:
+  - David Soria Parra (Lead Maintainer)
+  - Den Delimarsky (Lead Maintainer)
+tags:
+  - mcp
+  - roadmap
+  - community
+  - governance
+  - working-groups
+ShowToc: true
+---
+
+Today we're excited to publish an updated [roadmap](https://modelcontextprotocol.io/development/roadmap) for the Model Context Protocol (MCP), covering the next specification release and beyond.
+
+The roadmap sets the direction for protocol work over the coming months. It was developed by the Core Maintainers together with our community of maintainers and Working Groups.
+
+{{< button text="Explore the roadmap" url="https://modelcontextprotocol.io/development/roadmap" target="_self" >}}
+
+## Priority areas
+
+The roadmap is organized into five priority areas. Several of them pick up work that the [previous roadmap](/posts/2026-mcp-roadmap/) listed as on the horizon, including server-initiated events, result type improvements, and agent identity, which have since matured enough to become priorities in their own right. Each area is owned by a set of Core Maintainers and one or more Working Groups.
+
+![MCP Roadmap: five priority areas, agentic messaging primitives, HTTP-native transport unification and hardening, agent identity and enterprise-ready security, improved primitives, and improved SDK developer experience.](/posts/images/roadmap/priority-areas.svg)
+
+### Agentic messaging primitives
+
+Modern agentic workloads no longer fit the standard [request-and-response pattern](https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns). Loops can run for longer, servers can push streamed results, and there is a clear need to steer work mid-flight. MCP has been growing to meet these requirements, introducing [Tasks](https://modelcontextprotocol.io/extensions/tasks/overview), [`subscriptions/listen`](https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/subscriptions), and [progress notifications](https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/progress). We want to make sure that we not only offer the right primitives for the job, but also that they work well together. The work here spans server-initiated events (webhooks and channels, so clients aren't left polling for results), a composition review across the [Agents](https://modelcontextprotocol.io/community/working-groups/agents), Transports, and [Triggers & Events](https://modelcontextprotocol.io/community/working-groups/triggers-events) Working Groups, and maturing the Tasks extension ([SEP-2663](https://modelcontextprotocol.io/seps/2663-tasks-extension)) so it can move into the specification.
+
+### HTTP-native transport unification and hardening
+
+With the [2026-07-28 release](https://modelcontextprotocol.io/specification/2026-07-28/changelog), a remote MCP server is now no different from any other HTTP workload, making it easy to host and operate one on any infrastructure that developers and organizations already use for their APIs and services. The model has proven to scale, and we want to stretch it to cover other deployment modes as well, including local servers speaking [Streamable HTTP](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http) over [stdio](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/stdio). Unifying on one transport lets us simplify MCP server and client development even further.
+
+### Agent identity and enterprise-ready security
+
+[MCP authorization](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization) today is built around a person approving access in a browser. That works well for interactive clients, but more and more of the callers are agents running as cloud workloads with their own identity, acting on behalf of a user who isn't present, or delegating narrower authority to sub-agents. We want MCP servers to have a standardized way to recognize and trust those agent identities, built on existing standards rather than pasted API keys and long-lived tokens.
+
+The work here covers finalizing [Demonstrating Proof of Possession](https://www.rfc-editor.org/rfc/rfc9449) (DPoP) and driving its adoption, and defining an opinionated path for agent identity and delegation through [Workload Identity Federation](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1933), the ID-JAG grant behind [Enterprise-Managed Authorization](https://modelcontextprotocol.io/extensions/auth/enterprise-managed-authorization), and standard token exchange. We will also continue to grow our engagement with the OAuth standards bodies, including the IETF OAuth and [WIMSE](https://datatracker.ietf.org/wg/wimse/about/) working groups, to help the underlying standards evolve with the building blocks that agent identity needs.
+
+### Improved primitives
+
+Tool calling is the part of MCP most developers touch first, and it has held up well over the lifetime of the protocol. Where it falls a bit short, however, is in the result handling. A [`tools/call`](https://modelcontextprotocol.io/specification/2026-07-28/server/tools#tool-result) response can carry the same output in more than one form, and a server developer today has no way to know which form a given client will put in front of the model. We aim to make this easier by standardizing on one clear contract.
+
+The other challenge we need to address for primitive use is their ever-growing scale. Connecting to a server with a hundred tools means the model pays for that entire surface before the user has asked a single question, and tool selection tends to get worse as the list grows. We're starting a progressive discovery effort so a server can offer a small entry point and reveal more of its catalog as the conversation narrows.
+
+### Improved SDK developer experience
+
+Our SDKs are how developers experience MCP. We are investing in their ergonomics and their [conformance with the specification](https://modelcontextprotocol.io/community/sdk-tiers#conformance-testing), and in making them intuitive and well-documented across every platform and language we support. This is even more important now that many developers build MCP clients and servers by pointing an agent at our libraries, where clear APIs and accurate docs decide whether the code will work with minimal friction.
+
+## Proposal prioritization
+
+[Specification Enhancement Proposals](https://modelcontextprotocol.io/community/sep-guidelines) (SEPs) that fall within these priority areas get expedited review and have the best chance of acceptance. Proposals outside them aren't rejected automatically, but maintainer review time is scarce and goes to the roadmap first.
+
+If you're considering a SEP, identify the priority area it belongs to, raise it with the relevant [Working Group](https://modelcontextprotocol.io/community/working-interest-groups), and work with its members to shape your proposal. Each area on the [roadmap](https://modelcontextprotocol.io/development/roadmap) names the Core Maintainers responsible for it, and anyone interested in contributing can reach them on [Discord](https://modelcontextprotocol.io/community/communication#discord). We're excited to work with the community to review and build on the proposals that support this roadmap.
+
+## Get involved
+
+Every priority area above has a Working Group behind it or forming around it, and all of them have room for more contributors. There are several ways to participate:
+
+- **Join a Working Group or Interest Group**: see the [Working and Interest Groups](https://modelcontextprotocol.io/community/working-interest-groups) page and the [community channels](https://modelcontextprotocol.io/community/communication).
+- **Propose or comment on a SEP**: read the [SEP guidelines](https://modelcontextprotocol.io/community/sep-guidelines), then open one or weigh in.
+- **Start an experimental extension**: [SEP-2133](https://modelcontextprotocol.io/seps/2133-extensions) lets any WG or IG experiment in an `experimental-ext-` repository before a formal SEP.
+- **Contribute directly**: the [contributing guide](https://modelcontextprotocol.io/community/contributing) covers the specification, SDKs, and tooling.
+
+We look forward to growing and evolving MCP together!

--- a/blog/static/posts/images/roadmap/priority-areas.svg
+++ b/blog/static/posts/images/roadmap/priority-areas.svg
@@ -1,0 +1,45 @@
+<svg viewBox="0 0 1200 600" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="t d" font-family="ui-sans-serif,system-ui,-apple-system,Segoe UI,sans-serif">
+  <title id="t">MCP Roadmap</title>
+  <desc id="d">Model Context Protocol roadmap priority areas: agentic messaging primitives, HTTP-native transport unification and hardening, agent identity and enterprise-ready security, improved primitives, and improved SDK developer experience.</desc>
+  <defs>
+    <pattern id="gmin" width="24" height="24" patternUnits="userSpaceOnUse"><path d="M24 0H0V24" fill="none" stroke="#fff" stroke-opacity=".07"/></pattern>
+    <pattern id="gmaj" width="120" height="120" patternUnits="userSpaceOnUse"><path d="M120 0H0V120" fill="none" stroke="#fff" stroke-opacity=".14"/></pattern>
+    <style>
+      .bg   { fill:#0d2b4e }
+      .mark { fill:none; stroke:#fff; stroke-width:12; stroke-linecap:round }
+      .h1   { fill:#fff; font-size:52px; font-weight:650; letter-spacing:-.02em; dominant-baseline:central }
+      .tbl  { fill:none; stroke:#fff; stroke-opacity:.6; stroke-width:1 }
+      .rule { fill:none; stroke:#fff; stroke-opacity:.4; stroke-width:1; stroke-dasharray:4 4 }
+      .col  { stroke:#fff; stroke-opacity:.4; stroke-width:1 }
+      .ico  { fill:none; stroke:#fff; stroke-opacity:.95; stroke-width:1.75; stroke-linecap:round; stroke-linejoin:round }
+      .name { fill:#fff; font-size:16px; font-weight:500; letter-spacing:.14em; dominant-baseline:middle }
+    </style>
+  </defs>
+  <rect class="bg" width="1200" height="600"/>
+  <rect width="1200" height="600" fill="url(#gmin)"/>
+  <rect width="1200" height="600" fill="url(#gmaj)"/>
+
+  <g transform="translate(64.8,78.4) scale(0.29)"><g class="mark">
+    <path d="M25 97.8528L92.8823 29.9706C102.255 20.598 117.451 20.598 126.823 29.9706C136.196 39.3431 136.196 54.5391 126.823 63.9117L75.5581 115.177"/>
+    <path d="M76.2653 114.47L126.823 63.9117C136.196 54.5391 151.392 54.5391 160.765 63.9117L161.118 64.2652C170.491 73.6378 170.491 88.8338 161.118 98.2063L99.7248 159.6C96.6006 162.724 96.6006 167.789 99.7248 170.913L112.331 183.52"/>
+    <path d="M109.853 46.9411L59.6482 97.1457C50.2757 106.518 50.2757 121.714 59.6482 131.087C69.0208 140.459 84.2168 140.459 93.5894 131.087L143.794 80.8822"/>
+  </g></g>
+  <text class="h1" x="132" y="108">Roadmap</text>
+
+  <path class="tbl" d="M65 168H1135M65 528H1135M72 161V535M1128 161V535"/>
+  <line class="col" x1="144" y1="168" x2="144" y2="528"/>
+  <g class="ico" transform="translate(94,190) scale(1.1667)"><path d="M8 3 4 7l4 4" /> <path d="M4 7h16" /> <path d="m16 21 4-4-4-4" /> <path d="M20 17H4" /></g>
+  <text class="name" x="168" y="205">AGENTIC MESSAGING PRIMITIVES</text>
+  <path class="rule" d="M72 240H1128"/>
+  <g class="ico" transform="translate(94,262) scale(1.1667)"><path d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z" /> <path d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12" /> <path d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17" /></g>
+  <text class="name" x="168" y="277">HTTP-NATIVE TRANSPORT UNIFICATION AND HARDENING</text>
+  <path class="rule" d="M72 312H1128"/>
+  <g class="ico" transform="translate(94,334) scale(1.1667)"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /> <path d="m9 12 2 2 4-4" /></g>
+  <text class="name" x="168" y="349">AGENT IDENTITY AND ENTERPRISE-READY SECURITY</text>
+  <path class="rule" d="M72 384H1128"/>
+  <g class="ico" transform="translate(94,406) scale(1.1667)"><path d="M10 22V7a1 1 0 0 0-1-1H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-5a1 1 0 0 0-1-1H2" /> <rect x="14" y="2" width="8" height="8" rx="1" /></g>
+  <text class="name" x="168" y="421">IMPROVED PRIMITIVES</text>
+  <path class="rule" d="M72 456H1128"/>
+  <g class="ico" transform="translate(94,478) scale(1.1667)"><path d="m18 16 4-4-4-4" /> <path d="m6 8-4 4 4 4" /> <path d="m14.5 4-5 16" /></g>
+  <text class="name" x="168" y="493">IMPROVED SDK DEVELOPER EXPERIENCE</text>
+</svg>


### PR DESCRIPTION
Announces the roadmap for the 2026-12-15 specification release: how it was produced with the Working Groups, a short tour of the five priority areas, the release dates, and what the roadmap means for SEP authors.

Intended to publish alongside the roadmap page update (separate PR), which the post links to. Dated 2026-08-22; adjust the date if publication moves.