### PR TITLE
docs: regenerate rendered output for SEP-2549

### DIFF
--- a/docs/seps/2549-TTL-for-list-results.mdx
+++ b/docs/seps/2549-TTL-for-list-results.mdx
@@ -228,4 +228,4 @@ _No reference implementation yet._
 
 ## Security Implications
 
-A misconfigured or malicious serer could set an excessively long TTL, causing clients to cache stale data for longer than desired. However, since the TTL is a hint and clients can choose to ignore it or re-fetch if they suspect changes, the security risk is minimal. Clients should be designed to handle unexpected TTL values gracefully.
+A misconfigured or malicious server could set an excessively long TTL, causing clients to cache stale data for longer than desired. However, since the TTL is a hint and clients can choose to ignore it or re-fetch if they suspect changes, the security risk is minimal. Clients should be designed to handle unexpected TTL values gracefully.


### PR DESCRIPTION
Fixes the failing Render SEPs job:
https://github.com/modelcontextprotocol/modelcontextprotocol/actions/runs/33339583528/job/99332656804

PR #3310 fixed a typo in `seps/2549-TTL-for-list-results.md` without regenerating `docs/seps/`, so the rendered page still reads `serer` while its source reads `server`.

This makes `npm run check:seps` fail on main branch. Regenerated with `npm run generate:seps`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
