### PR TITLE
fix typo: serer->server

### DIFF
--- a/seps/2549-TTL-for-list-results.md
+++ b/seps/2549-TTL-for-list-results.md
@@ -201,4 +201,4 @@ _No reference implementation yet._
 
 ## Security Implications
 
-A misconfigured or malicious serer could set an excessively long TTL, causing clients to cache stale data for longer than desired. However, since the TTL is a hint and clients can choose to ignore it or re-fetch if they suspect changes, the security risk is minimal. Clients should be designed to handle unexpected TTL values gracefully.
+A misconfigured or malicious server could set an excessively long TTL, causing clients to cache stale data for longer than desired. However, since the TTL is a hint and clients can choose to ignore it or re-fetch if they suspect changes, the security risk is minimal. Clients should be designed to handle unexpected TTL values gracefully.


### PR DESCRIPTION
I've added one (1) additional character to fix a typo in the docs, correcting the word `sever` to `server`.

## Motivation and Context
Improving documentation by removing a typo; using the correct wording.

## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
N/A