### PR TITLE
docs(apps): list mcp-elements as a host-side framework option

### DIFF
--- a/docs/extensions/apps/overview.mdx
+++ b/docs/extensions/apps/overview.mdx
@@ -182,6 +182,9 @@ If you're building an MCP client and want to support MCP Apps, you have two opti
    package provides React components for rendering and interacting with MCP Apps
    views in your host application. See the
    [MCP-UI documentation](https://mcpui.dev/) for usage details.
+   [`mcp-elements`](https://github.com/mcp-elements/mcp-elements) offers a
+   copy-paste `McpAppFrame` host renderer (sandboxed iframe, CSP, `ui/initialize`
+   handshake, tool-call proxying) for React, Vue, and Angular.
 
 2. **Build on AppBridge**: The SDK includes an
    [**App Bridge**](https://apps.extensions.modelcontextprotocol.io/api/modules/app-bridge.html)


### PR DESCRIPTION
The "Client support" section of the MCP Apps overview currently names one framework option for host builders (`@mcp-ui/client`). This adds a one-line mention of [mcp-elements](https://github.com/mcp-elements/mcp-elements), whose `McpAppFrame` is an independent host-side implementation of the SEP-1865 protocol (sandboxed iframe, CSP, `ui/initialize` handshake, JSON-RPC tool-call proxying) shipped as copy-paste source for React, Vue and Angular.

Disclosure: I maintain mcp-elements. Happy to reword, shorten, or move it to the client matrix if that fits better.